### PR TITLE
Bundle B: framework realization (structural) + Stage 4 plan

### DIFF
--- a/docs/milestones.md
+++ b/docs/milestones.md
@@ -25,8 +25,8 @@ reference, modulo `_cpp_norm` whitespace/comment normalization.
 | Legacy elimination | ✅ all `codegen/jit/{pipeline,instructions,root,scan_negation,kernel_functor,file}.py` deleted | — |
 | Layout reorg | ✅ Phase A (`codegen/jit/` → `ir/dialects/target/cuda/`), Phase B (`ir/` namespace) | ⬜ Phase C (R1–R6 below) |
 | Docs / test rename sync | ✅ README + 10 `test_jit_*.py` → `test_cuda_*.py` | — |
-| **Stage 3 (IR framework consolidation)** | ✅ HIR/MIR dialect catalog ([PR #10](https://github.com/harp-lab/srdatalog-python/pull/10), opens Stage 3B) | ⬜ S3A.0–S3A.9 (P1/P2/P3 realization, codegen rename, renderer registry); S3B planning only |
-| Open work | — | Stage 3A (next — see [`stage3a_execution_plan.md`](./stage3a_execution_plan.md)), WS full runner, CPU/WASM target, HIR/MIR full Op-subclass migration (Stage 3B), `complete_runner.py` templating |
+| **Stage 3 (IR framework consolidation)** | ✅ structural realization (S3A.0–S3A.4 entry-only, S3A.6, S3A.7, S3A.9 — see Stage 3A index below) | ⬜ Bundle C: A6/A7 cleanup (S3A.8); ⬜ Stage 4: IIR semantic vocabulary (S3A.5 deferred there) |
+| Open work | — | Bundle C (A6/A7 cleanup), Stage 4 (semantic ops — replace RawString with structured IIR), WS full runner, CPU/WASM target, HIR/MIR full Op-subclass migration (Stage 3B), `complete_runner.py` templating |
 
 **Test gates currently passing (after Refactor PR R1–R9):**
 - 272/272 runner byte-equivalence (`tests/test_runner_byte_equivalence.py`) — 2 skipped (WS runner only)
@@ -149,18 +149,18 @@ Full execution plan with per-task scope, approach, risk, and test gate:
 see [`stage3a_execution_plan.md`](./stage3a_execution_plan.md). The table
 below is the index.
 
-| ID | Task | Why |
-|---|---|---|
-| **S3A.0** | Rename `ir/dialects/target/cuda/` → `ir/codegen/cuda/` | Resolve the category error: codegen is not a dialect. Foundational; everything below assumes the right vocabulary. |
-| **S3A.1** | Add Print_i (IIR s-expression printer) per dialect | Give IIR an inspectable text form; enables byte-equal s-expr testing of MIR→IIR lowerings. |
-| **S3A.2** | `sorted_array/lowerings.py` returns IIR data, not C++ text | Make IIR exist as inspectable data between lowering and render — separates the conflated steps. |
-| **S3A.3** | Split `codegen/cuda/emit.py` (41-case match) into `codegen/cuda/render/` package, registry-dispatched | **P1 fix.** Adding a dialect no longer requires editing codegen core. |
-| **S3A.4** | Formalize MIR→IIR lowerings as `Lowering` instances on each relation dialect's $L^{\text{out}}$ | **P3 realization.** |
-| **S3A.5** | Formalize R1–R5 (sorted_array §11 rewrites) as `Rewrite` instances on `sorted_array.R` | **P3 realization.** |
-| **S3A.6** | `PassDriver.run` dispatches lowerings/rewrites by type instead of being a no-op stub | The framework actually runs. |
-| **S3A.7** | Wire `Dialect.verifier` into PassDriver at phase boundaries | **D10.** |
-| **S3A.8** | Per-`Codegen` plugin registry; explicit `register_*` calls (no side effects) | **A6 + A7.** |
-| **S3A.9** | (Cleanup) no double `compile_to_hir`; relocate `block_group.py` emit functions into `codegen/cuda/render/parallel_data.py` | Independent small fixes. |
+| ID | Task | Status | Why |
+|---|---|---|---|
+| **S3A.0** | Rename `ir/dialects/target/cuda/` → `ir/codegen/cuda/` | ✅ PR #12 | Resolve the category error: codegen is not a dialect. |
+| **S3A.1** | Add Print_i (IIR s-expression printer) per dialect | ✅ PR #15 | Give IIR an inspectable text form. |
+| **S3A.2** | `sorted_array/lowerings.py` returns IIR data, not C++ text | ✅ PR #16 (Bundle A) | Lowering ↔ render separated; IIR exists as data. |
+| **S3A.3** | Split `codegen/cuda/emit.py` (41-case match) into `codegen/cuda/render/` package | ✅ PR #16 (Bundle A) | **P1 fix.** Renderer dispatched via `@register_render` registry. |
+| **S3A.4** | Register MIR→IIR entry as `@lowering` on each relation dialect | ✅ Bundle B (entry-point only) | **P3 realization (structural).** Internal helpers stay; per-helper formalization needs Stage 4. |
+| **S3A.5** | Formalize R1–R5 (sorted_array §11 rewrites) as `Rewrite` instances | ⬜ deferred to Stage 4 | The R1-R5 are entangled with `RawString` construction in lowerings.py. Cleanly extracting them needs the new structured ops Stage 4 introduces. |
+| **S3A.6** | `PassDriver` dependency validation + decorator infra | ✅ Bundle B | `@lowering`/`@rewrite`/`@verifier` decorators + `validate_dependencies()` raises `PassDependencyError` on unmet `consumes`. Op-level dispatch deferred (no production consumer yet). |
+| **S3A.7** | Wire `Dialect.verifier` into PassDriver | ✅ Bundle B | All 6 dialects ship a no-op verifier; `PassDriver.verify_all` walks them. Real per-dialect invariants land incrementally. |
+| **S3A.8** | Per-`Codegen` plugin registry; explicit `register_*` calls (no side effects) | ⬜ Bundle C | **A6 + A7.** |
+| **S3A.9** | (Cleanup) no double `compile_to_hir`; relocate `block_group.py` emit | ✅ PR #13 + Bundle A | |
 
 **S3A acceptance gate:**
 
@@ -193,11 +193,69 @@ own frozen-dataclass IRs with typed adapters at the framework boundary.
 | **S3B.5** | Lift HIR passes (`stratify`, `split`, `semi_naive`, `plan`, `index`, `rule_rewrite`) onto `core/passes.py`. | unifies pass infra |
 | **S3B.6** | Replace the hardcoded sequence in [pipeline.py:80-88](../src/srdatalog/ir/pipeline.py#L80-L88) with `compiler.run(passes=[...])`, allowing external code to reorder/insert/skip passes. | (composability) |
 
+**Honest scope note (added after Bundle B planning):** Stage 3A's
+"framework realization" is **structural** — the registry holds
+typed `Lowering`/`Rewrite` instances with declared dependencies, and
+the `@register_render` registry replaces the 41-case match. But for
+sorted_array's MIR→IIR lowering, the IIR ops it produces include
+~46 `RawString(text="<C++>")` escape hatches; the codegen's
+"renderer" for `RawString` is a passthrough (`return op.text`).
+That means most of the codegen's per-op dispatch is dispatching to
+string-passthrough functions — the abstraction is real but
+mostly empty. **Adding a second target today (CPU/WASM) would
+render every `RawString` as the same C++ text — there's no semantic
+information for it to translate differently.**
+
+This is tracked as Stage 4 below. Stage 3A is the structural
+prerequisite; Stage 4 is the semantic substance.
+
 **S3B open question:** does the unified framework cleanly express HIR's
 program-level operations (stratification, semi-naive variant generation),
 which are not per-op rewrites? If not, HIR may need to stay outside the
 dialect framework with a typed adapter at the boundary, and 3B narrows to
 just MIR.
+
+---
+
+## Stage 4 — IIR semantic vocabulary (planning)
+
+**Goal:** make "IR goes to target" mean something. Today the renderer
+registry exists (S3A.3) but its job is mostly text passthrough — the
+46 `RawString(text="<C++>")` sites in `sorted_array/lowerings.py`
+embed concrete CUDA expressions inside IIR ops, so the codegen has
+no semantic information to translate. Stage 4 replaces RawString with
+structured IIR ops so the codegen does real per-target translation
+rather than string concatenation.
+
+**Why this isn't in Stage 3A:** Stage 3A is about the *structural
+plumbing* (decorators, registries, dispatch, layering). Stage 4 is
+about the *semantic content* (what ops the IIR vocabulary needs to
+fully describe a kernel body without text escape hatches). They're
+genuinely separate concerns and Stage 4 is bigger.
+
+**Why this matters:** until Stage 4 lands, adding a second target
+(target.cpp_tbb, target.cpp_omp, target.cpu) is mostly copy-paste
+of the codegen — every RawString site renders the same C++ text
+regardless of target.
+
+### Stage 4 task index (planning)
+
+| ID | Task | Why |
+|---|---|---|
+| **S4.0** | Inventory the 46 `RawString` sites in `sorted_array/lowerings.py`. Categorize into: bare identifier (~10), arithmetic expression (~15), array index (~5), member access (~6), compound statement (~10). | Defines the new ops that need to exist. |
+| **S4.1** | Bare identifier sites → `VarRef` (already exists). Trivial replacement; ~10 sites. | Easy first step; reduces RawString count from 46 to 36. |
+| **S4.2** | Define arithmetic expression ops in a new `iir.expr` (or extend `iir.cf`) sub-dialect. Candidates: `BinOp(op, lhs, rhs)`, `UnaryOp(op, expr)`, or per-operator ops (`Add`, `Mul`, `Div`, `Mod`). | Open design decision: generic vs per-operator. Generic is fewer ops; per-operator gives sharper render dispatch. |
+| **S4.3** | Define `IndexExpr(arr, idx)` op + renderer. Replace ~5 RawString sites that currently embed `arr[i]` text. | |
+| **S4.4** | Define `MemberAccess(obj, member)` op + renderer. Replace ~6 RawString sites that embed `obj.member` text. | |
+| **S4.5** | Define `Ternary(cond, then_, else_)` op + renderer. Some compound statements decompose to ternaries. | |
+| **S4.6** | Tackle the ~10 gnarly compound RawString sites individually. Some may want their own structured ops; others may decompose into combinations of S4.2-S4.5 ops. | Hardest tier; do last. |
+| **S4.7** | Discipline test pinning RawString count at 0 (or a documented small N for inherently-target-specific intrinsics that don't have a structured form yet). New RawString uses caught in CI. | Caps regression. |
+| **S4.8** | Now-tractable: formalize R1–R5 from `ir_lowering_semantics.md` §11 as `Rewrite` instances on `sorted_array.R` (S3A.5 from the original Stage 3A scope, deferred here). | The rewrites operate on structured ops, not on text-fragments-wrapped-in-IR. |
+| **S4.9** | Once a real consumer exists (Stage 4's structured ops give one), implement op-level dispatch in `PassDriver.run` using the `core/strategy.py` combinators. | Op-level dispatch is YAGNI without Stage 4's semantic ops. |
+
+**Forcing function:** committing to add a second target (CPU/WASM)
+would push Stage 4 forward — without it, the second target's
+renderer is a copy of CUDA's.
 
 ---
 

--- a/src/srdatalog/ir/core/passes.py
+++ b/src/srdatalog/ir/core/passes.py
@@ -1,19 +1,47 @@
-'''Pass kinds and driver.
+'''Pass kinds, registration decorators, and driver.
 
 A pass is a transformation on the IR. Two flavors:
 
   Lowering — matches an op of one dialect, produces ops of another
              (or of a target dialect). Each Lowering carries the op
              class it matches, an `apply` callable that performs the
-             transformation, and a name for diagnostics.
+             transformation, declared `consumes` / `produces` dialect
+             names for dependency validation, and a name for diagnostics.
 
   Rewrite  — matches an op, produces ops of the *same* dialect.
              Used for internal optimizations like the IIR-sorted-array
              count-as-product or hint-narrowing rules.
 
-The PassDriver runs registered passes against a program tree. Stage 1
-implementation is a minimal shell that proves the registry is
-consulted; real fixpoint logic lands when the first dialect ships.
+Per the project memory note (`feedback_decorator_registries.md`),
+registration uses Triton-style decorators rather than imperative
+`register_X(OpClass, fn)` calls or class-based dispatch:
+
+    from srdatalog.ir.core import lowering, rewrite, verifier
+    from srdatalog.ir.dialects.relation.sorted_array import DIALECT
+
+    @lowering(DIALECT, mir.ExecutePipeline,
+              consumes=('mir',), produces=('iir.cf', 'relation.sorted_array'))
+    def _lower_execute_pipeline(ep, ctx):
+        ...
+
+    @rewrite(DIALECT, SaPrefCoop)
+    def _hint_introduction(op, ctx):
+        ...
+
+    @verifier(DIALECT)
+    def _verify_sorted_array(prog):
+        return []   # list of VerificationError
+
+The decorators mutate `dialect.lowerings` / `dialect.rewrites` /
+`dialect.verifier` in place. Decoration is the only registration
+path — there is no imperative API exposed.
+
+The `PassDriver` walks `compiler.dialects` to validate dependencies
+(every Lowering's `consumes` must be in the registered dialect set;
+otherwise raise `PassDependencyError`). Actual op-level dispatch is
+left to callers for now (production code calls lowering functions
+directly); the registry exists so external consumers can introspect
+"who lowers what" and so future stages can add a tree-walking dispatcher.
 
 See docs/ir_lowering_semantics.md, section 21.
 '''
@@ -21,10 +49,10 @@ See docs/ir_lowering_semantics.md, section 21.
 from __future__ import annotations
 
 from collections.abc import Callable
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from typing import Any
 
-from srdatalog.ir.core.dialect import Compiler
+from srdatalog.ir.core.dialect import Compiler, Dialect
 
 
 @dataclass
@@ -32,15 +60,25 @@ class Lowering:
   '''A lowering rule from one dialect to another.
 
   Fields:
-    matches — the Op subclass this rule matches (e.g. MirColumnJoin).
-    apply   — callable taking (op, context) and returning a list of
-              replacement ops in the target dialect.
-    name    — short identifier for diagnostics and pass tracing.
+    matches  — the Op subclass this rule matches (e.g. MirColumnJoin).
+    apply    — callable taking (op, context) and returning the
+               replacement IR (single op or list of ops; type depends
+               on the target dialect's contract).
+    name     — short identifier for diagnostics and pass tracing.
+    consumes — dialect names whose ops this lowering reads. Used by
+               PassDriver to validate that every required dialect is
+               registered before the lowering runs.
+    produces — dialect names whose ops this lowering emits. Used by
+               PassDriver for topological ordering of multi-pass
+               pipelines (a pass that produces dialect D must run
+               before any pass that consumes D).
   '''
 
   matches: type
-  apply: Callable[[Any, Any], list[Any]]
+  apply: Callable[[Any, Any], Any]
   name: str = ''
+  consumes: tuple[str, ...] = field(default_factory=tuple)
+  produces: tuple[str, ...] = field(default_factory=tuple)
 
 
 @dataclass
@@ -48,20 +86,151 @@ class Rewrite:
   '''A rewrite rule within a single dialect.
 
   Same shape as Lowering, but conventionally produces ops of the same
-  dialect as `matches`. Used for in-dialect optimizations.
+  dialect as `matches`. `consumes` / `produces` typically equal the
+  dialect's own name; PassDriver still uses them for dependency
+  validation if a rewrite reads ops from a sibling dialect.
   '''
 
   matches: type
-  apply: Callable[[Any, Any], list[Any]]
+  apply: Callable[[Any, Any], Any]
   name: str = ''
+  consumes: tuple[str, ...] = field(default_factory=tuple)
+  produces: tuple[str, ...] = field(default_factory=tuple)
+
+
+# -----------------------------------------------------------------------------
+# Decorator-style registration
+# -----------------------------------------------------------------------------
+
+
+def lowering(
+  dialect: Dialect,
+  matches: type,
+  *,
+  consumes: tuple[str, ...] = (),
+  produces: tuple[str, ...] = (),
+  name: str = '',
+) -> Callable[[Callable[[Any, Any], Any]], Callable[[Any, Any], Any]]:
+  '''Decorator: wrap fn as a Lowering and register on dialect.lowerings.
+
+  Usage:
+
+      @lowering(MY_DIALECT, mir.SomeOp,
+                consumes=('mir',),
+                produces=('iir.cf', 'relation.sorted_array'))
+      def _lower_some_op(op, ctx):
+          return ...
+
+  Returns the original function (so other decorators can stack).
+  '''
+
+  def _wrap(fn: Callable[[Any, Any], Any]) -> Callable[[Any, Any], Any]:
+    inst = Lowering(
+      matches=matches,
+      apply=fn,
+      name=name or fn.__name__,
+      consumes=tuple(consumes),
+      produces=tuple(produces),
+    )
+    dialect.lowerings.append(inst)
+    return fn
+
+  return _wrap
+
+
+def rewrite(
+  dialect: Dialect,
+  matches: type,
+  *,
+  consumes: tuple[str, ...] = (),
+  produces: tuple[str, ...] = (),
+  name: str = '',
+) -> Callable[[Callable[[Any, Any], Any]], Callable[[Any, Any], Any]]:
+  '''Decorator: wrap fn as a Rewrite and register on dialect.rewrites.
+
+  Usage:
+
+      @rewrite(MY_DIALECT, SomeOp)
+      def _hint_introduction(op, ctx):
+          return ...
+  '''
+
+  def _wrap(fn: Callable[[Any, Any], Any]) -> Callable[[Any, Any], Any]:
+    inst = Rewrite(
+      matches=matches,
+      apply=fn,
+      name=name or fn.__name__,
+      consumes=tuple(consumes),
+      produces=tuple(produces),
+    )
+    dialect.rewrites.append(inst)
+    return fn
+
+  return _wrap
+
+
+def verifier(dialect: Dialect) -> Callable[[Callable[[Any], Any]], Callable[[Any], Any]]:
+  '''Decorator: register fn as the dialect's verifier.
+
+  Usage:
+
+      @verifier(MY_DIALECT)
+      def _verify(prog):
+          return []   # list of VerificationError, [] = OK
+
+  Raises ValueError if the dialect already has a verifier registered.
+  '''
+
+  def _wrap(fn: Callable[[Any], Any]) -> Callable[[Any], Any]:
+    if dialect.verifier is not None:
+      raise ValueError(f'verifier already registered on {dialect.name!r}')
+    dialect.verifier = fn
+    return fn
+
+  return _wrap
+
+
+# -----------------------------------------------------------------------------
+# Pass dependency error
+# -----------------------------------------------------------------------------
+
+
+class PassDependencyError(Exception):
+  '''A registered pass declared `consumes=(D, ...)` but dialect D is
+  not registered with the Compiler. Raised by PassDriver.run before
+  any pass executes.
+
+  The recommended posture (per docs/stage3a_execution_plan.md §9) is
+  loud failure over silent fallback: a pipeline opting out of a
+  dialect's passes does so by not registering those passes, not by
+  not registering the dialect.
+  '''
+
+  def __init__(self, pass_name: str, missing_dialect: str, in_dialect: str) -> None:
+    self.pass_name = pass_name
+    self.missing_dialect = missing_dialect
+    self.in_dialect = in_dialect
+    super().__init__(
+      f'pass {pass_name!r} in dialect {in_dialect!r} declares '
+      f'consumes={missing_dialect!r}, but that dialect is not registered '
+      f'with the Compiler. Either register the dialect or unregister the pass.'
+    )
+
+
+# -----------------------------------------------------------------------------
+# PassDriver
+# -----------------------------------------------------------------------------
 
 
 class PassDriver:
   '''Runs registered rewrites and lowerings.
 
-  Stage 1 implementation: a minimal shell that walks the registry but
-  doesn't yet apply transformations — the real walker arrives with the
-  first dialect that needs it (Stage 3, IIR-sorted-array).
+  Today the driver does dependency validation (catches "pass P
+  consumes dialect D not enabled") and verifier dispatch. Op-level
+  dispatch (a tree walker that finds the registered Lowering for
+  each op kind and applies it) lands when the first production
+  consumer needs it; until then, callers invoke lowering functions
+  directly and the registry serves as introspection metadata.
 
   The driver does not know about specific dialects. New dialects
   participate by being registered; the driver consults the registry.
@@ -70,18 +239,52 @@ class PassDriver:
   def __init__(self, compiler: Compiler) -> None:
     self._compiler = compiler
 
+  def validate_dependencies(self) -> None:
+    '''Check every registered Lowering / Rewrite's `consumes` against
+    the registered dialect set. Raises PassDependencyError on the
+    first unmet dependency.'''
+    registered = {d.name for d in self._compiler.dialects}
+    for d in self._compiler.dialects:
+      for p in (*d.lowerings, *d.rewrites):
+        for needed in p.consumes:
+          if needed not in registered:
+            raise PassDependencyError(
+              pass_name=p.name,
+              missing_dialect=needed,
+              in_dialect=d.name,
+            )
+
+  def verify_all(self, prog: Any) -> list[Any]:
+    '''Invoke every registered dialect's verifier on `prog` and
+    aggregate the returned VerificationErrors. Returns [] if all
+    verifiers pass.'''
+    errors: list[Any] = []
+    for d in self._compiler.dialects:
+      if d.verifier is not None:
+        errors.extend(d.verifier(prog))
+    return errors
+
   def run(self, prog: Any) -> Any:
     '''Run all registered passes against `prog`. Returns the (possibly
     transformed) program.
 
-    Stage 1: no-op. Returns `prog` unchanged. Validates the registry
-    can be walked without error.
+    Validates pass dependencies first; raises PassDependencyError on
+    unmet consumes. Then runs verifiers and returns prog unchanged
+    (op-level dispatch is caller-driven for now; see class docstring).
     '''
-    for _dialect in self._compiler.dialects:
-      # Stage 1 placeholder. Real loop:
-      #   - run rewrites to fixpoint
-      #   - apply lowerings
-      #   - verify
-      # Lands when dialects ship their pass libraries (Stage 3+).
-      pass
+    self.validate_dependencies()
+    errors = self.verify_all(prog)
+    if errors:
+      raise RuntimeError(f'Verification failed: {errors}')
     return prog
+
+
+__all__ = [
+  'Lowering',
+  'PassDependencyError',
+  'PassDriver',
+  'Rewrite',
+  'lowering',
+  'rewrite',
+  'verifier',
+]

--- a/src/srdatalog/ir/dialects/iir/cf/__init__.py
+++ b/src/srdatalog/ir/dialects/iir/cf/__init__.py
@@ -94,3 +94,17 @@ __all__ = [
   'VarRef',
   'WriteOutput',
 ]
+
+
+# Verifier scaffolding — control-flow invariants (well-formed Block
+# nesting, OuterAnchor inside D2lSegmentLoop scope, etc.) land
+# incrementally as we encode them.
+def _register_passes() -> None:
+  from srdatalog.ir.core.passes import verifier
+
+  @verifier(DIALECT)
+  def _verify(_prog):
+    return []
+
+
+_register_passes()

--- a/src/srdatalog/ir/dialects/parallel/data/__init__.py
+++ b/src/srdatalog/ir/dialects/parallel/data/__init__.py
@@ -4,4 +4,33 @@ Each strategy decides how `ParallelFor` distributes work across
 threads/warps/blocks. A pipeline picks one at lowering time
 based on its workload characteristics (uniform vs skewed,
 fixed-shape vs dynamic).
+
+Currently registered ops:
+  - BgRootCjMulti — block-group root multi-source ColumnJoin
 '''
+
+from __future__ import annotations
+
+from srdatalog.ir.core import Dialect
+from srdatalog.ir.dialects.parallel.data.block_group import BgRootCjMulti
+
+DIALECT = Dialect(
+  name='parallel.data',
+  ops=[BgRootCjMulti],
+)
+
+
+# Verifier scaffolding — block-group / parallel-strategy invariants
+# land incrementally as we encode them.
+def _register_passes() -> None:
+  from srdatalog.ir.core.passes import verifier
+
+  @verifier(DIALECT)
+  def _verify(_prog):
+    return []
+
+
+_register_passes()
+
+
+__all__ = ['DIALECT', 'BgRootCjMulti']

--- a/src/srdatalog/ir/dialects/relation/d2l/__init__.py
+++ b/src/srdatalog/ir/dialects/relation/d2l/__init__.py
@@ -51,12 +51,18 @@ The legacy `plugin_view_count` is the underlying source for
 from __future__ import annotations
 
 from srdatalog.ir.codegen.cuda.envelope import ViewSpec
+from srdatalog.ir.core import Dialect
 
 # Side-effect import: registers D2L's CUDA plugin with
 # `codegen.cuda.plugin` so `plugin_view_count` etc. dispatch correctly
 # for relations declared `index_type="...Device2LevelIndex"`.
 from srdatalog.ir.dialects.relation.d2l import cuda as _cuda
 from srdatalog.ir.dialects.relation.d2l.ops import D2lSegmentLoop
+
+DIALECT = Dialect(
+  name='relation.d2l',
+  ops=[D2lSegmentLoop],
+)
 
 
 def view_count(version: str, index_type: str) -> int:
@@ -83,4 +89,17 @@ def view_counts_for_specs(
   return [view_count(sp.version, rel_index_types.get(sp.rel_name, '')) for sp in view_specs]
 
 
-__all__ = ['D2lSegmentLoop', 'view_count', 'view_counts_for_specs']
+__all__ = ['DIALECT', 'D2lSegmentLoop', 'view_count', 'view_counts_for_specs']
+
+
+# Verifier scaffolding — D2L invariants (segment_depth coherence, etc.)
+# land incrementally as we encode them.
+def _register_passes() -> None:
+  from srdatalog.ir.core.passes import verifier
+
+  @verifier(DIALECT)
+  def _verify(_prog):
+    return []
+
+
+_register_passes()

--- a/src/srdatalog/ir/dialects/relation/sorted_array/__init__.py
+++ b/src/srdatalog/ir/dialects/relation/sorted_array/__init__.py
@@ -69,3 +69,37 @@ __all__ = [
   'SaValid',
   'SaView',
 ]
+
+
+# ---------------------------------------------------------------------------
+# Pass registration (S3A.4)
+# ---------------------------------------------------------------------------
+#
+# Wires the MIR→IIR entry point (`lower_scan_pipeline`) into the
+# framework registry. Production code today still calls the lowering
+# directly via `compile_kernel_body`; this registration makes it
+# discoverable via PassDriver and pins its (consumes, produces) for
+# dependency validation.
+#
+# The body of `lower_scan_pipeline` is unchanged — this is a thin
+# adapter that takes a MIR ExecutePipeline and forwards its `pipeline`
+# list to the existing function. Future stages may move callers onto
+# the registry-driven dispatch path; for now both paths coexist.
+
+
+def _register_passes() -> None:
+  import srdatalog.ir.mir.types as mir
+  from srdatalog.ir.core.passes import lowering
+  from srdatalog.ir.dialects.relation.sorted_array.lowerings import lower_scan_pipeline
+
+  @lowering(
+    DIALECT,
+    mir.ExecutePipeline,
+    consumes=('mir',),
+    produces=('iir.cf', 'relation.sorted_array', 'relation.d2l', 'parallel.data'),
+  )
+  def lower_execute_pipeline(ep, ctx):  # noqa: ARG001 - ctx forwarded
+    return lower_scan_pipeline(ep.pipeline, ctx)
+
+
+_register_passes()

--- a/src/srdatalog/ir/dialects/relation/sorted_array/__init__.py
+++ b/src/srdatalog/ir/dialects/relation/sorted_array/__init__.py
@@ -89,7 +89,7 @@ __all__ = [
 
 def _register_passes() -> None:
   import srdatalog.ir.mir.types as mir
-  from srdatalog.ir.core.passes import lowering
+  from srdatalog.ir.core.passes import lowering, verifier
   from srdatalog.ir.dialects.relation.sorted_array.lowerings import lower_scan_pipeline
 
   @lowering(
@@ -98,8 +98,14 @@ def _register_passes() -> None:
     consumes=('mir',),
     produces=('iir.cf', 'relation.sorted_array', 'relation.d2l', 'parallel.data'),
   )
-  def lower_execute_pipeline(ep, ctx):  # noqa: ARG001 - ctx forwarded
+  def lower_execute_pipeline(ep, ctx):
     return lower_scan_pipeline(ep.pipeline, ctx)
+
+  # Verifier scaffolding — per-op invariants (D9: SaHint inside
+  # IterURV scope, etc.) land incrementally as we encode them.
+  @verifier(DIALECT)
+  def _verify(_prog):
+    return []
 
 
 _register_passes()

--- a/src/srdatalog/ir/hir/__init__.py
+++ b/src/srdatalog/ir/hir/__init__.py
@@ -38,6 +38,20 @@ DIALECT = Dialect(
 )
 
 
+# Verifier scaffolding — HIR invariants (stratum dependency acyclicity,
+# every relation decl appears in at most one stratum, etc.) land
+# incrementally as we encode them.
+def _register_passes() -> None:
+  from srdatalog.ir.core.passes import verifier
+
+  @verifier(DIALECT)
+  def _verify(_prog):
+    return []
+
+
+_register_passes()
+
+
 def default_pipeline(verbose: bool = False) -> Pipeline:
   '''Build the standard HIR pipeline.
 

--- a/src/srdatalog/ir/mir/__init__.py
+++ b/src/srdatalog/ir/mir/__init__.py
@@ -86,3 +86,17 @@ DIALECT = Dialect(
     Program,
   ],
 )
+
+
+# Verifier scaffolding — MIR invariants (well-formed pipelines, every
+# Scan/ColumnSource has a registered relation, etc.) land incrementally
+# as we encode them.
+def _register_passes() -> None:
+  from srdatalog.ir.core.passes import verifier
+
+  @verifier(DIALECT)
+  def _verify(_prog):
+    return []
+
+
+_register_passes()

--- a/tests/test_pass_framework.py
+++ b/tests/test_pass_framework.py
@@ -1,0 +1,203 @@
+'''Bundle B framework tests.
+
+Pins the contract for:
+  - @lowering / @rewrite / @verifier decorators (S3A.6 part 1)
+  - Lowering / Rewrite consumes/produces fields
+  - PassDriver.validate_dependencies — raises PassDependencyError
+    when a registered pass declares consumes=(D,) and D is not
+    in the Compiler's registry
+  - PassDriver.verify_all — invokes each dialect's verifier
+  - sorted_array's MIR→IIR entry point is registered (S3A.4)
+  - every existing dialect ships at least a no-op verifier (S3A.7)
+'''
+
+from __future__ import annotations
+
+import pytest
+
+from srdatalog.ir.core import Compiler, Dialect, Op
+from srdatalog.ir.core.passes import (
+  Lowering,
+  PassDependencyError,
+  PassDriver,
+  Rewrite,
+  lowering,
+  rewrite,
+  verifier,
+)
+
+# -----------------------------------------------------------------------------
+# Decorators (S3A.6 part 1)
+# -----------------------------------------------------------------------------
+
+
+class _ToyOp(Op):
+  pass
+
+
+def test_lowering_decorator_registers_on_dialect():
+  d = Dialect(name='toy.lowering')
+  assert d.lowerings == []
+
+  @lowering(d, _ToyOp, consumes=('a',), produces=('b',))
+  def _l(op, ctx):
+    return [op]
+
+  assert len(d.lowerings) == 1
+  l = d.lowerings[0]
+  assert isinstance(l, Lowering)
+  assert l.matches is _ToyOp
+  assert l.consumes == ('a',)
+  assert l.produces == ('b',)
+  assert l.name == '_l'
+
+
+def test_rewrite_decorator_registers_on_dialect():
+  d = Dialect(name='toy.rewrite')
+  assert d.rewrites == []
+
+  @rewrite(d, _ToyOp, name='count_as_product')
+  def _r(op, ctx):
+    return op
+
+  assert len(d.rewrites) == 1
+  r = d.rewrites[0]
+  assert isinstance(r, Rewrite)
+  assert r.matches is _ToyOp
+  assert r.name == 'count_as_product'
+
+
+def test_verifier_decorator_attaches_to_dialect():
+  d = Dialect(name='toy.verifier')
+  assert d.verifier is None
+
+  @verifier(d)
+  def _v(_):
+    return ['err']
+
+  assert d.verifier is _v
+  assert d.verifier(None) == ['err']
+
+
+def test_verifier_decorator_rejects_double_registration():
+  d = Dialect(name='toy.verifier.dup')
+
+  @verifier(d)
+  def _v1(_):
+    return []
+
+  with pytest.raises(ValueError, match='already registered'):
+
+    @verifier(d)
+    def _v2(_):
+      return []
+
+
+# -----------------------------------------------------------------------------
+# PassDriver.validate_dependencies (S3A.6 part 2)
+# -----------------------------------------------------------------------------
+
+
+def test_pass_driver_passes_with_satisfied_deps():
+  c = Compiler()
+  source = Dialect(name='toy.source')
+  target = Dialect(name='toy.target')
+
+  @lowering(target, _ToyOp, consumes=('toy.source',))
+  def _l(op, ctx):
+    return [op]
+
+  c.register_dialect(source)
+  c.register_dialect(target)
+
+  pd = PassDriver(c)
+  pd.validate_dependencies()  # should not raise
+
+
+def test_pass_driver_raises_on_unmet_dep():
+  c = Compiler()
+  target = Dialect(name='toy.target.unmet')
+
+  @lowering(target, _ToyOp, consumes=('toy.missing',))
+  def _l(op, ctx):
+    return [op]
+
+  c.register_dialect(target)
+
+  pd = PassDriver(c)
+  with pytest.raises(PassDependencyError) as ei:
+    pd.validate_dependencies()
+  assert ei.value.missing_dialect == 'toy.missing'
+  assert ei.value.in_dialect == 'toy.target.unmet'
+  assert 'toy.missing' in str(ei.value)
+
+
+def test_pass_driver_run_validates_then_verifies():
+  '''Smoke: PassDriver.run validates deps then runs verifiers and
+  returns prog unchanged.'''
+  c = Compiler()
+  d = Dialect(name='toy.runner')
+
+  @verifier(d)
+  def _v(_):
+    return []
+
+  c.register_dialect(d)
+  pd = PassDriver(c)
+  out = pd.run('hello')
+  assert out == 'hello'
+
+
+# -----------------------------------------------------------------------------
+# Production dialect registrations (S3A.4 + S3A.7)
+# -----------------------------------------------------------------------------
+
+
+def _all_production_dialects():
+  '''Every framework-tracked dialect in srdatalog.ir.'''
+  from srdatalog.ir.dialects.iir.cf import DIALECT as cf_d
+  from srdatalog.ir.dialects.parallel.data import DIALECT as pd_d
+  from srdatalog.ir.dialects.relation.d2l import DIALECT as d2l_d
+  from srdatalog.ir.dialects.relation.sorted_array import DIALECT as sa_d
+  from srdatalog.ir.hir import DIALECT as hir_d
+  from srdatalog.ir.mir import DIALECT as mir_d
+
+  return [hir_d, mir_d, cf_d, sa_d, d2l_d, pd_d]
+
+
+def test_every_production_dialect_has_a_verifier():
+  '''S3A.7 acceptance gate: every framework-tracked dialect ships at
+  least a no-op verifier so PassDriver.verify_all has something to
+  call. Real per-dialect invariants land incrementally.'''
+  for d in _all_production_dialects():
+    assert d.verifier is not None, f'dialect {d.name!r} missing verifier'
+    # Smoke: verifier callable + returns iterable
+    assert d.verifier(None) == [], f'dialect {d.name!r} verifier should return [] today'
+
+
+def test_sorted_array_lowering_registered():
+  '''S3A.4: sorted_array's MIR→IIR entry is registered as a Lowering.'''
+  import srdatalog.ir.mir.types as mir
+  from srdatalog.ir.dialects.relation.sorted_array import DIALECT
+
+  matches = [l for l in DIALECT.lowerings if l.matches is mir.ExecutePipeline]
+  assert len(matches) == 1, (
+    f'expected 1 Lowering matching mir.ExecutePipeline on sorted_array.DIALECT, got {len(matches)}'
+  )
+  l = matches[0]
+  assert l.consumes == ('mir',)
+  assert 'iir.cf' in l.produces
+  assert 'relation.sorted_array' in l.produces
+
+
+def test_all_production_dialects_register_with_a_compiler():
+  '''Smoke: a fresh Compiler can hold every production dialect; deps
+  validate cleanly (sorted_array's consumes=('mir',) is satisfied
+  because mir is in the set).'''
+  c = Compiler()
+  for d in _all_production_dialects():
+    c.register_dialect(d)
+
+  pd = PassDriver(c)
+  pd.validate_dependencies()  # should not raise
+  assert pd.verify_all(None) == []


### PR DESCRIPTION
## Summary

Bundle B from [`docs/stage3a_execution_plan.md`](docs/stage3a_execution_plan.md), rescoped after planning discussion. Four commits, structural framework realization + honest planning of Stage 4.

## Commits

| # | SHA | Task | Why |
|---|---|---|---|
| 1 | `00f8c41` | **S3A.6 part 1** — extend `Lowering`/`Rewrite` + add `@lowering`/`@rewrite`/`@verifier` decorators | Triton-style registration; consumes/produces fields for dependency validation |
| 2 | `72c1d3d` | **S3A.4** (entry-point only) — register sorted_array MIR→IIR via `@lowering` | Wraps `lower_scan_pipeline` as a `Lowering(matches=mir.ExecutePipeline, ...)` instance |
| 3 | `e6e7925` | **S3A.7** — wire `@verifier` across all dialects + plug `parallel.data`/`d2l` `DIALECT` gaps | All 6 dialects ship a (no-op) verifier; PassDriver.verify_all walks them |
| 4 | `6e4ff63` | **docs** — reflect Bundle B's actual scope; plan Stage 4 (IIR semantic vocabulary) | Honest scope; defers S3A.5 (R1-R5) to Stage 4 |

## What Bundle B delivers (structural realization)

- **`@lowering(DIALECT, OpClass, consumes=(...), produces=(...))`** decorator wraps a function as a `Lowering` instance and registers on `dialect.lowerings`.
- **`@rewrite(DIALECT, OpClass)`** same for `Rewrite`.
- **`@verifier(DIALECT)`** registers a verifier on `dialect.verifier`; rejects double registration.
- **`PassDriver.validate_dependencies()`** walks every registered Lowering/Rewrite, raises `PassDependencyError` if any `consumes` references a dialect not in the Compiler's registry. Loud-fail per [§9 design decision](docs/stage3a_execution_plan.md#9-open-design-decision).
- **`PassDriver.verify_all(prog)`** invokes every dialect's verifier, aggregates `VerificationError` lists.
- **`PassDriver.run(prog)`** validates deps + verifies + returns `prog`. (Op-level dispatch is YAGNI — see Stage 4.)
- **All 6 production dialects** (hir, mir, iir.cf, sorted_array, d2l, parallel.data) now have:
  - A registered `DIALECT` (closed two pre-existing gaps in d2l and parallel.data)
  - A no-op verifier (real per-dialect invariants land incrementally per D9/D10)
- **sorted_array** has its MIR→IIR entry registered as a `Lowering` with correct `consumes=('mir',)` and `produces=('iir.cf', 'relation.sorted_array', 'relation.d2l', 'parallel.data')`.

## What Bundle B does NOT deliver (acknowledged in commit 4 + docs)

The framework realization is **structural, not semantic**. For sorted_array's MIR→IIR lowering, the IIR ops it produces include 46 `RawString(text="<C++>")` escape hatches; the codegen's renderer for `RawString` is a passthrough. So most of the per-op dispatch dispatches to string-passthrough functions — **the abstraction is real but mostly empty for the bulk of code paths**. Adding a second target today would render every RawString as the same C++ text.

This is now tracked as **Stage 4 — IIR semantic vocabulary** (planning-only):
- S4.0 inventory the 46 RawString sites
- S4.1 trivial bare-identifier sites → `VarRef` (~10 sites)
- S4.2 arithmetic ops (`BinOp` etc., ~15 sites)
- S4.3-S4.5 IndexExpr, MemberAccess, Ternary (~16 sites)
- S4.6 gnarly compound forms (~10 sites)
- S4.7 discipline test pinning RawString count
- S4.8 R1–R5 rewrites (now-tractable on structured ops; was S3A.5)
- S4.9 op-level dispatch in PassDriver (real consumer exists)

Stage 4 is the project that makes "IR goes to target" mean something.

## Test plan

- [x] `python -m pytest tests/` — **1067 passed, 5 skipped** (1057 baseline + 10 new in `tests/test_pass_framework.py`)
- [x] `python -m ruff check src tests` — clean
- [x] `python -m ruff format --check src tests tools examples` — clean
- [x] New `tests/test_pass_framework.py` (10 tests) covers: decorators (4), PassDriver dep validation + run (3), production registrations (3)
- [x] Smoke: every production dialect has a verifier; sorted_array's lowering is registered with right consumes/produces; all 6 dialects register cleanly with a fresh Compiler

## Stage 3A progress

- ✅ S3A.0 (PR #12) — codegen rename
- ✅ S3A.1 (PR #15) — Print_i
- ✅ S3A.2 (PR #16) — sorted_array lowerings stop importing codegen
- ✅ S3A.3 (PR #16) — render registry
- ✅ S3A.4 (this PR) — entry-point Lowering registered
- ⬜ S3A.5 — **deferred to Stage 4** (entangled with RawString)
- ✅ S3A.6 (this PR) — decorators + dep validation (op-level dispatch deferred)
- ✅ S3A.7 (this PR) — verifier wiring
- ⬜ S3A.8 — Bundle C (per-Codegen registry, kill A6/A7)
- ✅ S3A.9 (PR #13 + Bundle A) — cleanup

🤖 Generated with [Claude Code](https://claude.com/claude-code)