### PR TITLE
S4.1 + S4.2: bare identifier → VarRef; iir.expr dialect with BinOp

### DIFF
--- a/src/srdatalog/ir/codegen/cuda/render/__init__.py
+++ b/src/srdatalog/ir/codegen/cuda/render/__init__.py
@@ -133,6 +133,7 @@ def _eager_register_all() -> None:
   from srdatalog.ir.codegen.cuda.render import (
     d2l,
     iir_cf,
+    iir_expr,
     parallel_data,
     sorted_array,
   )

--- a/src/srdatalog/ir/codegen/cuda/render/iir_expr.py
+++ b/src/srdatalog/ir/codegen/cuda/render/iir_expr.py
@@ -1,0 +1,22 @@
+'''CUDA renderers for the iir.expr dialect.
+
+Per docs/stage4_iir_vocabulary.md S4.2.
+'''
+
+from __future__ import annotations
+
+from srdatalog.ir.codegen.cuda.render import EmitCtx, emit_expr, register_render
+from srdatalog.ir.dialects.iir.expr.ops import BinOp
+
+
+@register_render(BinOp, mode='expr')
+def _render_bin_op(op: BinOp, ctx: EmitCtx) -> str:
+  '''Render `<lhs> <op_str> <rhs>` with no surrounding parens. Matches
+  the existing RawString-with-bare-text behavior these handlers replace
+  — preserves byte-equivalence for the lowerings being migrated.
+
+  Caller is responsible for any precedence-explicit grouping; future
+  Parens / explicit-grouping support can be added without changing this
+  handler's contract.
+  '''
+  return f'{emit_expr(op.lhs, ctx)} {op.op_str} {emit_expr(op.rhs, ctx)}'

--- a/src/srdatalog/ir/dialects/iir/expr/__init__.py
+++ b/src/srdatalog/ir/dialects/iir/expr/__init__.py
@@ -1,0 +1,49 @@
+'''iir.expr — expression-shaped IIR ops.
+
+Per docs/stage4_iir_vocabulary.md §2 (S4.2): structured replacements
+for arithmetic / index / member-access / ternary RawString sites in
+sorted_array/lowerings.py.
+
+Currently registered ops:
+  - BinOp(op_str, lhs, rhs) — binary expression. Generic op_str
+    (per the open design decision §3.1: chose generic over per-operator).
+
+Planned (later S4 tasks):
+  - IntLit / BoolLit       — typed literals
+  - IndexExpr(arr, idx)    — subscript expression
+  - MemberAccess(obj, m)   — `obj.member`
+  - MemberCall(obj, m, *)  — `obj.method(args)`
+  - Ternary(cond, t, e)    — `cond ? t : e`
+  - BoolNot(expr)          — `!expr`
+
+The split between iir.cf (statements) and iir.expr (expressions)
+mirrors the existing emit/emit_expr distinction in the renderer
+registry — it is not a purely cosmetic split.
+'''
+
+from __future__ import annotations
+
+from srdatalog.ir.core import Dialect
+from srdatalog.ir.dialects.iir.expr.ops import BinOp
+
+DIALECT = Dialect(
+  name='iir.expr',
+  ops=[BinOp],
+)
+
+
+# Verifier scaffolding — expression-level invariants (operator string
+# in the allowed set, lhs/rhs are expression-shaped, etc.) land
+# incrementally as we encode them.
+def _register_passes() -> None:
+  from srdatalog.ir.core.passes import verifier
+
+  @verifier(DIALECT)
+  def _verify(_prog):
+    return []
+
+
+_register_passes()
+
+
+__all__ = ['DIALECT', 'BinOp']

