### PR TITLE
HIR/MIR standardization step 1: dialect-catalog + Enum rename

### DIFF
--- a/docs/milestones.md
+++ b/docs/milestones.md
@@ -25,7 +25,7 @@ reference, modulo `_cpp_norm` whitespace/comment normalization.
 | Legacy elimination | ✅ all `codegen/jit/{pipeline,instructions,root,scan_negation,kernel_functor,file}.py` deleted | — |
 | Layout reorg | ✅ Phase A (`codegen/jit/` → `ir/dialects/target/cuda/`), Phase B (`ir/` namespace) | ⬜ Phase C (R1–R6 below) |
 | Docs / test rename sync | ✅ README + 10 `test_jit_*.py` → `test_cuda_*.py` | — |
-| Open work | — | WS full runner, CPU/WASM target, HIR/MIR as proper dialects, `complete_runner.py` templating |
+| Open work | HIR/MIR catalog (step 1) | WS full runner, CPU/WASM target, HIR/MIR full Op-subclass+frozen migration (step 2), `complete_runner.py` templating |
 
 **Test gates currently passing (after Refactor PR R1–R9):**
 - 272/272 runner byte-equivalence (`tests/test_runner_byte_equivalence.py`) — 2 skipped (WS runner only)
@@ -295,7 +295,7 @@ Not part of any milestone series; flagged for awareness.
 
 | Topic | Effort | Trade-off |
 |---|---|---|
-| **Promote HIR / MIR to real dialects** | medium | They predate the dialect framework. Would unlock pattern matchers / strategies on HIR/MIR ops. Mostly rename + `Op` mixin. |
+| **Promote HIR / MIR to real dialects** | medium | Step 1 landed: `Dialect("hir")` + `Dialect("mir")` catalog registrations alongside `iir.cf`, `relation.sorted_array`, `target.cuda`; renamed the colliding `srdatalog.ir.hir.pass_.Dialect` Enum to `IRLevel` to disambiguate. Step 2 (frozen+slots+`Op` subclass + ~15 mutation-site refactor to use `dataclasses.replace`) deferred to a follow-up PR. |
 | **`complete_runner.py` templating** | large | ~700 lines of f-string-heavy CUDA emission. Either lift more shapes into structured ops, or introduce a templating layer (jinja-style or `quote`-style). Long-term direction question. |
 | **WS full runner** | LARGE | Net-new — legacy never finished it. Would design the WCOJTask queue, cross-warp stealing, `par.data.atomic_ws` dialect. Currently blocks 2 skipped fixtures. |
 | **Second target (CPU / WASM)** | very large | Would actually exercise the IR layering — same IIR, different emit. Validates the "target.cuda" prefix in the layout. |

--- a/src/srdatalog/ir/hir/__init__.py
+++ b/src/srdatalog/ir/hir/__init__.py
@@ -3,13 +3,39 @@
 Entry point: `compile_to_hir(program)` runs the default pipeline
 (currently: stratification only; future passes will be appended here as
 they are ported from Nim).
