### PR TITLE
Stage 3A: design plan + milestones reshape

### DIFF
--- a/docs/milestones.md
+++ b/docs/milestones.md
@@ -25,7 +25,8 @@ reference, modulo `_cpp_norm` whitespace/comment normalization.
 | Legacy elimination | ✅ all `codegen/jit/{pipeline,instructions,root,scan_negation,kernel_functor,file}.py` deleted | — |
 | Layout reorg | ✅ Phase A (`codegen/jit/` → `ir/dialects/target/cuda/`), Phase B (`ir/` namespace) | ⬜ Phase C (R1–R6 below) |
 | Docs / test rename sync | ✅ README + 10 `test_jit_*.py` → `test_cuda_*.py` | — |
-| Open work | HIR/MIR catalog (step 1) | WS full runner, CPU/WASM target, HIR/MIR full Op-subclass+frozen migration (step 2), `complete_runner.py` templating |
+| **Stage 3 (IR framework consolidation)** | ✅ HIR/MIR dialect catalog ([PR #10](https://github.com/harp-lab/srdatalog-python/pull/10), opens Stage 3B) | ⬜ S3A.0–S3A.9 (P1/P2/P3 realization, codegen rename, renderer registry); S3B planning only |
+| Open work | — | Stage 3A (next — see [`stage3a_execution_plan.md`](./stage3a_execution_plan.md)), WS full runner, CPU/WASM target, HIR/MIR full Op-subclass migration (Stage 3B), `complete_runner.py` templating |
 
 **Test gates currently passing (after Refactor PR R1–R9):**
 - 272/272 runner byte-equivalence (`tests/test_runner_byte_equivalence.py`) — 2 skipped (WS runner only)
@@ -111,6 +112,92 @@ into reviewable commits:
 9. Docs + milestone update
 
 Each commit should keep tests green so bisect stays useful.
+
+---
+
+## Stage 3 — IR framework consolidation
+
+**Goal:** realize Properties P1 / P2 / P3 from
+[`ir_lowering_semantics.md` §4](./ir_lowering_semantics.md) — the spec
+documents them, but the codebase doesn't enforce them. Production
+bypasses the framework; lowerings exist as ad-hoc Python functions, not
+typed `Lowering` instances; `PassDriver.run` is a no-op. Adding a new
+dialect today requires editing existing files (the 41-case match in
+`target/cuda/emit.py`), violating P1.
+
+**Binding vocabulary (resolved during planning):**
+- **Lowering** ($D_1.\text{Op} \to D_2.\text{Op}^*$, data → data, framework-dispatched)
+- **Render** ($D.\text{Op} \to \text{str}$, data → target text, codegen-dispatched)
+- **Print** ($D.\text{Op} \to \text{s-expr}$, data → canonical text, dialect-owned)
+
+These are three different operations the current code conflates. Each IR
+layer has one Print; only IIR has Renders (one per codegen). HIR and MIR
+do not go to target text.
+
+**Dialect ≠ Codegen.** Dialects own IR data $\langle T, O, L^{\text{out}}, R, V \rangle + \text{Print}$.
+Codegens own a Render registry plus target configuration — no ops, no
+lowerings, no rewrites. GPU codegen is a "dumb printer" by design.
+
+**Sequencing rationale:** Stage 3A realizes the framework on the dialects
+that already exist. Stage 3B (HIR/MIR onto `Op`/`Type` subclasses) waits
+because re-evaluation after 3A may show HIR/MIR are better off with typed
+adapters at the framework boundary than full migration.
+
+### Stage 3A — realize P1/P2/P3 (do first)
+
+Full execution plan with per-task scope, approach, risk, and test gate:
+see [`stage3a_execution_plan.md`](./stage3a_execution_plan.md). The table
+below is the index.
+
+| ID | Task | Why |
+|---|---|---|
+| **S3A.0** | Rename `ir/dialects/target/cuda/` → `ir/codegen/cuda/` | Resolve the category error: codegen is not a dialect. Foundational; everything below assumes the right vocabulary. |
+| **S3A.1** | Add Print_i (IIR s-expression printer) per dialect | Give IIR an inspectable text form; enables byte-equal s-expr testing of MIR→IIR lowerings. |
+| **S3A.2** | `sorted_array/lowerings.py` returns IIR data, not C++ text | Make IIR exist as inspectable data between lowering and render — separates the conflated steps. |
+| **S3A.3** | Split `codegen/cuda/emit.py` (41-case match) into `codegen/cuda/render/` package, registry-dispatched | **P1 fix.** Adding a dialect no longer requires editing codegen core. |
+| **S3A.4** | Formalize MIR→IIR lowerings as `Lowering` instances on each relation dialect's $L^{\text{out}}$ | **P3 realization.** |
+| **S3A.5** | Formalize R1–R5 (sorted_array §11 rewrites) as `Rewrite` instances on `sorted_array.R` | **P3 realization.** |
+| **S3A.6** | `PassDriver.run` dispatches lowerings/rewrites by type instead of being a no-op stub | The framework actually runs. |
+| **S3A.7** | Wire `Dialect.verifier` into PassDriver at phase boundaries | **D10.** |
+| **S3A.8** | Per-`Codegen` plugin registry; explicit `register_*` calls (no side effects) | **A6 + A7.** |
+| **S3A.9** | (Cleanup) no double `compile_to_hir`; relocate `block_group.py` emit functions into `codegen/cuda/render/parallel_data.py` | Independent small fixes. |
+
+**S3A acceptance gate:**
+
+- New `tests/test_ir_no_import_side_effects.py` — importing a module under
+  `ir/dialects/` or `ir/codegen/` must not mutate state in any other module (A7).
+- `tests/test_ir_core_discipline.py` extended — no module under `ir/dialects/`
+  or `ir/codegen/` defines a top-level mutable dict/list (A6).
+- New `tests/test_codegen_completeness.py` — every Codegen has renderers for
+  every op in every supported dialect (catches "added op, forgot renderer"
+  at `Compiler()` construction, not at first emit).
+- New `tests/test_lowering_registry.py` — every documented MIR op has a
+  registered `Lowering` on every relation dialect that supports it.
+- ddisasm fixture and the full byte-equivalence suite still pass
+  (1009/5 skip baseline preserved).
+- Each S3A task ships as its own PR (Step 1 / PR #10 set the precedent —
+  even modest IR changes warrant their own scope).
+
+### Stage 3B — unify HIR/MIR onto the Op/Dialect framework (planning only)
+
+**Status:** *planning only.* Land Stage 3A first. After 3A, re-evaluate
+whether 3B is the right next move or whether HIR/MIR should stay as their
+own frozen-dataclass IRs with typed adapters at the framework boundary.
+
+| ID | Description | Discipline rule |
+|---|---|---|
+| **S3B.1** | Convert HIR types in [hir/types.py](../src/srdatalog/ir/hir/types.py) to `Op`/`Type` subclasses. | D1, D2, D3, D4, D11 |
+| **S3B.2** | Convert MIR types in [mir/types.py](../src/srdatalog/ir/mir/types.py) similarly. | D1, D2, D3, D4, D11 |
+| **S3B.3** | Replace the ~15 `dataclasses.replace`-style mutation sites with strategy combinators from [core/strategy.py](../src/srdatalog/ir/core/strategy.py). | D6, D7 |
+| **S3B.4** | Migrate the monolithic [hir/lower.py](../src/srdatalog/ir/hir/lower.py) into per-op `Lowering`s registered on the HIR dialect (uses S3A.4 + S3A.6 infra). | (composability) |
+| **S3B.5** | Lift HIR passes (`stratify`, `split`, `semi_naive`, `plan`, `index`, `rule_rewrite`) onto `core/passes.py`. | unifies pass infra |
+| **S3B.6** | Replace the hardcoded sequence in [pipeline.py:80-88](../src/srdatalog/ir/pipeline.py#L80-L88) with `compiler.run(passes=[...])`, allowing external code to reorder/insert/skip passes. | (composability) |
+
+**S3B open question:** does the unified framework cleanly express HIR's
+program-level operations (stratification, semi-naive variant generation),
+which are not per-op rewrites? If not, HIR may need to stay outside the
+dialect framework with a typed adapter at the boundary, and 3B narrows to
+just MIR.
 
 ---
 
@@ -295,15 +382,14 @@ Not part of any milestone series; flagged for awareness.
 
 | Topic | Effort | Trade-off |
 |---|---|---|
-| **Promote HIR / MIR to real dialects** | medium | Step 1 landed: `Dialect("hir")` + `Dialect("mir")` catalog registrations alongside `iir.cf`, `relation.sorted_array`, `target.cuda`; renamed the colliding `srdatalog.ir.hir.pass_.Dialect` Enum to `IRLevel` to disambiguate. Step 2 (frozen+slots+`Op` subclass + ~15 mutation-site refactor to use `dataclasses.replace`) deferred to a follow-up PR. |
 | **`complete_runner.py` templating** | large | ~700 lines of f-string-heavy CUDA emission. Either lift more shapes into structured ops, or introduce a templating layer (jinja-style or `quote`-style). Long-term direction question. |
 | **WS full runner** | LARGE | Net-new — legacy never finished it. Would design the WCOJTask queue, cross-warp stealing, `par.data.atomic_ws` dialect. Currently blocks 2 skipped fixtures. |
-| **Second target (CPU / WASM)** | very large | Would actually exercise the IR layering — same IIR, different emit. Validates the "target.cuda" prefix in the layout. |
+| **Second target (CPU / WASM)** | very large | Would actually exercise the IR layering — same IIR, different emit. Validates the "target.cuda" prefix in the layout. Strong forcing function for Stage 3A.1 (plugin-ized emit dispatch). |
 | **Mypy cleanup in `ir/dialects/target/cuda/`** | medium | ~6 pre-existing errors (unreachable, missing type args). Inherited from legacy moves; not blocking. |
-| **`ir/core/` strategy / pattern infra** | medium | Stratego-style combinators in `strategy.py` are barely used. Either commit to using them in lowering / passes, or trim. |
 | **Provenance / SR semiring path** | very large | Touched in `provenance.py` but not woven through dialect lowering. Would be a sizable IR project if provenance becomes first-class. |
-| **HIR-level passes (`stratify`, `split`, `semi_naive`, `plan`)** | medium | Real passes but not under `ir/core` pass framework. Aligning would unify pass infrastructure. |
 | **`ir/dialects/target/cuda/context.py` simplification** | small | After legacy deletion, only `materialized.py` / `view_slots.py` / `block_group.py` (lazy) and unit tests still need it. Mostly inlinable. |
+
+*Promoted into Stage 3 (above):* HIR/MIR catalog registration → ✅ landed via [PR #10](https://github.com/harp-lab/srdatalog-python/pull/10) (opens Stage 3B); HIR/MIR Op-subclass migration → S3B.1–S3B.2; HIR-level passes onto `core/passes.py` → S3B.5; commit to the `core/strategy.py` combinators → S3B.3.
 
 ---
 

--- a/docs/stage3a_execution_plan.md
+++ b/docs/stage3a_execution_plan.md
@@ -11,7 +11,7 @@ plan.
 Binding specs (read first):
 - [`design_principles.md`](./design_principles.md) — D-rules and A-rules
 - [`ir_lowering_semantics.md`](./ir_lowering_semantics.md) Part I §3–§4 — dialect ABI + P1/P2/P3
-- [`src/srdatalog/ir/core/CLAUDE.md`](../src/srdatalog/ir/core/CLAUDE.md) — `ir/core/` invariants
+- `src/srdatalog/ir/core/CLAUDE.md` — `ir/core/` invariants (in-tree, not built into sphinx)
 
 ## 1. Vocabulary (binding)
 
@@ -309,7 +309,7 @@ dialect that supports it.
 ### S3A.5 — formalize R1–R5 as `Rewrite` instances on `sorted_array.R`
 
 **Goal.** Realize P3 for rewrites. R1–R5 from
-[ir_lowering_semantics.md §11](./ir_lowering_semantics.md#L494) exist in
+[`ir_lowering_semantics.md`](./ir_lowering_semantics.md) §11 exist in
 code (count-as-product, hint introduction, negation pre-narrow, etc.) but
 not as `Rewrite` instances.
 

--- a/docs/stage3a_execution_plan.md
+++ b/docs/stage3a_execution_plan.md
@@ -1,0 +1,490 @@
+---
+orphan: true
+---
+
+# Stage 3A — execution plan
+
+Operational companion to [`milestones.md` § Stage 3](./milestones.md). The
+milestones doc indexes the work; this doc is the binding design + per-task
+plan.
+
+Binding specs (read first):
+- [`design_principles.md`](./design_principles.md) — D-rules and A-rules
+- [`ir_lowering_semantics.md`](./ir_lowering_semantics.md) Part I §3–§4 — dialect ABI + P1/P2/P3
+- [`src/srdatalog/ir/core/CLAUDE.md`](../src/srdatalog/ir/core/CLAUDE.md) — `ir/core/` invariants
+
+## 1. Vocabulary (binding)
+
+The conversation that produced this plan kept tripping on three operations
+that the current code conflates. They are different and stay different:
+
+| Operation | Type | Target-aware? | Dispatched by | Test surface |
+|---|---|---|---|---|
+| **Lowering** | `D1.Op → D2.Op*` (data → data) | No | `PassDriver` (typed) | byte-equal s-expr of D2 |
+| **Render** | `D.Op → str` (data → target text) | Yes | Codegen's render registry | byte-equal target text |
+| **Print** | `D.Op → str` (data → canonical s-expr) | No | Dialect-owned printer | byte-equal s-expr |
+
+**Dialect ≠ Codegen.** A dialect owns IR data: $\langle T, O, L^{\text{out}}, R, V \rangle$
+plus Print. A codegen consumes IR data and produces target-specific text:
+a Render registry plus target configuration (block size, stream count, etc.).
+Codegens have no ops, no lowerings, no rewrites. They are pure renderers
+plus parameter providers — "dumb printers" by design.
+
+## 2. IR topology
+
+```
+                                                  ┌─→ s-expr   (Print: canonical, debug/test)
+                                                  │
+HIR ── lower ──→ MIR ── lower ──→ IIR ────────────┤
+                                                  │
+                                                  ├─→ C++      (Codegen.cuda Render)
+                                                  ├─→ C++/TBB  (Codegen.cpp_tbb Render — future)
+                                                  └─→ ...      (other codegens)
+```
+
+Each IR layer carries the same five-tuple plus Print. Only IIR has Renders
+(one per codegen that consumes it). HIR and MIR don't go to target text;
+they only have Print.
+
+```
+HIR  = ⟨T_h, O_h, L_h^out, R_h, V_h⟩ + Print_h
+MIR  = ⟨T_m, O_m, L_m^out, R_m, V_m⟩ + Print_m
+IIR  = ⟨T_i, O_i, L_i^out, R_i, V_i⟩ + Print_i + Render_cuda + Render_tbb + …
+```
+
+`L_h^out` = HIR → MIR. `L_m^out` = MIR → IIR (per-source dialect, P2 dispatch).
+`L_i^out` is empty today — IIR is the lowest IR; below it is target text via Render.
+
+## 3. Target file layout (post-S3A.0)
+
+```
+src/srdatalog/ir/
+├── core/                                  # framework: Compiler, PassDriver, Lowering, Rewrite, Verifier
+├── hir/                                   # dialect: HIR
+│   ├── types.py                           # T_h, O_h
+│   ├── lowerings.py                       # L_h^out — Lowering instances
+│   ├── rewrites.py                        # R_h
+│   ├── verifier.py                        # V_h
+│   └── print.py                           # Print_h
+├── mir/
+│   ├── types.py                           # T_m, O_m  (already exists)
+│   ├── lowerings.py                       # L_m^out — per-source dispatch
+│   ├── passes.py                          # R_m  (exists, ad-hoc — formalize)
+│   ├── verifier.py                        # V_m
+│   └── print.py                           # Print_m  (exists today as mir/emit.py — RENAME)
+├── dialects/                              # IIR-contributing dialects (own T, O, L^out, R, V)
+│   ├── iir/cf/
+│   ├── relation/sorted_array/
+│   ├── relation/d2l/
+│   └── parallel/data/
+└── codegen/                               # NOT dialects — renderers
+    └── cuda/
+        ├── render/                        # per-IIR-op renderer functions, registry-dispatched
+        │   ├── iir_cf.py
+        │   ├── sorted_array.py
+        │   ├── d2l.py
+        │   └── parallel_data.py
+        ├── strategy.py                    # block size, stream count, scheduling policy
+        ├── orchestrator.py                # MIR → step-body C++
+        ├── complete_runner.py             # MIR + IIR → kernel struct C++
+        ├── main_file.py                   # main.cpp shape
+        ├── plugin.py                      # index plugin registry (per-Codegen instance)
+        └── api.py                         # public entry point
+```
+
+## 4. The renderer-completeness safety contract
+
+The framework enforces that **adding a new op is safe to register** —
+forgetting a renderer fails loudly at `Compiler()` construction, not at
+first emit.
+
+```python
+# src/srdatalog/ir/codegen/cuda/__init__.py
+
+class CudaCodegen:
+    supported_dialects = (
+        iir_cf.DIALECT,
+        sorted_array.DIALECT,
+        d2l.DIALECT,
+        parallel_data.DIALECT,
+    )
+    render_handlers: dict[type[Op], RenderFn] = {}
+
+    @classmethod
+    def verify_completeness(cls):
+        for dialect in cls.supported_dialects:
+            for op_cls in dialect.ops:
+                if op_cls not in cls.render_handlers:
+                    raise CodegenIncompleteError(
+                        f"{cls.__name__} supports {dialect.name} but "
+                        f"has no renderer for {op_cls.__name__}"
+                    )
+```
+
+`Compiler.register_codegen(CudaCodegen)` calls `verify_completeness()`. Mismatch
+= every test that constructs a `Compiler` fails immediately.
+
+Workflow when adding a new op (e.g. `SaSkipList` to `sorted_array`):
+1. Add the dataclass to `dialects/relation/sorted_array/ops.py`.
+2. Register a renderer in `codegen/cuda/render/sorted_array.py`:
+   ```python
+   @register_render(CudaCodegen, SaSkipList)
+   def _render(op: SaSkipList, ctx: RenderCtx) -> str: ...
+   ```
+3. Add a `Lowering` if any upper dialect's L^out should produce it.
+
+Skip step 2 → completeness check raises at Compiler construction → CI red.
+
+## 5. Test surfaces
+
+Each layer has its own correctness gate. Lower layers don't depend on text
+emit going through:
+
+| Layer | Test | Granularity |
+|---|---|---|
+| HIR | byte-equal Print_h s-expr (vs frozen golden) | per pipeline pass |
+| MIR | byte-equal Print_m s-expr (vs frozen golden) | per MIR pass / lowering |
+| IIR | byte-equal Print_i s-expr (vs frozen golden) | per MIR→IIR lowering / IIR rewrite |
+| C++ | byte-equal Codegen.cuda output (vs Nim reference) | per kernel / per runner — *existing* gate |
+| Renderer completeness | `tests/test_codegen_completeness.py` | per (codegen, dialect) pair, in CI |
+
+The Print_i test gate is what makes IIR an inspectable layer rather than
+the fleeting intermediate it is today.
+
+## 6. Pre-flight: pin violations as failing tests
+
+Land these *before* any S3A task. They turn cleanup into red→green so
+"done" has an unambiguous meaning.
+
+### 6.1 `tests/test_ir_no_import_side_effects.py` (new)
+
+Importing a module under `ir/dialects/` or `ir/codegen/` must not mutate
+state in any *other* module. Currently fails: importing `relation.d2l`
+mutates `target.cuda.plugin._PLUGIN_REGISTRY` via the side-effect import
+at [d2l/__init__.py:56](../src/srdatalog/ir/dialects/relation/d2l/__init__.py#L56).
+**S3A.8 turns this green.**
+
+### 6.2 Extension to `tests/test_ir_core_discipline.py`
+
+No module under `ir/dialects/` or `ir/codegen/` defines a top-level
+mutable dict or list. Currently fails on
+[plugin.py:147](../src/srdatalog/ir/dialects/target/cuda/plugin.py#L147).
+**S3A.8 turns this green.**
+
+### 6.3 `tests/test_codegen_completeness.py` (new)
+
+For each registered Codegen, every op in every supported dialect has a
+renderer. Pre-S3A this test cannot exist (codegen registry doesn't exist).
+**S3A.0 + S3A.3 enable it; pinned thereafter.**
+
+## 7. Task plans
+
+### S3A.0 — rename `ir/dialects/target/cuda/` → `ir/codegen/cuda/`
+
+**Goal.** Resolve the category error: codegen is not a dialect. Establish
+the right vocabulary in the codebase before any other Stage 3A work.
+
+**Approach.** `git mv` the directory. Update every import. Optionally keep
+a thin re-export shim at the old path for one release.
+
+**Risk.** Very low. Pure namespace move, no semantics change.
+
+**Test gate.** Full suite green; no behavior change.
+
+**Commit shape.** 1 commit; mostly mechanical.
+
+---
+
+### S3A.1 — add Print_i (IIR s-expression)
+
+**Goal.** Give IIR a canonical text form so MIR→IIR lowerings can be
+tested without involving C++ codegen.
+
+**Files.** New: `dialects/iir/cf/print.py`,
+`dialects/relation/sorted_array/print.py`,
+`dialects/relation/d2l/print.py`,
+`dialects/parallel/data/print.py`.
+
+**Approach.** Mirror [`mir/emit.py`](../src/srdatalog/ir/mir/emit.py)
+(the MIR s-expr printer) — one dispatch function per dialect, called from
+a top-level `print_iir(op)` that dispatches by op's owning dialect.
+
+**Risk.** Low. Pure addition; no existing code changes.
+
+**Test gate.** New `tests/test_iir_print_roundtrip.py` — for each op
+class, construct an instance and assert the s-expr is non-empty + parses
+back. Frozen goldens added as IIR shapes stabilize.
+
+**Commit shape.** 1 commit.
+
+---
+
+### S3A.2 — sorted_array/lowerings returns IIR data, not C++ text
+
+**Goal.** Make IIR exist as inspectable data between lowering and render.
+Today [sorted_array/lowerings.py:353](../src/srdatalog/ir/dialects/relation/sorted_array/lowerings.py#L353)
+calls `target.cuda.emit.emit(op, ctx)` directly — IIR exists for ~one
+stack frame.
+
+**Approach.** Split the lowering into two phases:
+1. Build IIR tree (returns `IirOp` data).
+2. Caller invokes Render on the IIR tree separately.
+
+The caller (currently `complete_runner.py`) becomes:
+```python
+iir_body = sorted_array.lower_pipeline_body(ep)
+cuda_text = codegen.cuda.render(iir_body, ctx)
+```
+
+**Risk.** Medium. Requires identifying every site that consumes "MIR
+pipeline body C++" today and routing through the new two-phase path.
+Mitigation: Print_i (S3A.1) provides an inspection point for the
+intermediate IIR tree.
+
+**Test gate.** Existing C++ byte-equivalence suite still green (no
+semantic change). New `tests/test_mir_to_iir_lowering.py` asserts IIR
+shape via Print_i for representative pipelines.
+
+**Commit shape.** 2 commits: 1 (introduce two-phase API alongside
+existing path) + 1 (migrate callers, delete old path).
+
+---
+
+### S3A.3 — split `codegen/cuda/emit.py` into `codegen/cuda/render/` package
+
+**Goal.** Eliminate the 41-case match
+([emit.py:95](../src/srdatalog/ir/dialects/target/cuda/emit.py#L95)).
+Adding a new dialect should not require editing codegen core code (P1 fix).
+
+**Approach.**
+
+1. Create `codegen/cuda/render/` with one file per IIR-contributing
+   dialect: `iir_cf.py`, `sorted_array.py`, `d2l.py`, `parallel_data.py`.
+2. Move each match arm from `emit.py` into the corresponding file as a
+   handler function.
+3. Each handler self-registers via `@register_render(CudaCodegen, OpClass)`.
+4. The dispatcher in `codegen/cuda/render/__init__.py` becomes
+   `CudaCodegen.render_handlers[type(op)](op, ctx)`.
+5. Delete `emit.py` (or convert to a re-export of the new dispatcher).
+
+**Risk.** Medium-high. Touches the byte-equivalence hot path. Mitigation:
+move handlers in groups (one dialect at a time, one commit per dialect),
+running the byte-equivalence suite between each.
+
+**Test gate.** All 1009 tests still green. New
+`tests/test_codegen_completeness.py` (gate 6.3) green. Smoke test:
+register a dummy `relation.lsm` dialect and verify that adding a renderer
+for its ops in `codegen/cuda/render/` is the only change needed.
+
+**Commit shape.** ~6 commits: 1 (registry infra + dispatcher) + 4 (one
+per dialect's handlers moved) + 1 (delete old emit.py).
+
+---
+
+### S3A.4 — formalize MIR→IIR lowerings as `Lowering` instances
+
+**Goal.** Realize P3 — typed pass dispatch via the framework.
+
+**Files.**
+- [sorted_array/lowerings.py](../src/srdatalog/ir/dialects/relation/sorted_array/lowerings.py) — main MIR→IIR lowerings
+- [d2l/__init__.py](../src/srdatalog/ir/dialects/relation/d2l/__init__.py) — D2L-specific lowerings
+- Per-dialect `L^out` registration on the dialect's `DIALECT` record
+
+**Approach.** For each existing ad-hoc Python lowering function:
+1. Wrap it in a `Lowering` instance with `matches`, `apply`, `name` fields.
+2. Add to the source dialect's `DIALECT.lowerings` list.
+3. Update the `Lowering` dataclass with `consumes: tuple[str, ...]` and
+   `produces: tuple[str, ...]` (the dialect names of input and output ops).
+
+**Risk.** Low-medium. Lowerings exist; this is wrapping + registering.
+
+**Test gate.** Unchanged C++ byte-equivalence. New `tests/test_lowering_registry.py`
+asserts: every documented MIR op has a registered lowering on every relation
+dialect that supports it.
+
+**Commit shape.** 2-3 commits, one per dialect.
+
+---
+
+### S3A.5 — formalize R1–R5 as `Rewrite` instances on `sorted_array.R`
+
+**Goal.** Realize P3 for rewrites. R1–R5 from
+[ir_lowering_semantics.md §11](./ir_lowering_semantics.md#L494) exist in
+code (count-as-product, hint introduction, negation pre-narrow, etc.) but
+not as `Rewrite` instances.
+
+**Approach.** For each R1–R5:
+1. Identify the existing implementation.
+2. Wrap as a `Rewrite` instance with `matches`, `apply`, `name`.
+3. Register on `sorted_array.DIALECT.rewrites`.
+
+**Risk.** Low. Rewrites already work; this is wrapping + registering.
+
+**Test gate.** Unchanged byte-equivalence. New unit tests apply each
+rewrite in isolation and assert the output IIR via Print_i.
+
+**Commit shape.** 1-2 commits.
+
+---
+
+### S3A.6 — `PassDriver.run` dispatches by type
+
+**Goal.** Make the framework actually run, instead of being a no-op stub.
+
+**Files.** [core/passes.py:73-87](../src/srdatalog/ir/core/passes.py#L73-L87).
+
+**Approach.**
+
+1. Replace the no-op loop with: walk the program; for each op, look up
+   matching `Lowering` / `Rewrite` instances in the registered dialects;
+   apply them (rewrites to fixpoint, then lowerings).
+2. Add `consumes` / `produces` topo-ordering for lowerings.
+3. On unmet dependency, raise `PassDependencyError` with the missing
+   dialect name.
+
+**Open design decision** — see §9 below.
+
+**Risk.** Medium. New behavior, but starts from a no-op so nothing regresses.
+Production code keeps using direct calls until S3A.4 / S3A.5 land lowerings
+into the registry.
+
+**Test gate.** New `tests/test_pass_driver_dispatch.py` — register a few
+toy lowerings on a toy dialect; assert the driver dispatches them in
+topo order and raises on unmet deps.
+
+**Commit shape.** 1-2 commits.
+
+---
+
+### S3A.7 — wire `Dialect.verifier` into PassDriver
+
+**Goal.** Enforce D10 — verification at every level.
+
+**Approach.**
+
+1. After each pass run, `PassDriver` invokes `d.verifier(prog)` for every
+   dialect. On `VerificationError`, abort with the pass name attached.
+2. Add a no-op verifier to each existing dialect as scaffolding (real
+   per-dialect verification grows as a follow-up).
+
+**Risk.** Low.
+
+**Test gate.** New `tests/test_pass_driver_verify.py` — register a dialect
+whose verifier always fails; assert `PassDriver.run` aborts cleanly.
+
+**Commit shape.** 1 commit.
+
+---
+
+### S3A.8 — per-`Codegen` plugin registry; explicit `register_*` calls
+
+**Goal.** Kill A6 (module-global mutable state) and A7 (import-time
+side-effect registration).
+
+**Files.**
+- [target/cuda/plugin.py:147-148](../src/srdatalog/ir/dialects/target/cuda/plugin.py#L147-L148) — `_PLUGIN_REGISTRY`, `_DEFAULT_PLUGIN`
+- [d2l/__init__.py:56](../src/srdatalog/ir/dialects/relation/d2l/__init__.py#L56) — side-effect import
+
+**Approach.**
+
+1. Move plugin registry off the module onto a `CudaCodegen` instance
+   (post-S3A.0 location).
+2. Replace `register_index_plugin(plugin)` →
+   `register_index_plugin(codegen, plugin)`.
+3. In `d2l/cuda.py`, replace module-level registration with an explicit
+   `register_d2l_cuda_plugin(codegen)` function.
+4. Delete the side-effect import at `d2l/__init__.py:56`.
+5. Find every code path that needs D2L registered; add the explicit call
+   at the right level (likely `codegen/cuda/api.py`).
+
+**Risk.** Medium. Threading the codegen instance is mechanical but touches
+many call sites. Risk of missing a register call → silent fallback to
+default plugin → wrong output. Mitigation: temporarily log the
+"fell back to default" branch; run full suite; ensure no test trips it.
+
+**Test gate.** Pre-flight tests 6.1 + 6.2 turn green. Existing
+byte-equivalence still passes.
+
+**Commit shape.** 2 commits: 1 (introduce per-codegen registry, keep
+module-level as deprecated shim) + 1 (delete shim, fail discipline tests
+on remaining usage).
+
+---
+
+### S3A.9 — independent cleanups
+
+Two small items unrelated to the framework realization but worth bundling:
+
+**S3A.9a — stop double-running HIR.**
+[pipeline.py:87-88](../src/srdatalog/ir/pipeline.py#L87-L88) calls
+`compile_to_hir` then `compile_to_mir`, which re-runs `compile_to_hir`.
+Change `compile_to_mir(program, *, hir=None, ...)` to accept an existing
+HIR. **Commit shape:** 1 commit.
+
+**S3A.9b — relocate `block_group.py` emit functions.** The dialect file
+contains target-specific emit functions
+([block_group.py:107+](../src/srdatalog/ir/dialects/parallel/data/block_group.py#L107))
+that pull in cuda context helpers. Move emit functions out into
+`codegen/cuda/render/parallel_data.py` (post-S3A.0). The dialect file
+keeps only its op definitions. **Commit shape:** 1 commit.
+
+## 8. Suggested execution order
+
+Smallest mechanical change first; risky / high-blast-radius last.
+
+| # | Task | Why this slot |
+|---|---|---|
+| 0 | Pre-flight tests (6.1, 6.2) | Define "done" for S3A.8 |
+| 1 | **S3A.0** | Foundational rename; resolves vocabulary; everything below assumes it |
+| 2 | **S3A.9a** | Tiny mechanical warm-up |
+| 3 | **S3A.1** | Print_i unblocks testing all later tasks |
+| 4 | **S3A.6** | PassDriver becomes real (no-op → real) — needed for later tasks to register against |
+| 5 | **S3A.4** | Lowerings as data; uses S3A.6 |
+| 6 | **S3A.5** | Rewrites as data; uses S3A.6 |
+| 7 | **S3A.2** | IIR-as-data refactor; uses S3A.1 + S3A.4 |
+| 8 | **S3A.3** | Renderer registry — biggest blast radius; do after lowering is data |
+| 9 | **S3A.9b** | block_group cleanup; piggybacks on S3A.3's renderer file layout |
+| 10 | **S3A.7** | Verifier wiring — last because verifiers grow over time |
+| 11 | **S3A.8** | Per-Codegen registry + explicit register; piggybacks on S3A.0 layout |
+
+Each task ships as its own PR.
+
+## 9. Open design decision (resolve before S3A.6)
+
+**Question.** When a pass `P` declares `consumes=("dialect_X",)` but
+`dialect_X` is not registered with the `Compiler`, what should
+`PassDriver` do?
+
+| Behavior | Pros | Cons |
+|---|---|---|
+| **Abort with `PassDependencyError`** | Loud failure; explicit | Pipelines must spell out every dialect they use |
+| **Auto-skip the pass with a warning** | Convenient; pipelines work with subsets | Silent under-application of optimization; bug-bait |
+| **Auto-skip silently** | Matches LLVM PassManager defaults | Worst of both — neither loud nor explicit |
+
+**Recommendation: Abort.** Matches the framework's existing posture (loud
+failure over silent fallback — see [`design_principles.md`](./design_principles.md)
+A4 / A8). A pipeline opting out of a dialect's passes does so by not
+registering those passes, not by not registering the dialect.
+
+**Decide explicitly before writing S3A.6 code.**
+
+## 10. What this plan deliberately does NOT include
+
+- **A new IR layer (e.g. LIR for explicit scheduling).** Considered and
+  rejected: would not help P1/P3 realization. Defer until a concrete
+  forcing function appears (e.g. multi-target, scheduling rewrites).
+- **Target dialect ops** (Model A from earlier discussion). GPU codegen
+  stays a "dumb printer" — no ops, no lowerings. If CUDA-specific
+  transformations as data become valuable later, introduce
+  `dialects/target/cuda/` then; it's a distinct concern from `codegen/cuda/`.
+- **`iir.cf.GridStrideLoop` / `iir.cf.ParallelFor` cleanup.** These are
+  CUDA-flavored ops in the cross-target IIR layer — a known smell, but
+  fixing them doesn't help P1/P3. Defer (likely until a second codegen
+  exists, then choose: move to target dialect ops, or parameterize with
+  a strategy field).
+- **Stage 3B** — HIR/MIR types onto `Op`/`Type` subclasses with
+  `@dataclass(frozen=True, slots=True)` per D1–D4. Planning only until
+  Stage 3A lands; revisited after.
+- **CPU/WASM target.** Strong forcing function for the design but out
+  of scope for the cleanup work.
+- **`complete_runner.py` templating.** Orthogonal — separate radar item.


### PR DESCRIPTION
## Summary

- Adds [`docs/stage3a_execution_plan.md`](docs/stage3a_execution_plan.md) as the binding plan for the IR-framework-realization stage (S3A.0–S3A.9).
- Reshapes [`docs/milestones.md`](docs/milestones.md) Stage 3 section around realizing P1 / P2 / P3 from `ir_lowering_semantics.md` §4, with the binding vocabulary (Lowering / Render / Print; Dialect / Codegen) inlined.
- Foundational task declared as **S3A.0**: `ir/dialects/target/cuda/` → `ir/codegen/cuda/`. Codegen has no ops, no lowerings, no rewrites — calling it a dialect was a category error.

## Three pieces of confusion the plan resolves

1. **Lowering / Render / Print** are three distinct operations (data→data, data→target text, data→canonical s-expr). The plan distinguishes them throughout; current code conflates them.

2. **Dialect ≠ Codegen.** Dialects own IR data ⟨T, O, L^out, R, V⟩ + Print. Codegens own a Render registry + target config — no ops, no lowerings, no rewrites. GPU codegen is a "dumb printer" by design.

3. **The actual problem is unrealized framework.** `ir_lowering_semantics.md` §4 documents P1 / P2 / P3 but the codebase does not enforce them: `PassDriver.run` is a no-op stub, lowerings exist as ad-hoc Python (not `Lowering` instances), adding a new dialect requires editing the 41-case match in `target/cuda/emit.py`. Stage 3A closes these gaps on the existing dialects.

## What's in the execution plan

- **§1** Vocabulary — Lowering / Render / Print as three distinct operations
- **§2** IR topology with separate lowering vs render edges
- **§3** Target file layout post-S3A.0
- **§4** Renderer-completeness safety contract (`verify_completeness()` runs at `Compiler()` construction)
- **§5** Test surfaces (byte-equal s-expr per IR + byte-equal target text + completeness CI gate)
- **§6** Pre-flight failing tests
- **§7** Per-task plans for S3A.0 through S3A.9 (goal / approach / risk / test gate / commit shape)
- **§8** Suggested execution order (12 slots; smallest first; S3A.3 last)
- **§9** Open design decision for S3A.6 (`PassDriver` dep failure UX — recommendation: abort with `PassDependencyError`)
- **§10** Explicit deferrals: LIR introduction, target-dialect ops, iir.cf `GridStrideLoop` / `ParallelFor` impurity cleanup, Stage 3B, CPU/WASM, `complete_runner.py` templating

## Worth a review thread before code starts

- **§4 safety contract** — does `verify_completeness()` at `Compiler()` construction match the failure-mode posture you want?
- **§9 open design decision** — recommendation is "abort with `PassDependencyError`" on unmet `consumes`. Other options listed.
- **§10 deferrals** — particularly the iir.cf `GridStrideLoop` / `ParallelFor` impurity. Defer until 2nd target lands, or fold into Stage 3A?

## Test plan

- [x] Docs-only commit; no source files touched
- [x] 1009 / 5 skip baseline preserved
- [x] All relative markdown links verified

🤖 Generated with [Claude Code](https://claude.com/claude-code)