--- a/src/srdatalog/ir/dialects/iir/expr/ops.py
+++ b/src/srdatalog/ir/dialects/iir/expr/ops.py
@@ -1,0 +1,61 @@
+'''iir.expr op definitions — expression-shaped IIR.
+
+Per the project memory note `feedback_decorator_registries.md`,
+all ops are pure data (D1), frozen+slots dataclasses (D2/D3),
+@final to lock the closed sum (D11).
+
+S4.2 ships only `BinOp`; subsequent S4 tasks add the rest of the
+expression vocabulary (literals, index expressions, member access,
+ternaries, boolean negation).
+'''
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import final
+
+from srdatalog.ir.core import Op
+
+
+@final
+@dataclass(frozen=True, slots=True)
+class BinOp(Op):
+  '''Binary operator expression.
+
+  `op_str` is the C++ operator literal (e.g. `'+'`, `'*'`, `'/'`,
+  `'%'`, `'=='`, `'<'`, `'&&'`, `'<<'`, etc.). Per the open design
+  decision in docs/stage4_iir_vocabulary.md §3.1, we use a generic
+  `op_str` rather than per-operator subclasses (`Mul`, `Div`, ...)
+  to keep the op surface small.
+
+  Renders to `<lhs> <op_str> <rhs>` with no surrounding parens.
+  Callers needing precedence-explicit grouping should construct
+  the IR with explicit grouping (or wait for a future Parens op).
+
+  N-ary chains (e.g. `a * b * c`) are left-folded at construction
+  time: `BinOp("*", BinOp("*", a, b), c)`. A `bin_op_chain(op_str,
+  exprs)` helper makes this ergonomic.
+  '''
+
+  op_str: str
+  lhs: Op
+  rhs: Op
+
+
+def bin_op_chain(op_str: str, exprs: list[Op]) -> Op:
+  '''Left-fold `exprs` with the given binary operator. Requires
+  `len(exprs) >= 1`. For `len == 1`, returns the lone expression
+  unchanged (no wrapping BinOp emitted).
+
+  Used by lowerings that produce variadic-arity expressions like
+  `degree0 * degree1 * degree2`.
+  '''
+  if not exprs:
+    raise ValueError(f'bin_op_chain({op_str!r}, ...) requires at least one expression')
+  result = exprs[0]
+  for e in exprs[1:]:
+    result = BinOp(op_str=op_str, lhs=result, rhs=e)
+  return result
+
+
+__all__ = ['BinOp', 'bin_op_chain']

--- a/src/srdatalog/ir/dialects/iir/expr/print.py
+++ b/src/srdatalog/ir/dialects/iir/expr/print.py
@@ -1,0 +1,33 @@
+'''Print_i for the iir.expr dialect.'''
+
+from __future__ import annotations
+
+from srdatalog.ir.dialects.iir.expr.ops import BinOp
+from srdatalog.ir.print_iir import _ind, print_iir
+
+OPS: tuple[type, ...] = (BinOp,)
+
+
+def print_op(op, indent: int = 0) -> str:
+  p = _ind(indent)
+
+  if isinstance(op, BinOp):
+    lhs = print_iir(op.lhs, indent + 1)
+    rhs = print_iir(op.rhs, indent + 1)
+    return (
+      p
+      + f'(bin-op #:op-str "{op.op_str}"\n'
+      + p
+      + '  #:lhs\n'
+      + lhs
+      + '\n'
+      + p
+      + '  #:rhs\n'
+      + rhs
+      + ')'
+    )
+
+  raise TypeError(f'iir.expr print_op: unknown op {type(op).__name__}')
+
+
+__all__ = ['OPS', 'print_op']

--- a/src/srdatalog/ir/dialects/relation/sorted_array/lowerings.py
+++ b/src/srdatalog/ir/dialects/relation/sorted_array/lowerings.py
@@ -44,6 +44,8 @@ from srdatalog.ir.dialects.iir.cf import (
   TiledBallotBlock,
   VarRef,
 )