+
+A `DIALECT` catalog is also exposed (see `srdatalog.ir.core.dialect`)
+so HIR participates in the framework registry alongside `iir.cf`,
+`relation.sorted_array`, etc. The HIR types here are not yet
+`Op`-subclassed or frozen — that's the next standardization step.
+The catalog is purely metadata today.
 '''
 
 from __future__ import annotations
 
 from srdatalog.dsl import Program
+from srdatalog.ir.core import Dialect
 from srdatalog.ir.hir.pass_ import Pipeline
-from srdatalog.ir.hir.types import HirProgram
+from srdatalog.ir.hir.types import (
+  AccessPattern,
+  HirProgram,
+  HirRuleVariant,
+  HirStratum,
+  RelationDecl,
+  Version,
+)
+
+DIALECT = Dialect(
+  name='hir',
+  types=[
+    AccessPattern,
+    HirProgram,
+    HirRuleVariant,
+    HirStratum,
+    RelationDecl,
+    Version,
+  ],
+)
 
 
 def default_pipeline(verbose: bool = False) -> Pipeline:

--- a/src/srdatalog/ir/hir/index.py
+++ b/src/srdatalog/ir/hir/index.py
@@ -25,7 +25,7 @@ only has to be stable, not byte-matched against Nim.
 
 from __future__ import annotations
 
-from srdatalog.ir.hir.pass_ import Dialect, PassInfo, PassLevel
+from srdatalog.ir.hir.pass_ import IRLevel, PassInfo, PassLevel
 from srdatalog.ir.hir.types import (
   HirProgram,
   HirRuleVariant,
@@ -168,8 +168,8 @@ class IndexSelectionPass:
     name="IndexSelection",
     level=PassLevel.HIR_TRANSFORM,
     order=300,
-    source_dialect=Dialect.HIR,
-    target_dialect=Dialect.HIR,
+    source_dialect=IRLevel.HIR,
+    target_dialect=IRLevel.HIR,
   )
 
   def run(self, hir: HirProgram) -> HirProgram:

--- a/src/srdatalog/ir/hir/pass_.py
+++ b/src/srdatalog/ir/hir/pass_.py
@@ -38,8 +38,16 @@ class PassLevel(Enum):
   DIALECT_UNIFY = "plDialectUnify"  # MirNode -> MirNode (unified dialect)
 
 
-class Dialect(Enum):
-  '''IR abstraction level. Mirrors Nim pass_infrastructure.Dialect.'''
+class IRLevel(Enum):
+  '''IR abstraction level (HIR / MIR variants).
+
+  Renamed from `Dialect` to disambiguate from
+  `srdatalog.ir.core.dialect.Dialect`, the framework registry record
+  that catalogs ops/types per dialect (`relation.sorted_array`,
+  `iir.cf`, etc.). This is purely an abstraction-level *label* used
+  by `PassInfo.source_dialect` / `target_dialect`.
+
+  Mirrors Nim `pass_infrastructure.Dialect`.'''
 
   HIR = "HIR"
   MIR_WCOJ = "MIR_WCOJ"
@@ -55,8 +63,8 @@ class PassInfo:
   name: str
   level: PassLevel
   order: int  # Lower runs first within the same level
-  source_dialect: Dialect
-  target_dialect: Dialect
+  source_dialect: IRLevel
+  target_dialect: IRLevel
 
 
 @runtime_checkable

--- a/src/srdatalog/ir/hir/plan.py
+++ b/src/srdatalog/ir/hir/plan.py
@@ -21,7 +21,7 @@ from __future__ import annotations
 from dataclasses import dataclass, field
 
 from srdatalog.dsl import Agg, ArgKind, Atom, Filter, Let, Negation, PlanEntry, Rule, Split
-from srdatalog.ir.hir.pass_ import Dialect, PassInfo, PassLevel
+from srdatalog.ir.hir.pass_ import IRLevel, PassInfo, PassLevel
 from srdatalog.ir.hir.types import AccessPattern, HirProgram, HirRuleVariant, Version
 
 # -----------------------------------------------------------------------------
@@ -520,8 +520,8 @@ class JoinPlannerPass:
     name="JoinPlanning",
     level=PassLevel.HIR_TRANSFORM,
     order=200,
-    source_dialect=Dialect.HIR,
-    target_dialect=Dialect.HIR,
+    source_dialect=IRLevel.HIR,
+    target_dialect=IRLevel.HIR,
   )
 
   def run(self, hir: HirProgram) -> HirProgram:

--- a/src/srdatalog/ir/hir/rule_rewrite.py
+++ b/src/srdatalog/ir/hir/rule_rewrite.py
@@ -23,7 +23,7 @@ from srdatalog.dsl import (
   PlanEntry,
   Rule,
 )
-from srdatalog.ir.hir.pass_ import Dialect, PassInfo, PassLevel
+from srdatalog.ir.hir.pass_ import IRLevel, PassInfo, PassLevel
 from srdatalog.ir.hir.provenance import compiler_gen
 from srdatalog.ir.hir.types import RelationDecl
 
@@ -158,8 +158,8 @@ class WildcardRewritePass:
     name="WildcardRewrite",
     level=PassLevel.RULE_REWRITE,
     order=-1,
-    source_dialect=Dialect.HIR,
-    target_dialect=Dialect.HIR,
+    source_dialect=IRLevel.HIR,
+    target_dialect=IRLevel.HIR,
   )
 
   def run(self, rules, decls):
@@ -171,8 +171,8 @@ class ConstantRewritePass:
     name="ConstantRewrite",
     level=PassLevel.RULE_REWRITE,
     order=0,
-    source_dialect=Dialect.HIR,
-    target_dialect=Dialect.HIR,
+    source_dialect=IRLevel.HIR,
+    target_dialect=IRLevel.HIR,
   )
 
   def run(self, rules, decls):
@@ -184,8 +184,8 @@ class HeadConstantRewritePass:
     name="HeadConstantRewrite",
     level=PassLevel.RULE_REWRITE,
     order=1,
-    source_dialect=Dialect.HIR,
-    target_dialect=Dialect.HIR,
+    source_dialect=IRLevel.HIR,
+    target_dialect=IRLevel.HIR,
   )
 
   def run(self, rules, decls):
@@ -447,8 +447,8 @@ class SemiJoinPass:
     name="SemiJoinOpt",
     level=PassLevel.RULE_REWRITE,
     order=2,
-    source_dialect=Dialect.HIR,
-    target_dialect=Dialect.HIR,
+    source_dialect=IRLevel.HIR,
+    target_dialect=IRLevel.HIR,
   )
 
   def run(self, rules, decls):

--- a/src/srdatalog/ir/hir/semi_naive.py
+++ b/src/srdatalog/ir/hir/semi_naive.py
@@ -17,7 +17,7 @@ members get incrementalized).
 from __future__ import annotations
 
 from srdatalog.dsl import Atom, Rule
-from srdatalog.ir.hir.pass_ import Dialect, PassInfo, PassLevel
+from srdatalog.ir.hir.pass_ import IRLevel, PassInfo, PassLevel
 from srdatalog.ir.hir.types import HirProgram, HirRuleVariant, Version
 
 
@@ -69,8 +69,8 @@ class SemiNaiveVariantPass:
     name="SemiNaiveVariants",
     level=PassLevel.HIR_TRANSFORM,
     order=100,
-    source_dialect=Dialect.HIR,
-    target_dialect=Dialect.HIR,
+    source_dialect=IRLevel.HIR,
+    target_dialect=IRLevel.HIR,
   )
 
   def run(self, hir: HirProgram) -> HirProgram:

--- a/src/srdatalog/ir/hir/split.py
+++ b/src/srdatalog/ir/hir/split.py
@@ -16,7 +16,7 @@ JoinPlannerPass from hir_plan._plan_variant.
 from __future__ import annotations
 
 from srdatalog.dsl import ArgKind, Atom
-from srdatalog.ir.hir.pass_ import Dialect, PassInfo, PassLevel
+from srdatalog.ir.hir.pass_ import IRLevel, PassInfo, PassLevel
 from srdatalog.ir.hir.types import HirProgram, RelationDecl
 
 
@@ -60,8 +60,8 @@ class TempRelSynthesisPass:
     name="TempRelSynthesis",
     level=PassLevel.HIR_TRANSFORM,
     order=250,
-    source_dialect=Dialect.HIR,
-    target_dialect=Dialect.HIR,
+    source_dialect=IRLevel.HIR,
+    target_dialect=IRLevel.HIR,
   )
 
   def run(self, hir: HirProgram) -> HirProgram:
@@ -95,8 +95,8 @@ class TempIndexRegistrationPass:
     name="TempIndexRegistration",
     level=PassLevel.HIR_TRANSFORM,
     order=350,
-    source_dialect=Dialect.HIR,
-    target_dialect=Dialect.HIR,
+    source_dialect=IRLevel.HIR,
+    target_dialect=IRLevel.HIR,
   )
 
   def run(self, hir: HirProgram) -> HirProgram:

--- a/src/srdatalog/ir/hir/stratify.py
+++ b/src/srdatalog/ir/hir/stratify.py
@@ -19,7 +19,7 @@ downstream ordering (dependency edges, SCC membership iteration).
 from __future__ import annotations
 
 from srdatalog.dsl import Agg, Atom, Negation, Rule
-from srdatalog.ir.hir.pass_ import Dialect, PassInfo, PassLevel
+from srdatalog.ir.hir.pass_ import IRLevel, PassInfo, PassLevel
 from srdatalog.ir.hir.types import HirProgram, HirStratum, RelationDecl
 
 
@@ -265,8 +265,8 @@ class StratificationPass:
     name="Stratification",
     level=PassLevel.HIR_TRANSFORM,
     order=0,
-    source_dialect=Dialect.HIR,
-    target_dialect=Dialect.HIR,
+    source_dialect=IRLevel.HIR,
+    target_dialect=IRLevel.HIR,
   )
 
   def run(self, rules: list[Rule], decls: list[RelationDecl]) -> HirProgram:

--- a/src/srdatalog/ir/mir/__init__.py
+++ b/src/srdatalog/ir/mir/__init__.py
@@ -4,9 +4,85 @@ Submodules:
   - ``types``  — the MIR ADT (Scan, ColumnJoin, CartesianJoin, etc.)
   - ``passes`` — MIR optimization passes (clause reordering, etc.)
   - ``emit``   — S-expression printer for golden-diff tests
+
+A `DIALECT` catalog is also exposed (see `srdatalog.ir.core.dialect`)
+so MIR participates in the framework registry alongside `iir.cf`,
+`relation.sorted_array`, etc. The MIR types here are not yet
+`Op`-subclassed or frozen — that's the next standardization step.
+The catalog is purely metadata today.
 '''
 
 from __future__ import annotations
 
