### PR TITLE
chore: bump version 0.1.0 → 0.2.0.dev0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "srdatalog"
-version = "0.1.0"
+version = "0.2.0.dev0"
 description = "Super-Reconfigurable Datalog — Python frontend with JIT C++/CUDA codegen"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/src/srdatalog/__init__.py
+++ b/src/srdatalog/__init__.py
@@ -69,7 +69,7 @@ from srdatalog.ir.dialects.target.cuda.orchestrator import gen_step_body
 # Compilation pipeline
 from srdatalog.ir.hir import compile_to_hir, compile_to_mir
 
-__version__ = "0.1.0"
+__version__ = "0.2.0.dev0"
 
 __all__ = [
   # DSL


### PR DESCRIPTION
## Summary

Tags [`ad3e2f26`](https://github.com/harp-lab/srdatalog-python/commit/ad3e2f26c2f00820bc52c51933f3e22232d54ccf) as **`v0.1.0`** (the dialect-based JIT codegen baseline, before the Stage 3A IR-framework-consolidation work begins).

Bumps the in-tree version to **`0.2.0.dev0`** to make the post-0.1.0 development state visible to anyone reading the code or installing from source.

## Why 0.2.0 (not 0.1.1)

Stage 3A is in progress (planning + initial PRs already landing — see [#11](https://github.com/harp-lab/srdatalog-python/pull/11), [#12](https://github.com/harp-lab/srdatalog-python/pull/12), [#13](https://github.com/harp-lab/srdatalog-python/pull/13)). The forthcoming changes are **not API-compatible** with 0.1.0:

- Codegen rename: `srdatalog.ir.dialects.target.cuda` → `srdatalog.ir.codegen.cuda` (external imports break)
- `compile_to_mir` signature change: `verbose` and `apply_mir_passes` become keyword-only
- Framework realization (P1/P2/P3) introduces typed `Lowering` / `Rewrite` instances and live `PassDriver` dispatch — affects anyone who introspects the dialect catalog

Per PEP 440, `0.2.0.dev0` marks the in-progress state of the next minor release.

## Files changed

- [`pyproject.toml`](pyproject.toml) — line 7
- [`src/srdatalog/__init__.py`](src/srdatalog/__init__.py) — line 72

## Tag

Already pushed: `v0.1.0` (annotated, on commit `ad3e2f26` "better type check"). Visible at [github.com/harp-lab/srdatalog-python/releases/tag/v0.1.0](https://github.com/harp-lab/srdatalog-python/releases/tag/v0.1.0).

## Test plan

- [x] `python -c "import srdatalog; print(srdatalog.__version__)"` → `0.2.0.dev0`
- [x] `grep "^version" pyproject.toml` → `version = "0.2.0.dev0"`
- [x] `python -m pytest tests/` — 1009 passed, 5 skipped (no behavior change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)