### PR TITLE
S3A.9a: stop double-running compile_to_hir per compile_program

### DIFF
--- a/src/srdatalog/ir/hir/__init__.py
+++ b/src/srdatalog/ir/hir/__init__.py
@@ -81,6 +81,8 @@ def compile_to_hir(program: Program, verbose: bool = False) -> HirProgram:
 
 def compile_to_mir(
   program: Program,
+  *,
+  hir: HirProgram | None = None,
   verbose: bool = False,
   apply_mir_passes: bool = True,
 ):
@@ -89,11 +91,17 @@ def compile_to_mir(
   By default runs the ported MIR optimization passes (pre_reconstruct_rebuild,
   clause_order_reorder, prefix_source_reorder). Pass `apply_mir_passes=False`
   to stop at the raw output of `lower_hir_to_mir_steps`.
+
+  Pass `hir=...` to reuse an already-computed HirProgram. The default
+  (`hir=None`) runs `compile_to_hir(program, verbose=verbose)` internally.
+  Callers that already have HIR (e.g. `ir.pipeline.compile_program`)
+  should pass it to avoid the redundant pass.
   '''
   import srdatalog.ir.mir.types as mir
   from srdatalog.ir.hir.lower import lower_hir_to_mir_steps
 
-  hir = compile_to_hir(program, verbose=verbose)
+  if hir is None:
+    hir = compile_to_hir(program, verbose=verbose)
   steps = lower_hir_to_mir_steps(hir)
   if apply_mir_passes:
     from srdatalog.ir.mir.passes import apply_all_mir_passes

--- a/src/srdatalog/ir/pipeline.py
+++ b/src/srdatalog/ir/pipeline.py
@@ -85,7 +85,7 @@ def compile_program(program: Program, project_name: str) -> CompileResult:
   (renders it in a webview) branch from.
   '''
   hir = compile_to_hir(program)
-  mir = compile_to_mir(program)
+  mir = compile_to_mir(program, hir=hir)
 
   ext_db = f"{project_name}_DB"
   device_db = f"{ext_db}_DeviceDB"

--- a/tests/test_pipeline_no_double_hir.py
+++ b/tests/test_pipeline_no_double_hir.py
@@ -1,0 +1,92 @@
+'''S3A.9a — pin "compile_to_hir runs at most once per compile_program".
+
+Pre-S3A.9a, ir/pipeline.py:compile_program called compile_to_hir(program)
+explicitly AND then called compile_to_mir(program), which internally
+re-ran compile_to_hir(program). Two HIR passes per compile.
+
+Post-fix, compile_to_mir accepts an optional hir= kwarg; pipeline.py
+threads its already-computed HIR through, so no duplicate run.
+
+This test counts compile_to_mir's INTERNAL invocations of compile_to_hir
+(via the srdatalog.ir.hir module namespace, where compile_to_mir resolves
+the name at runtime). pipeline.py's explicit call uses its own bound name
+and is invisible to this counter — exactly what we want, since we are
+testing the redundant-internal-call bug.
+
+  Pre-fix: counter == 1 (the redundant internal call).
+  Post-fix: counter == 0 (compile_to_mir reuses the passed-in hir).
+'''
+
+from __future__ import annotations
+
+from srdatalog.dsl import Program, Relation, Var
+
+
+def _build_tiny_program() -> Program:
+  X, Y, Z = Var("x"), Var("y"), Var("z")
+  arc = Relation("ArcInput", 2)
+  edge = Relation("Edge", 2)
+  path = Relation("Path", 2)
+  return Program(
+    rules=[
+      (edge(X, Y) <= arc(X, Y)).named("EdgeLoad"),
+      (path(X, Y) <= edge(X, Y)).named("TCBase"),
+      (path(X, Z) <= path(X, Y) & edge(Y, Z)).named("TCRec"),
+    ],
+  )
+
+
+def test_compile_program_does_not_double_run_compile_to_hir(monkeypatch):
+  from srdatalog.ir import hir as hir_mod
+  from srdatalog.ir import pipeline as pipeline_mod
+
+  original = hir_mod.compile_to_hir
+  call_count = 0
+
+  def counted(*args, **kwargs):
+    nonlocal call_count
+    call_count += 1
+    return original(*args, **kwargs)
+
+  monkeypatch.setattr(hir_mod, "compile_to_hir", counted)
+
+  pipeline_mod.compile_program(_build_tiny_program(), "TestProj")
+
+  assert call_count == 0, (
+    f"compile_to_mir made {call_count} internal compile_to_hir call(s); "
+    "expected 0 — pipeline.compile_program should thread its HIR through."
+  )
+
+
+def test_compile_to_mir_still_runs_hir_when_no_hir_passed():
+  '''Sanity: when no hir is passed, compile_to_mir must still call
+  compile_to_hir internally (this is the back-compat path for callers
+  that don't have HIR yet).'''
+  from srdatalog.ir.hir import compile_to_mir
+
+  prog = _build_tiny_program()
+  # Just exercising the path; if compile_to_hir wasn't called, the
+  # downstream lower_hir_to_mir_steps would explode on a None HIR.
+  mir = compile_to_mir(prog)
+  assert mir is not None
+  assert len(mir.steps) > 0
+
+
+def test_compile_to_mir_reuses_provided_hir():
+  '''Sanity: when hir IS passed, compile_to_mir uses it (does not
+  rerun compile_to_hir). Asserted by passing a HIR computed once
+  and checking the output is structurally equivalent to a fresh
+  end-to-end run.'''
+  from srdatalog.ir.hir import compile_to_hir, compile_to_mir
+
+  prog = _build_tiny_program()
+  hir = compile_to_hir(prog)
+  mir_via_passed = compile_to_mir(prog, hir=hir)
+  mir_via_internal = compile_to_mir(prog)
+
+  # Same number of steps; same recursive flags.
+  assert len(mir_via_passed.steps) == len(mir_via_internal.steps)
+  for (n1, r1), (n2, r2) in zip(mir_via_passed.steps, mir_via_internal.steps):
+    assert r1 == r2
+    # Structural equality on MIR — they're frozen dataclasses.
+    assert type(n1) is type(n2)


### PR DESCRIPTION
## Summary

Per [`docs/stage3a_execution_plan.md` §7 task S3A.9a](docs/stage3a_execution_plan.md). Small, mechanical, isolated — Stage 3A's warm-up.

**Pre-fix flow** in [`ir/pipeline.py:compile_program`](src/srdatalog/ir/pipeline.py#L80-L88):

```python
hir = compile_to_hir(program)        # explicit pass
mir = compile_to_mir(program)        # internally re-runs compile_to_hir(program)
```

Two HIR passes per `compile_program` call, with identical inputs + outputs. The second pass was redundant work; the bug was invisible because outputs matched.

## Fix

`compile_to_mir` gains a keyword-only `hir=` parameter. When provided, the internal `compile_to_hir` call is skipped. `pipeline.py` threads its already-computed HIR through.

```python
def compile_to_mir(
  program: Program,
  *,
  hir: HirProgram | None = None,    # NEW
  verbose: bool = False,
  apply_mir_passes: bool = True,
):
    if hir is None:
        hir = compile_to_hir(program, verbose=verbose)
    ...
```

`verbose` and `apply_mir_passes` are now keyword-only. Verified safe — every existing caller in `src/` and `tests/` passes only `program` positionally (grep confirmed).

## Test that pins the contract

New [`tests/test_pipeline_no_double_hir.py`](tests/test_pipeline_no_double_hir.py) — 3 tests:

1. **`test_compile_program_does_not_double_run_compile_to_hir`** — monkeypatches `srdatalog.ir.hir.compile_to_hir`; runs `compile_program`; asserts the patched function is called **0** times. Pre-fix this would assert `1 == 0` and fail. The test exploits the asymmetry that `pipeline.py` has its own bound name (`from … import compile_to_hir`) while `compile_to_mir`'s internal call resolves through the module namespace at runtime — so patching the module attr only catches the redundant internal call, exactly what we're testing.

2. **`test_compile_to_mir_still_runs_hir_when_no_hir_passed`** — back-compat sanity for callers that don't have a HIR yet.

3. **`test_compile_to_mir_reuses_provided_hir`** — structural sanity that passing `hir=` produces the same MIR shape as the internal-call path.

## Test plan

- [x] `python -m pytest tests/test_pipeline_no_double_hir.py -v` — 3 passed
- [x] `python -m pytest tests/` — **1012 passed, 5 skipped** (1009 baseline + 3 new)
- [x] `python -m ruff check src tests` — clean
- [x] No conflict with [PR #12 (S3A.0 codegen rename)](https://github.com/harp-lab/srdatalog-python/pull/12) — this PR touches only `ir/hir/__init__.py`, `ir/pipeline.py`, and the new test; no overlap with the renamed paths.

## Stage 3A progress

- ✅ S3A.0 — codegen rename ([PR #12](https://github.com/harp-lab/srdatalog-python/pull/12))
- ✅ S3A.9a — no double `compile_to_hir` (this PR)
- ⬜ S3A.1 — Print_i for IIR (next)
- ⬜ S3A.6 — `PassDriver.run` real dispatch
- ⬜ S3A.4 / S3A.5 / S3A.2 / S3A.3 / S3A.9b / S3A.7 / S3A.8

🤖 Generated with [Claude Code](https://claude.com/claude-code)