-# No re-exports here by design — submodule-qualified imports read
-# cleanly and avoid circular-import hazards (types ↔ passes cross-ref).
+from srdatalog.ir.core import Dialect
+from srdatalog.ir.mir.types import (
+  Aggregate,
+  BalancedScan,
+  Block,
+  CartesianJoin,
+  CheckSize,
+  ClearRelation,
+  ColumnJoin,
+  ColumnSource,
+  ComputeDelta,
+  ComputeDeltaIndex,
+  ConstantBind,
+  CreateFlatView,
+  ExecutePipeline,
+  Filter,
+  FixpointPlan,
+  GatherColumn,
+  InjectCppHook,
+  InnerPipeline,
+  InsertInto,
+  MergeIndex,
+  MergeRelation,
+  Negation,
+  ParallelGroup,
+  PositionedExtract,
+  PostStratumReconstructInternCols,
+  ProbeJoin,
+  Program,
+  RebuildIndex,
+  RebuildIndexFromIndex,
+  Scan,
+)
+
+DIALECT = Dialect(
+  name='mir',
+  ops=[
+    # Leaf / pipeline ops
+    Aggregate,
+    CartesianJoin,
+    ColumnJoin,
+    ColumnSource,
+    ConstantBind,
+    CreateFlatView,
+    Filter,
+    GatherColumn,
+    InnerPipeline,
+    InsertInto,
+    Negation,
+    PositionedExtract,
+    ProbeJoin,
+    Scan,
+    # Fixpoint maintenance
+    CheckSize,
+    ClearRelation,
+    ComputeDelta,
+    ComputeDeltaIndex,
+    MergeIndex,
+    MergeRelation,
+    RebuildIndex,
+    RebuildIndexFromIndex,
+    # Structural
+    BalancedScan,
+    Block,
+    ExecutePipeline,
+    FixpointPlan,
+    InjectCppHook,
+    ParallelGroup,
+    PostStratumReconstructInternCols,
+    Program,
+  ],
+)

