### PR TITLE
F2: match Nim Table iteration order for pre-narrow Negation emit

### DIFF
--- a/docs/milestones.md
+++ b/docs/milestones.md
@@ -31,7 +31,7 @@ reference, modulo `_cpp_norm` whitespace/comment normalization.
 - 272/272 runner byte-equivalence (`tests/test_runner_byte_equivalence.py`) — 6 skipped: 2 WS runner + 4 ddisasm F1–F3 gaps (no compile-errors)
 - 253/253 jit-batch byte-equivalence (`tests/test_byte_equivalence_jit.py`)
 - 4/4 N5.3/N5.4 guard tests (`tests/test_n5_3_n5_4_guards.py`)
-- **23/27 ddisasm runner rules byte-equal** to upstream Nim, **0 compile-errors**, 4 documented divergences (F1–F3 follow-ups)
+- **24/27 ddisasm runner rules byte-equal** to upstream Nim, **0 compile-errors**, 3 documented divergences (F1 ×2 + F3 ×1; F2 landed)
 - 1005 / 1005 total in suite (6 documented skips)
 
 ---
@@ -90,7 +90,7 @@ Each item below must be green before merge:
 | ID | Topic | Why deferred |
 |---|---|---|
 | **F1** | ddisasm head-tuple ordering (`varr,varp` vs `varp,varr` in `StackLiveVarBlockEnd1_D0_splitA`) | MIR-level head-arg ordering investigation. Not structural; produces valid (just different) C++. |
-| **F2** | ddisasm pre-narrow Negation iteration order (`StackLiveVarPriorUsed`) | `_register_neg_pre_narrow` reorder. Small fix but separable feature work. |
+| **F2** | ddisasm pre-narrow Negation iteration order (`StackLiveVarPriorUsed`) | ✅ landed. Reproduces Nim's `Table[int, ...]` hash-bucket iteration via a hashWangYi1 port + linear-probe slot resolution. |
 | **F3** | ddisasm `_tiled_cart_eligible` predicate gap (`StackDefUsed1`) | Tiled-Cartesian eligibility predicate disagrees with Nim. Investigation, not refactor. |
 | **F4** | N5.3 (single-source nested CJ over D2L FULL_VER) | No live workload. Pinned by guard test. |
 | **F5** | N5.4-Negation / N5.4-Aggregate over D2L FULL_VER | Both Nim and dialect broken; defer until upstream fixes. |
@@ -208,13 +208,12 @@ Nim itself silently emits wrong code. Byte-equivalence with Nim
 
 - 23 / 27 ddisasm rules byte-equal to Nim through the dialect.
 - 0 / 27 fail kernel-body compile.
-- 4 / 27 compile but disagree with Nim — F1 head ordering (×2), F2
-  neg-prenarrow ordering, F3 tiled-Cartesian eligibility. All four
-  are tracked in
+- 3 / 27 compile but disagree with Nim — F1 head ordering (×2), F3
+  tiled-Cartesian eligibility (×1). Tracked in
   [`tests/test_runner_byte_equivalence.py`](../tests/test_runner_byte_equivalence.py)
   and [`tests/test_cuda_complete_runner.py`](../tests/test_cuda_complete_runner.py)
-  `RUNNER_BYTE_MATCH_SKIPS` with concise reasons. Each is a separable
-  feature investigation (HIR/MIR-level for F1+F2, predicate-tweak for F3).
+  `RUNNER_BYTE_MATCH_SKIPS` with concise reasons. F2 (neg-prenarrow
+  ordering) landed via Nim Table-iteration port.
 
 | Pattern | Dialect | Nim | Hit by ddisasm? | Verdict |
 |---|---|---|---|---|
