### PR TITLE
Bundle C: S3A.8 — kill A7 (explicit register_default_plugins)

### DIFF
--- a/src/srdatalog/ir/codegen/cuda/__init__.py
+++ b/src/srdatalog/ir/codegen/cuda/__init__.py
@@ -17,4 +17,19 @@ from srdatalog.ir.core import Dialect
 DIALECT = Dialect(name='target.cuda')
 
 
-__all__ = ['DIALECT', 'EmitCtx', 'emit']
+def register_default_plugins() -> None:
+  '''Register the default CUDA index plugins. Idempotent.
+
+  Per S3A.8 / docs/stage3a_execution_plan.md §7 (kill A7), each compile
+  entry point in `codegen.cuda.api` calls this at the start of compile
+  time. No module-import-time side effects from dialect packages — the
+  codegen is the registry's owner and explicitly opts into each plugin
+  here. Adding a new index dialect = adding a `register_X_cuda_plugin()`
+  function in that dialect and calling it from this function.
+  '''
+  from srdatalog.ir.dialects.relation.d2l.cuda import register_d2l_cuda_plugin
+
+  register_d2l_cuda_plugin()
+
+
+__all__ = ['DIALECT', 'EmitCtx', 'emit', 'register_default_plugins']

--- a/src/srdatalog/ir/codegen/cuda/api.py
+++ b/src/srdatalog/ir/codegen/cuda/api.py
@@ -48,10 +48,13 @@ def compile_pipeline(ep: m.ExecutePipeline, *, target: Target = 'cuda') -> str:
   if target != 'cuda':
     raise ValueError(f'compile_pipeline: unsupported target {target!r}')
 
+  from srdatalog.ir.codegen.cuda import register_default_plugins
   from srdatalog.ir.codegen.cuda.envelope import (
     assign_handle_positions,
     emit_full_file,
   )
+
+  register_default_plugins()
 
   pipeline = list(ep.pipeline)
   assign_handle_positions(pipeline)