--- a/tests/test_hir_mir_dialect_catalog.py
+++ b/tests/test_hir_mir_dialect_catalog.py
@@ -1,0 +1,85 @@
+'''HIR + MIR dialect-catalog registration tests.
+
+Verifies that `srdatalog.ir.hir` and `srdatalog.ir.mir` expose `DIALECT`
+catalog objects matching the framework's `srdatalog.ir.core.Dialect`
+contract, and that they register cleanly with a fresh `Compiler`.
+
+This is the first step of the HIR/MIR standardization (issue tracked
+in docs/milestones.md). The HIR/MIR types themselves are not yet
+`Op`-subclassed or `frozen+slots` — that follow-up step requires
+refactoring the ~15 mutation sites that currently mutate handle_start
+/ concurrent_write / etc. on MIR nodes.
+
+Today's contract: each dialect catalogs its types/ops by class
+reference; pattern-matching/strategy/verifier hooks land later.
+'''
+
+from __future__ import annotations
+
+import pytest
+
+from srdatalog.ir.core import Compiler, Dialect
+
+
+def test_hir_dialect_exists():
+  from srdatalog.ir.hir import DIALECT
+
+  assert isinstance(DIALECT, Dialect)
+  assert DIALECT.name == 'hir'
+  # HIR catalogs its core types (HirProgram, HirStratum, HirRuleVariant,
+  # RelationDecl, AccessPattern, Version). These are not Op-subclassed
+  # yet — they're catalogued under `types` for now.
+  assert len(DIALECT.types) >= 6
+  type_names = {t.__name__ for t in DIALECT.types}
+  for expected in (
+    'AccessPattern',
+    'HirProgram',
+    'HirRuleVariant',
+    'HirStratum',
+    'RelationDecl',
+    'Version',
+  ):
+    assert expected in type_names, f'HIR DIALECT missing {expected}'
+
+
+def test_mir_dialect_exists():
+  from srdatalog.ir.mir import DIALECT
+
+  assert isinstance(DIALECT, Dialect)
+  assert DIALECT.name == 'mir'
+  # MIR catalogs every op kind in `types.py`. Today these are mutable
+  # @dataclass — the standardization is to bring them under the framework
+  # registry. Frozen+slots+Op-subclass migration is a follow-up.
+  assert len(DIALECT.ops) >= 25
+  op_names = {o.__name__ for o in DIALECT.ops}
+  # Spot-check the load-bearing op kinds that the dialect-emit relies on.
+  for expected in (
+    'CartesianJoin',
+    'ColumnJoin',
+    'ColumnSource',
+    'ExecutePipeline',
+    'FixpointPlan',
+    'InsertInto',
+    'Negation',
+    'Program',
+    'Scan',
+  ):
+    assert expected in op_names, f'MIR DIALECT missing {expected}'
+
+
+def test_hir_and_mir_register_with_compiler():
+  '''Both dialects must register cleanly with a fresh Compiler — same
+  contract as `relation.sorted_array`, `iir.cf`, `target.cuda`.'''
+  from srdatalog.ir.hir import DIALECT as HIR_DIALECT
+  from srdatalog.ir.mir import DIALECT as MIR_DIALECT
+
+  compiler = Compiler()
+  compiler.register_dialect(HIR_DIALECT)
+  compiler.register_dialect(MIR_DIALECT)
+
+  names = {d.name for d in compiler.dialects}
+  assert names == {'hir', 'mir'}
+
+  # Idempotent registration is forbidden — re-registering raises.
+  with pytest.raises(ValueError, match=r"already registered"):
+    compiler.register_dialect(HIR_DIALECT)