@@ -225,7 +224,7 @@ Nim itself silently emits wrong code. Byte-equivalence with Nim
 | **N5.4-Negation** — std-path over D2L FULL_VER | ❌ raises `NotImplementedError` | ❌ **NO** seg-loop wrap ([jit_scan_negation.nim:142-187](https://github.com/.../jit_scan_negation.nim)) | ❌ no | **Both broken.** Nim silently emits single-view `valid()` check; semantically wrong on FULL_VER (HEAD/FULL split). Defer until upstream fixes. |
 | **N5.4-Aggregate** — over D2L FULL_VER | ❌ no `Aggregate` IR op | ❌ **NO** seg-loop wrap ([jit_scan_negation.nim:212-276](https://github.com/.../jit_scan_negation.nim)) | ❌ no | **Both broken.** Nim emits a single `aggregate<>(...)` call against one view. Defer. |
 | ddisasm: head tuple ordering (`varr,varp` vs `varp,varr`) | ❌ wrong order | ✅ correct | ✅ `StackLiveVarBlockEnd1_D0_splitA` | MIR-level head ordering bug — not kernel-body. Investigate HIR→MIR pass for head-arg ordering. |
-| ddisasm: pre-narrow Negation emission order | ❌ reversed order | ✅ correct | ✅ `StackLiveVarPriorUsed` | `_register_neg_pre_narrow` iterates Negations in MIR order; Nim apparently iterates in handle_idx order or similar. Fix is a small reorder. |
+| ddisasm: pre-narrow Negation emission order | ✅ landed (F2) | ✅ correct | ✅ `StackLiveVarPriorUsed` | Nim iterates `Table[int, ...]` in hash-bucket order (slot = `hashWangYi1(handle_idx) & 63`). Ported as `_nim_table_iter_order` helper. |
 | ddisasm: tiled-Cartesian eligibility | ❌ skips tiling | ✅ tiles | ✅ `StackDefUsed1` | `_tiled_cart_eligible` predicate disagrees with Nim — likely relevant when Cartesian source has prefix vars but the binding is single-source/single-var. |
 
 **Note on N5.4-Scan over-implementation:** commit `a90062d` added a

--- a/src/srdatalog/ir/dialects/relation/sorted_array/lowerings.py
+++ b/src/srdatalog/ir/dialects/relation/sorted_array/lowerings.py
@@ -1738,7 +1738,17 @@ def _lower_nested_cart(
   # Pre-narrow handle bindings — between total/0 check and flat
   # loop. Each info emits a comment + zero or more const_prefix
   # binds + the final var_name bind.
-  for info, const_var_names in pre_narrow_emissions:
+  #
+  # Emission order: Nim's `Table[int, ...]` hash-bucket order over
+  # the negation handle indices. Counter-suffix names (`_neg_pre_<n>`)
+  # were already allocated at registration time (forward), so reordering
+  # only the EMIT order keeps the names stable while matching Nim
+  # byte-for-byte. F2 fix; see ddisasm StackLiveVarPriorUsed
+  # (handles 8, 9 → Nim emits handle 9 first because hashWangYi1(9)&63
+  # = 3 < hashWangYi1(8)&63 = 54).
+  emit_order_indices = _nim_table_iter_order(registered_neg_idxs)
+  for emit_idx in emit_order_indices:
+    info, const_var_names = pre_narrow_emissions[emit_idx]
     if ctx.debug:
       stmts.append(
         Comment(
@@ -2229,6 +2239,51 @@ def _scan_var_used(
   byte-for-byte.
   '''
   return any(_var_used_in_op(var_name, op) for op in (*middle, *inserts))
+
+
+def _nim_int_hash(x: int) -> int:
+  '''Port of Nim 2.x `hash(x: int)` = `hashWangYi1(uint64(x))`.
+
+  Nim's default `Table[int, V]` uses this hash for the slot calc
+  `slot = hash(key) & (cap - 1)`. We reproduce it bit-exact so the
+  pre-narrow Negation emit order matches the Nim reference.
+  '''
+  P0 = 0xA0761D6478BD642F
+  P1 = 0xE7037ED1A0B428DB
+  P58 = 0xEB44ACCAB455D165 ^ 8
+  mask64 = (1 << 64) - 1
+
+  def hi_xor_lo(a: int, b: int) -> int:
+    prod = (a * b) & ((1 << 128) - 1)
+    return ((prod >> 64) ^ (prod & mask64)) & mask64
+
+  return hi_xor_lo(hi_xor_lo(P0, (x & mask64) ^ P1), P58)
+
+
+def _nim_table_iter_order(keys: list[int], cap: int = 64) -> list[int]:
+  '''Indices into `keys` in Nim `Table[int, ...]` iteration order.
+
+  Reproduces Nim's `Table` insert + iterate behavior:
+    - slot = `hashWangYi1(key) & (cap - 1)`
+    - linear-probe forward on collision (`(h + 1) & (cap - 1)`)
+    - iterate slots in ascending order
+
+  `cap=64` matches Nim's `defaultInitialSize` for Table (rehashing
+  doesn't fire below the load-factor threshold for any pre-narrow
+  count we hit in practice).
+
+  Returns a permutation of `range(len(keys))` — the order in which
+  the caller should walk its parallel `keys`-indexed list.
+  '''
+  if not keys:
+    return []
+  slots: list[int] = [-1] * cap
+  for i, k in enumerate(keys):
+    h = _nim_int_hash(k) & (cap - 1)
+    while slots[h] != -1:
+      h = (h + 1) & (cap - 1)
+    slots[h] = i
+  return [s for s in slots if s != -1]
 
 
 def _state_key(

--- a/tests/test_cuda_complete_runner.py
+++ b/tests/test_cuda_complete_runner.py
@@ -115,10 +115,6 @@ RUNNER_BYTE_MATCH_SKIPS = {
   # in the destination emit. Likely a MIR-level head-arg ordering — needs
   # MIR-side investigation; not a kernel-body issue.
   ("ddisasm", "StackLiveVarBlockEnd1_D0_splitA"),
-  # ddisasm: pre-narrow Negation emission order differs — Python emits
-  # `RegDefUse...` before `StackDefUse...`; Nim emits in reverse. Likely an
-  # iteration-order bug in `_register_neg_pre_narrow`.
-  ("ddisasm", "StackLiveVarPriorUsed"),
   # ddisasm: tiled-Cartesian eligibility differs — Nim emits the tiled-smem
   # variant in the materialize kernel; Python emits the non-tiled variant.
   # Likely a `_tiled_cart_eligible` predicate disagreement.

--- a/tests/test_runner_byte_equivalence.py
+++ b/tests/test_runner_byte_equivalence.py
@@ -47,10 +47,6 @@ RUNNER_BYTE_MATCH_SKIPS: dict[tuple[str, str], str] = {
     'Head tuple ordering divergence (`varp, varr` vs `varr, varp`) — likely '
     'MIR-level head-arg ordering, not kernel-body.'
   ),
-  ('ddisasm', 'StackLiveVarPriorUsed'): (
-    'Pre-narrow Negation emission order differs (`Reg...` before `Stack...` vs '
-    'reversed in Nim) — iteration order in `_register_neg_pre_narrow`.'
-  ),
   ('ddisasm', 'StackDefUsed1'): (
     'Tiled-Cartesian eligibility differs — Nim emits the tiled-smem materialize '
     'variant; Python emits non-tiled. Likely `_tiled_cart_eligible` predicate gap.'


### PR DESCRIPTION
## Summary

ddisasm `StackLiveVarPriorUsed` had the two pre-narrow Negation handles
(`RegDefUseDefinedInBlock` + `StackDefUseDefinedInBlock`) emitted in
MIR-walk order, while Nim emits them in Stack-then-Reg order. Was
tracked as F2 in [`docs/milestones.md`](docs/milestones.md).

## Root cause

Nim's `_register_negation_pre_narrow` registers Negations into a
`Table[int, NegPreNarrowInfo]` keyed by handle index. Iteration order
is hash-bucket order, not insertion order. For our two cases:

| Rule | Handle indices | Slots (cap=64) | Nim emits |
|---|---|---|---|
| `lsqb_q7_optional/Case4Neither` | 4, 5 | `[3, 6]` | `[4, 5]` (forward) |
| `ddisasm/StackLiveVarPriorUsed` | 8, 9 | `[54, 3]` | `[9, 8]` (reversed) |

Python's `dict` iterates insertion-order, so it diverges only on the
second rule. The naive fix "just `reversed()`" matches StackLivePriorUsed
but breaks Case4Neither.

## Fix

Reproduce Nim's `Table[int, ...]` iteration semantics:

- **`_nim_int_hash(x)`** — bit-exact port of Nim 2.x `hashWangYi1`
  (the default integer hash since Nim 1.4). Verified against an
  empirical Nim test program.
- **`_nim_table_iter_order(keys, cap=64)`** — reproduces the slot
  layout of a default-init `Table[int,V]` (cap=`defaultInitialSize`=64,
  no rehashing at our entry counts) with linear-probe insertion + ascending-
  slot iteration. Returns indices into `keys` in Nim-iteration order.
- `_lower_nested_cart` walks `pre_narrow_emissions` using those
  indices.

## Test plan

- [x] `pytest tests/` — 1003 pass / 8 skip
- [x] ddisasm `StackLiveVarPriorUsed` byte-equals Nim
- [x] ddisasm `Case4Neither` (the regression-trap from "just reversed")
      still byte-equals Nim
- [x] Full ddisasm sweep: 24/27 byte-match (was 23/27 after #4)
- [x] Counter-suffix names (`_neg_pre_<n>`) unchanged — registration
      order still allocates them, only EMIT order is reordered
- [x] `_nim_table_iter_order` is a permutation, never drops or
      duplicates entries

## Remaining ddisasm gaps (out of scope)

- **F1** head-tuple ordering (`StackLiveVarBlockEnd1_D0_splitA`, `_splitB`) — HIR/MIR-level
- **F3** tiled-Cartesian eligibility (`StackDefUsed1`) — predicate gap

🤖 Generated with [Claude Code](https://claude.com/claude-code)