@@ -87,8 +90,10 @@ def compile_runner(
   anchors this entry point to the upstream goldens throughout the
   migration.
   '''
+  from srdatalog.ir.codegen.cuda import register_default_plugins
   from srdatalog.ir.codegen.cuda.runner import emit_runner_full
 
+  register_default_plugins()
   return emit_runner_full(ep, db_type_name, rel_index_types=rel_index_types)
 
 
@@ -134,6 +139,7 @@ def compile_kernel_body(
       slots advance by 2 per FULL_VER D2L source — matching legacy
       `compute_view_slot_offsets`. Pass {} or None for plain DSAI.
   '''
+  from srdatalog.ir.codegen.cuda import register_default_plugins
   from srdatalog.ir.codegen.cuda.emit import EmitCtx, emit
   from srdatalog.ir.codegen.cuda.envelope import (
     assign_handle_positions,
@@ -146,6 +152,7 @@ def compile_kernel_body(
     lower_scan_pipeline,
   )
 
+  register_default_plugins()
   pipeline = list(ep.pipeline)
   assign_handle_positions(pipeline)
 

--- a/src/srdatalog/ir/codegen/cuda/complete_runner.py
+++ b/src/srdatalog/ir/codegen/cuda/complete_runner.py
@@ -28,14 +28,12 @@ dedup_hash, balanced scan, fan-out, materialized pipelines.
 
 from __future__ import annotations
 
-# Side-effect import: pulling in the D2L dialect auto-registers its
-# CUDA plugin with `codegen.cuda.plugin`. Without this,
-# `plugin_view_count` falls back to the default plugin (view_count=1
-# for every version) for any relation declared with
-# `index_type="...Device2LevelIndex"`, silently undercounting
-# NumSources and diverging from upstream.
-import srdatalog.ir.dialects.relation.d2l  # noqa: F401
 import srdatalog.ir.mir.types as m
+
+# Per S3A.8 (kill A7), CUDA index plugins are now registered by
+# `codegen.cuda.register_default_plugins()` at compile time (called
+# by every entry point in `codegen.cuda.api`). The previous
+# side-effect import of `srdatalog.ir.dialects.relation.d2l` is gone.
 from srdatalog.ir.codegen.cuda.materialized import is_materialized_pipeline
 from srdatalog.ir.codegen.cuda.pipeline_utils import (
   assign_handle_positions,

--- a/src/srdatalog/ir/dialects/relation/d2l/__init__.py
+++ b/src/srdatalog/ir/dialects/relation/d2l/__init__.py
@@ -52,12 +52,12 @@ from __future__ import annotations
 
 from srdatalog.ir.codegen.cuda.envelope import ViewSpec
 from srdatalog.ir.core import Dialect
-
-# Side-effect import: registers D2L's CUDA plugin with
-# `codegen.cuda.plugin` so `plugin_view_count` etc. dispatch correctly
-# for relations declared `index_type="...Device2LevelIndex"`.
-from srdatalog.ir.dialects.relation.d2l import cuda as _cuda
 from srdatalog.ir.dialects.relation.d2l.ops import D2lSegmentLoop
+
+# Per S3A.8 (kill A7), this package no longer triggers CUDA plugin
+# registration as a side effect of import. The codegen calls
+# `srdatalog.ir.codegen.cuda.register_default_plugins()` at compile
+# time to wire the D2L plugin into its registry.
 
 DIALECT = Dialect(
   name='relation.d2l',

--- a/src/srdatalog/ir/dialects/relation/d2l/cuda.py
+++ b/src/srdatalog/ir/dialects/relation/d2l/cuda.py
@@ -3,10 +3,14 @@
 How the D2L (Device2LevelIndex) dialect emits as CUDA: registers an
 `IndexPlugin` with `codegen.cuda.plugin`'s registry that supplies the
 per-version view_count (FULL=2 for HEAD+FULL, DELTA/NEW=1) and the
-host-side view-setup code emitted around CUDA kernels. Importing
-this module — typically via `import srdatalog.ir.dialects.relation.d2l`
-— is enough to register the plugin (the D2L package's `__init__`
-re-imports this side-effectfully).
+host-side view-setup code emitted around CUDA kernels.
+
+Per S3A.8 / docs/stage3a_execution_plan.md §7 (kill A7), the registration
+is exposed as an explicit `register_d2l_cuda_plugin()` function. The
+CUDA codegen calls it at compile time via
+`codegen.cuda.register_default_plugins()` — no module-import-time
+side effects. Calling `import srdatalog.ir.dialects.relation.d2l`
+no longer mutates the codegen's plugin registry as a side effect.
 
 D2L design recap:
   - HEAD + FULL sorted arrays per relation.
@@ -60,6 +64,23 @@ def new_two_level_plugin() -> IndexPlugin:
   return plugin
 
 
-# Module-level instance + registration (compile-time in Nim; import-time here).
 two_level_plugin = new_two_level_plugin()
-register_index_plugin(two_level_plugin)
+
+
+def register_d2l_cuda_plugin() -> None:
+  '''Register the Device2LevelIndex plugin with codegen.cuda.plugin's
+  default registry. Idempotent — re-registering with the same cpp_type
+  key is safe (overwrites with the same value).
+
+  Called by `codegen.cuda.register_default_plugins()` at compile time.
+  Per S3A.8, no caller invokes this at import time.
+  '''
+  register_index_plugin(two_level_plugin)
+
+
+__all__ = [
+  'IndexPlugin',
+  'new_two_level_plugin',
+  'register_d2l_cuda_plugin',
+  'two_level_plugin',
+]

--- a/tests/test_ir_no_import_side_effects.py
+++ b/tests/test_ir_no_import_side_effects.py
@@ -1,0 +1,157 @@
+'''Pre-flight discipline test for S3A.8 (kill A7).
+
+Per docs/stage3a_execution_plan.md §6.1: importing a module under
+`ir/dialects/` must not mutate state in any *other* module. The
+historical violation: importing `srdatalog.ir.dialects.relation.d2l`
+triggered a side-effect import of `d2l/cuda.py`, which called
+`register_index_plugin(two_level_plugin)` and mutated
+`codegen/cuda/plugin._PLUGIN_REGISTRY`. After S3A.8 the registration
+is explicit (`codegen.cuda.register_default_plugins()`); importing
+the dialect alone does nothing to the codegen registry.
+
+The test runs in a subprocess because Python caches modules — a
+second import of d2l in the same process is a no-op even if the
+first import had side effects. Subprocess gives a fresh interpreter
+state.
+'''
+
+from __future__ import annotations
+
+import subprocess
+import sys
+
+
+def _run_in_subprocess(code: str) -> tuple[int, str, str]:
+  r = subprocess.run(
+    [sys.executable, '-c', code],
+    capture_output=True,
+    text=True,
+  )
+  return r.returncode, r.stdout, r.stderr
+
+
+def test_d2l_import_does_not_mutate_codegen_plugin_registry():
+  '''Pin A7: importing srdatalog.ir.dialects.relation.d2l must not
+  mutate srdatalog.ir.codegen.cuda.plugin._PLUGIN_REGISTRY.
+
+  Pre-S3A.8 this would fail (d2l/__init__.py had `from . import cuda
+  as _cuda` which side-effect-imported d2l/cuda.py, which ran
+  `register_index_plugin(two_level_plugin)` at module load).
+  '''
+  code = """
+import sys
+
+# Snapshot before any d2l-related imports.
+import srdatalog.ir.codegen.cuda.plugin as p
+before = dict(p._PLUGIN_REGISTRY)
+
+# Import the dialect.
+import srdatalog.ir.dialects.relation.d2l  # noqa: F401
+
+# Snapshot after.
+after = dict(p._PLUGIN_REGISTRY)
+
+if before != after:
+    added = set(after) - set(before)
+    removed = set(before) - set(after)
+    print(f'FAIL: d2l import mutated registry. added={added}, removed={removed}',
+          file=sys.stderr)
+    sys.exit(1)
+print('OK')
+"""
+  rc, out, err = _run_in_subprocess(code)
+  assert rc == 0, f'subprocess failed:\nstdout: {out}\nstderr: {err}'
+  assert 'OK' in out
+
+
+def test_d2l_cuda_module_import_does_not_mutate_registry():
+  '''Per S3A.8, even directly importing d2l.cuda must not mutate the
+  codegen registry. Registration is exposed as register_d2l_cuda_plugin()
+  and only happens when called explicitly.
+  '''
+  code = """
+import sys
+
+import srdatalog.ir.codegen.cuda.plugin as p
+before = dict(p._PLUGIN_REGISTRY)
+
+import srdatalog.ir.dialects.relation.d2l.cuda  # noqa: F401
+
+after = dict(p._PLUGIN_REGISTRY)
+
+if before != after:
+    print(f'FAIL: importing d2l.cuda mutated registry. diff={set(after) ^ set(before)}',
+          file=sys.stderr)
+    sys.exit(1)
+print('OK')
+"""
+  rc, out, err = _run_in_subprocess(code)
+  assert rc == 0, f'subprocess failed:\nstdout: {out}\nstderr: {err}'
+  assert 'OK' in out
+
+
+def test_register_default_plugins_does_register_d2l():
+  '''Inverse: when called explicitly, register_default_plugins() does
+  add the D2L plugin to the registry.'''
+  code = """
+import sys
+
+import srdatalog.ir.codegen.cuda.plugin as p
+import srdatalog.ir.dialects.relation.d2l.cuda  # safe per the test above
+
+before = 'SRDatalog::GPU::Device2LevelIndex' in p._PLUGIN_REGISTRY
+if before:
+    print(f'FAIL: d2l already registered before explicit call', file=sys.stderr)
+    sys.exit(1)
+
+from srdatalog.ir.codegen.cuda import register_default_plugins
+register_default_plugins()
+
+if 'SRDatalog::GPU::Device2LevelIndex' not in p._PLUGIN_REGISTRY:
+    print(f'FAIL: register_default_plugins did not register d2l', file=sys.stderr)
+    sys.exit(1)
+print('OK')
+"""
+  rc, out, err = _run_in_subprocess(code)
+  assert rc == 0, f'subprocess failed:\nstdout: {out}\nstderr: {err}'
+  assert 'OK' in out
+
+
+def test_compile_pipeline_triggers_default_plugin_registration():
+  '''End-to-end smoke: production compile entry points implicitly
+  register defaults via the explicit call inside their function body.
+  Running compile_pipeline on a real DSL program leaves the registry
+  populated.'''
+  code = """
+import sys
+
+# Build a tiny program.
+from srdatalog.dsl import Program, Relation, Var
+
+X, Y, Z = Var('x'), Var('y'), Var('z')
+edge = Relation('Edge', 2)
+path = Relation('Path', 2)
+prog = Program(rules=[
+    (path(X, Y) <= edge(X, Y)).named('Base'),
+    (path(X, Z) <= edge(X, Y) & path(Y, Z)).named('Rec'),
+])
+
+import srdatalog.ir.codegen.cuda.plugin as p
+before = 'SRDatalog::GPU::Device2LevelIndex' in p._PLUGIN_REGISTRY
+if before:
+    print('FAIL: d2l already registered before compile_program', file=sys.stderr)
+    sys.exit(1)
+
+from srdatalog.ir.pipeline import compile_program
+# pipeline.compile_program → gen_complete_runner → ... → eventually
+# api.compile_kernel_body which calls register_default_plugins().
+compile_program(prog, 'TestProj')
+
+if 'SRDatalog::GPU::Device2LevelIndex' not in p._PLUGIN_REGISTRY:
+    print('FAIL: d2l not registered after compile_program', file=sys.stderr)
+    sys.exit(1)
+print('OK')
+"""
+  rc, out, err = _run_in_subprocess(code)
+  assert rc == 0, f'subprocess failed:\nstdout: {out}\nstderr: {err}'
+  assert 'OK' in out


### PR DESCRIPTION
## Summary

Bundle C from [`docs/stage3a_execution_plan.md`](docs/stage3a_execution_plan.md), trimmed to the A7 slice of S3A.8.

**Stacked on PR #17** (Bundle B). This PR's base will auto-update to `main` when #17 merges; until then the diff below is just C's new commit on top of B.

## What changed

- **`d2l/cuda.py`** — registration wrapped in `register_d2l_cuda_plugin()` function. Module-level `register_index_plugin(two_level_plugin)` removed.
- **`d2l/__init__.py`** — `from . import cuda as _cuda` side-effect import removed. Importing the d2l dialect alone is now pure metadata.
- **`codegen/cuda/__init__.py`** — new `register_default_plugins()` function. Codegen is the registry's owner; it explicitly opts into each plugin here. Adding a new index dialect = providing `register_X_cuda_plugin()` and calling it from this function.
- **`codegen/cuda/api.py`** — every entry point (`compile_pipeline`, `compile_runner`, `compile_kernel_body`) calls `register_default_plugins()` at start. Idempotent.
- **`codegen/cuda/complete_runner.py`** — dropped the `import srdatalog.ir.dialects.relation.d2l  # noqa: F401` that existed only to trigger the side-effect chain.

## Pre-flight test pinning the fix

[`tests/test_ir_no_import_side_effects.py`](tests/test_ir_no_import_side_effects.py) — 4 cases, all in subprocesses for clean module state:

1. **`test_d2l_import_does_not_mutate_codegen_plugin_registry`** — pre-fix this would fail; post-fix d2l import is pure.
2. **`test_d2l_cuda_module_import_does_not_mutate_registry`** — even direct import of `d2l.cuda` doesn't mutate; only the function call does.
3. **`test_register_default_plugins_does_register_d2l`** — inverse: explicit call works.
4. **`test_compile_pipeline_triggers_default_plugin_registration`** — end-to-end smoke that production paths still register correctly.

## What's NOT in this PR (A6 still partially violated)

`codegen/cuda/plugin` still holds `_PLUGIN_REGISTRY` as a module-global mutable dict. **A6 (no module-level mutable state) is still violated.** Killing A6 fully requires threading a per-`Compiler` / per-`Codegen` registry through every plugin lookup site (~10+ call sites across codegen modules). That's a much bigger refactor — tracked as a follow-up beyond Stage 3A.

This PR delivers the **A7 half** of S3A.8: no module-import-time side effects from dialect packages. The A6 half is documented as remaining.

## Test plan

- [x] `python -m pytest tests/test_ir_no_import_side_effects.py -v` — 4 passed
- [x] `python -m pytest tests/` — **1071 passed, 5 skipped** (1067 baseline from Bundle B + 4 new pre-flight)
- [x] `python -m ruff check src tests` — clean
- [x] `python -m ruff format --check src tests tools examples` — clean
- [x] Byte-equivalence preserved (full byte-equivalence suite ran clean)
- [x] `grep "from . import cuda as _cuda" src/srdatalog/ir/dialects/` — no matches

## Stage 3A status (after both #17 + this PR merge)

- ✅ S3A.0 — codegen rename
- ✅ S3A.1 — Print_i
- ✅ S3A.2 — sorted_array lowerings stop importing codegen
- ✅ S3A.3 — render registry
- ✅ S3A.4 (entry-point only) — sorted_array's MIR→IIR registered
- ⬜ S3A.5 — deferred to Stage 4 (entangled with RawString)
- ✅ S3A.6 — decorators + dep validation
- ✅ S3A.7 — verifier wiring
- 🟨 S3A.8 — A7 done (this PR); A6 still partial (module-global registry remains)
- ✅ S3A.9 — cleanup

🤖 Generated with [Claude Code](https://claude.com/claude-code)