--- a/tests/test_hir_pipeline.py
+++ b/tests/test_hir_pipeline.py
@@ -7,7 +7,7 @@ order, and rejects misregistered passes (wrong PassLevel).
 from srdatalog.dsl import Program, Relation, Rule, Var
 from srdatalog.ir.hir import compile_to_hir
 from srdatalog.ir.hir.pass_ import (
-  Dialect,
+  IRLevel,
   PassInfo,
   PassLevel,
   Pipeline,
@@ -37,8 +37,8 @@ class _RecordingRewrite:
       name=f"Record({tag})",
       level=PassLevel.RULE_REWRITE,
       order=order,
-      source_dialect=Dialect.HIR,
-      target_dialect=Dialect.HIR,
+      source_dialect=IRLevel.HIR,
+      target_dialect=IRLevel.HIR,
     )
     self._tag = tag
     self._trace = trace
@@ -56,8 +56,8 @@ class _RecordingHirTransform:
       name=f"Record({tag})",
       level=PassLevel.HIR_TRANSFORM,
       order=order,
-      source_dialect=Dialect.HIR,
-      target_dialect=Dialect.HIR,
+      source_dialect=IRLevel.HIR,
+      target_dialect=IRLevel.HIR,
     )
     self._tag = tag
     self._trace = trace