+from srdatalog.ir.dialects.iir.expr import BinOp
+from srdatalog.ir.dialects.iir.expr.ops import bin_op_chain
 from srdatalog.ir.dialects.parallel.data.block_group import (
   BgRootCjMulti,
   BgSourceSpec,
@@ -501,7 +503,7 @@ def _lower_root_cart(
   outer_stmts.append(
     Bind(
       name=total_var,
-      expr=RawString(text=' * '.join(degree_var_names)),
+      expr=bin_op_chain('*', [VarRef(name=v) for v in degree_var_names]),
       type_decl='uint32_t',
     )
   )
@@ -533,14 +535,22 @@ def _lower_root_cart(
     inner_decompose_stmts.append(
       Bind(
         name=idx_vars[0],
-        expr=RawString(text=f'{flat_idx_var} / {degree_var_names[1]}'),
+        expr=BinOp(
+          op_str='/',
+          lhs=VarRef(name=flat_idx_var),
+          rhs=VarRef(name=degree_var_names[1]),
+        ),
         type_decl='uint32_t',
       )
     )
     inner_decompose_stmts.append(
       Bind(
         name=idx_vars[1],
-        expr=RawString(text=f'{flat_idx_var} % {degree_var_names[1]}'),
+        expr=BinOp(
+          op_str='%',
+          lhs=VarRef(name=flat_idx_var),
+          rhs=VarRef(name=degree_var_names[1]),
+        ),
         type_decl='uint32_t',
       )
     )
@@ -1213,7 +1223,7 @@ def _lower_nested_cart_tiled(
   stmts.append(
     Bind(
       name=total_var,
-      expr=RawString(text=' * '.join(degree_var_names)),
+      expr=bin_op_chain('*', [VarRef(name=v) for v in degree_var_names]),
       type_decl='uint32_t',
     )
   )
@@ -1734,7 +1744,7 @@ def _lower_nested_cart(
   stmts.append(
     Bind(
       name=total_var,
-      expr=RawString(text=' * '.join(degree_var_names)),
+      expr=bin_op_chain('*', [VarRef(name=v) for v in degree_var_names]),
       type_decl='uint32_t',
     )
   )

--- a/src/srdatalog/ir/dialects/relation/sorted_array/lowerings.py
+++ b/src/srdatalog/ir/dialects/relation/sorted_array/lowerings.py
@@ -821,7 +821,7 @@ def _lower_root_cj_multi(
 
   loop = GridStrideLoop(
     idx_name=y_idx_var,
-    bound=RawString(text='num_unique_root_keys'),
+    bound=VarRef(name='num_unique_root_keys'),
     body=loop_body,
   )
   outer_stmts.append(ParallelFor(strategy='warp_strided', body=loop))

--- a/src/srdatalog/ir/print_iir.py
+++ b/src/srdatalog/ir/print_iir.py
@@ -77,6 +77,8 @@ def print_iir(op: Op, indent: int = 0) -> str:
   # print.py imports helpers from this module).
   from srdatalog.ir.dialects.iir.cf.print import OPS as cf_OPS
   from srdatalog.ir.dialects.iir.cf.print import print_op as cf_print
+  from srdatalog.ir.dialects.iir.expr.print import OPS as expr_OPS
+  from srdatalog.ir.dialects.iir.expr.print import print_op as expr_print
   from srdatalog.ir.dialects.parallel.data.print import OPS as pd_OPS
   from srdatalog.ir.dialects.parallel.data.print import print_op as pd_print
   from srdatalog.ir.dialects.relation.d2l.print import OPS as d2l_OPS
@@ -86,6 +88,8 @@ def print_iir(op: Op, indent: int = 0) -> str:
 
   if isinstance(op, cf_OPS):
     return cf_print(op, indent)
+  if isinstance(op, expr_OPS):
+    return expr_print(op, indent)
   if isinstance(op, sa_OPS):
     return sa_print(op, indent)
   if isinstance(op, d2l_OPS):

--- a/tests/test_pass_framework.py
+++ b/tests/test_pass_framework.py
@@ -156,13 +156,14 @@ def test_pass_driver_run_validates_then_verifies():
 def _all_production_dialects():
   '''Every framework-tracked dialect in srdatalog.ir.'''
   from srdatalog.ir.dialects.iir.cf import DIALECT as cf_d
+  from srdatalog.ir.dialects.iir.expr import DIALECT as expr_d
   from srdatalog.ir.dialects.parallel.data import DIALECT as pd_d
   from srdatalog.ir.dialects.relation.d2l import DIALECT as d2l_d
   from srdatalog.ir.dialects.relation.sorted_array import DIALECT as sa_d
   from srdatalog.ir.hir import DIALECT as hir_d
   from srdatalog.ir.mir import DIALECT as mir_d
 
-  return [hir_d, mir_d, cf_d, sa_d, d2l_d, pd_d]
+  return [hir_d, mir_d, cf_d, expr_d, sa_d, d2l_d, pd_d]
 
 
 def test_every_production_dialect_has_a_verifier():


### PR DESCRIPTION
## Summary

First substantive Stage 4 PR. Three commits:

| # | SHA | Task | Sites cleared |
|---|---|---|---|
| 1 | `10db906` | **S4.1** Category A — bare identifier `RawString → VarRef` | 1 (46 → 45) |
| 2 | `(infra)` | **S4.2 infra** — new `iir.expr` sub-dialect with `BinOp` + `bin_op_chain` helper + Print_i + CUDA renderer | 0 (infrastructure) |
| 3 | `c7d2aa1` | **S4.2 migration** — replace 5 arithmetic RawString sites in `lowerings.py` (Category C) | 5 (45 → 40) |

**Stacked on PR #19** (S4.0 inventory). Base auto-updates as the chain merges.

## What `iir.expr` adds

A new sub-dialect parallel to `iir.cf`, mirroring the existing
`emit`/`emit_expr` distinction in the renderer. Currently ships one
op:

```python
@final
@dataclass(frozen=True, slots=True)
class BinOp(Op):
    op_str: str   # '+', '-', '*', '/', '%', '==', '<', '&&', ...
    lhs: Op
    rhs: Op
```

Plus a `bin_op_chain(op_str, exprs)` helper that left-folds variadic
chains: `bin_op_chain('*', [a, b, c])` → `BinOp('*', BinOp('*', a, b), c)`.

CUDA renderer emits `<lhs> <op> <rhs>` with **no surrounding parens** — matches the existing RawString text behavior, preserves byte-equivalence. Future precedence-explicit grouping can land via a dedicated `Parens(expr)` op without changing this contract.

Subsequent S4 tasks extend the vocabulary (`IntLit`, `IndexExpr`, `MemberAccess`, `MemberCall`, `Ternary`, `BoolNot`).

## Migration progress

| Category | Status | Sites |
|---|---|---|
| A — bare identifier | ✅ done | 1 |
| C — arithmetic expr | ✅ done | 5 |
| **Subtotal cleared** | | **6 of 46** |
| B, D, E, F, G, H, I, J, K, L, M | ⬜ pending | 40 remaining |

## Files

**New:**
- `src/srdatalog/ir/dialects/iir/expr/__init__.py` — DIALECT + verifier
- `src/srdatalog/ir/dialects/iir/expr/ops.py` — `BinOp`, `bin_op_chain`
- `src/srdatalog/ir/dialects/iir/expr/print.py` — Print_i
- `src/srdatalog/ir/codegen/cuda/render/iir_expr.py` — CUDA render handler

**Modified:**
- `src/srdatalog/ir/print_iir.py` — dispatcher knows `iir.expr`
- `src/srdatalog/ir/codegen/cuda/render/__init__.py` — eager-imports `iir_expr` render module
- `src/srdatalog/ir/dialects/relation/sorted_array/lowerings.py` — 6 RawString sites replaced
- `tests/test_pass_framework.py` — `iir.expr` added to production dialect list

## Test plan

- [x] `python -m pytest tests/` — **1071 passed, 5 skipped** (no test count change; baseline preserved)
- [x] `python -m ruff check src tests` — clean
- [x] `python -m ruff format --check src tests tools examples` — clean
- [x] Smoke: `bin_op_chain('*', [VarRef('x'), VarRef('y'), VarRef('z')])` → renders as `'x * y * z'`; Print_i form well-formed
- [x] Byte-equivalence preserved end-to-end across all migrated sites

## Stage 4 status

- ✅ S4.0 (PR #19) — inventory
- ✅ S4.1 (this PR) — Category A
- ✅ S4.2 (this PR) — Category C (BinOp infra + 5 sites)
- ⬜ S4.3 — Categories D, K (`IndexExpr`, `MemberAccess`)
- ⬜ S4.4 — Category G (`IfReturn`, `IfContinue`)
- ⬜ S4.5 — Categories F, I (`Ternary`, `BoolNot`)
- ⬜ S4.6 — Category L (multi-line emission blocks; hardest tier)
- ⬜ S4.7 — discipline test pinning RawString count
- ⬜ S4.8 — R1–R5 rewrites (was deferred from S3A.5)
- ⬜ S4.9 — op-level dispatch in PassDriver

🤖 Generated with [Claude Code](https://claude.com/claude-code)