### PR DESCRIPTION
## Summary

Brings HIR and MIR into the framework's `Dialect` registry alongside
`iir.cf`, `relation.sorted_array`, `target.cuda`. Step 1 of the
multi-PR migration tracked in [docs/milestones.md](docs/milestones.md).

## Two coherent changes

**1. Disambiguate `Dialect` naming** — rename `srdatalog.ir.hir.pass_.Dialect`
Enum to `IRLevel`.

The Enum was purely an abstraction-level *label* (HIR / MIR_WCOJ /
MIR_BINARY / etc.) used by `PassInfo.source_dialect` /
`target_dialect`. It shadowed `srdatalog.ir.core.dialect.Dialect`,
the framework registry record that catalogs ops/types per dialect.
That collision was confusing.

Updated 7 call-sites: `stratify.py`, `plan.py`, `semi_naive.py`,
`index.py`, `split.py`, `rule_rewrite.py`, `tests/test_hir_pipeline.py`.

**2. Add `DIALECT` catalog registrations.**

  - `srdatalog.ir.hir.DIALECT = Dialect(name='hir', types=[...])` —
    catalogs HirProgram, HirStratum, HirRuleVariant, RelationDecl,
    AccessPattern, Version.
  - `srdatalog.ir.mir.DIALECT = Dialect(name='mir', ops=[...])` —
    catalogs all 30 MIR op classes from `mir/types.py`.

Both register cleanly with a fresh `Compiler` (same contract as
the existing dialects).

## Out of scope (step 2 — separate PR)

- Migrating HIR/MIR types to subclass `Op` / `Type` (`from
  srdatalog.ir.core.ops import Op`).
- Making them `@dataclass(frozen=True, slots=True)` per discipline
  rules D2/D3.

This requires refactoring ~15 mutation sites that currently mutate
MIR/HIR fields in place:

  - `envelope.py:79,82,86` + `pipeline_utils.py:107,110,114` —
    `assign_handle_positions` mutates `node.handle_start`.
  - `orchestrator.py:418` — `exec_ops[rule_idx].concurrent_write = True`.
  - `mir/passes.py:40,176,237,306,309` — passes mutate `source_specs`,
    `var_from_source`, `pipeline`, `instructions`.
  - `hir/plan.py:476-478` — `HirRuleVariant.work_stealing` /
    `block_group` / `dedup_hash` setter assignments.

Each would become a `dataclasses.replace` returning a new node, with
callers threading the replacement back through the pipeline. Tractable
but bigger surface than this PR.

## Test plan

- [x] `pytest tests/` — 1009 pass / 5 skip (was 1006/5; +3 from new
      `tests/test_hir_mir_dialect_catalog.py`)
- [x] New tests verify both dialects exist, expose the expected types/ops,
      and register with a fresh `Compiler` without name collisions
- [x] Existing HIR pipeline tests (which used `Dialect.HIR` from the
      Enum) continue to pass under the rename to `IRLevel.HIR`

🤖 Generated with [Claude Code](https://claude.com/claude-code)