### PR TITLE
S4.3: IndexExpr / MemberAccess / MemberCall (5 more sites cleared)

### DIFF
--- a/src/srdatalog/ir/codegen/cuda/render/iir_expr.py
+++ b/src/srdatalog/ir/codegen/cuda/render/iir_expr.py
@@ -6,7 +6,7 @@ Per docs/stage4_iir_vocabulary.md S4.2.
 from __future__ import annotations
 
 from srdatalog.ir.codegen.cuda.render import EmitCtx, emit_expr, register_render
-from srdatalog.ir.dialects.iir.expr.ops import BinOp
+from srdatalog.ir.dialects.iir.expr.ops import BinOp, IndexExpr, MemberAccess, MemberCall
 
 
 @register_render(BinOp, mode='expr')
@@ -20,3 +20,19 @@ def _render_bin_op(op: BinOp, ctx: EmitCtx) -> str:
   handler's contract.
   '''
   return f'{emit_expr(op.lhs, ctx)} {op.op_str} {emit_expr(op.rhs, ctx)}'
+
+
+@register_render(IndexExpr, mode='expr')
+def _render_index_expr(op: IndexExpr, ctx: EmitCtx) -> str:
+  return f'{emit_expr(op.arr, ctx)}[{emit_expr(op.idx, ctx)}]'
+
+
+@register_render(MemberAccess, mode='expr')
+def _render_member_access(op: MemberAccess, ctx: EmitCtx) -> str:
+  return f'{emit_expr(op.obj, ctx)}.{op.member}'
+
+
+@register_render(MemberCall, mode='expr')
+def _render_member_call(op: MemberCall, ctx: EmitCtx) -> str:
+  args = ', '.join(emit_expr(a, ctx) for a in op.args)
+  return f'{emit_expr(op.obj, ctx)}.{op.method}({args})'

--- a/src/srdatalog/ir/dialects/iir/expr/__init__.py
+++ b/src/srdatalog/ir/dialects/iir/expr/__init__.py
@@ -24,11 +24,11 @@ registry — it is not a purely cosmetic split.
 from __future__ import annotations
 
 from srdatalog.ir.core import Dialect
-from srdatalog.ir.dialects.iir.expr.ops import BinOp
+from srdatalog.ir.dialects.iir.expr.ops import BinOp, IndexExpr, MemberAccess, MemberCall
 
 DIALECT = Dialect(
   name='iir.expr',
-  ops=[BinOp],
+  ops=[BinOp, IndexExpr, MemberAccess, MemberCall],
 )
 
 
@@ -46,4 +46,4 @@ def _register_passes() -> None:
 _register_passes()
 
 
-__all__ = ['DIALECT', 'BinOp']
+__all__ = ['DIALECT', 'BinOp', 'IndexExpr', 'MemberAccess', 'MemberCall']

--- a/src/srdatalog/ir/dialects/iir/expr/ops.py
+++ b/src/srdatalog/ir/dialects/iir/expr/ops.py
@@ -19,6 +19,46 @@ from srdatalog.ir.core import Op
 
 @final
 @dataclass(frozen=True, slots=True)
+class IndexExpr(Op):
+  '''Subscript expression: `<arr>[<idx>]`.
+
+  Renders to `<arr>[<idx>]`. `arr` and `idx` are both expression-shaped
+  ops (typically `VarRef`s but may be more complex).
+  '''
+
+  arr: Op
+  idx: Op
+
+
+@final
+@dataclass(frozen=True, slots=True)
+class MemberAccess(Op):
+  '''Member access without call: `<obj>.<member>`.
+
+  Renders to `<obj>.<member>`. Used for field reads like
+  `view.num_rows_`. Method calls (with parens) use `MemberCall`.
+  '''
+
+  obj: Op
+  member: str
+
+
+@final
+@dataclass(frozen=True, slots=True)
+class MemberCall(Op):
+  '''Member function call: `<obj>.<method>(<args...>)`.
+
+  Renders to `<obj>.<method>(<args...>)`. `args` is a tuple of
+  expression-shaped ops; empty tuple = no-arg call (`obj.method()`).
+  '''
+
+  obj: Op
+  method: str
+  args: tuple[Op, ...]
+
+
+@final
+@dataclass(frozen=True, slots=True)
 class BinOp(Op):
   '''Binary operator expression.
 
@@ -58,4 +98,4 @@ def bin_op_chain(op_str: str, exprs: list[Op]) -> Op:
   return result
 
 
-__all__ = ['BinOp', 'bin_op_chain']
+__all__ = ['BinOp', 'IndexExpr', 'MemberAccess', 'MemberCall', 'bin_op_chain']

--- a/src/srdatalog/ir/dialects/iir/expr/print.py
+++ b/src/srdatalog/ir/dialects/iir/expr/print.py
@@ -2,10 +2,10 @@
 
 from __future__ import annotations
 
-from srdatalog.ir.dialects.iir.expr.ops import BinOp
+from srdatalog.ir.dialects.iir.expr.ops import BinOp, IndexExpr, MemberAccess, MemberCall
 from srdatalog.ir.print_iir import _ind, print_iir
 
-OPS: tuple[type, ...] = (BinOp,)
+OPS: tuple[type, ...] = (BinOp, IndexExpr, MemberAccess, MemberCall)
 
 
 def print_op(op, indent: int = 0) -> str:
@@ -25,6 +25,33 @@ def print_op(op, indent: int = 0) -> str:
       + '  #:rhs\n'
       + rhs
       + ')'
+    )
+
+  if isinstance(op, IndexExpr):
+    arr = print_iir(op.arr, indent + 1)
+    idx = print_iir(op.idx, indent + 1)
+    return p + '(index-expr\n' + p + '  #:arr\n' + arr + '\n' + p + '  #:idx\n' + idx + ')'
+
+  if isinstance(op, MemberAccess):
+    obj = print_iir(op.obj, indent + 1)
+    return p + f'(member-access #:member "{op.member}"\n' + p + '  #:obj\n' + obj + ')'
+
+  if isinstance(op, MemberCall):
+    obj = print_iir(op.obj, indent + 1)
+    if not op.args:
+      return p + f'(member-call #:method "{op.method}"\n' + p + '  #:obj\n' + obj + ')'
+    args = '\n'.join(print_iir(a, indent + 2) for a in op.args)
+    return (
+      p
+      + f'(member-call #:method "{op.method}"\n'
+      + p
+      + '  #:obj\n'
+      + obj
+      + '\n'
+      + p
+      + '  #:args (\n'
+      + args
+      + '))'
     )
 
   raise TypeError(f'iir.expr print_op: unknown op {type(op).__name__}')

--- a/src/srdatalog/ir/dialects/relation/sorted_array/lowerings.py
+++ b/src/srdatalog/ir/dialects/relation/sorted_array/lowerings.py
@@ -44,7 +44,7 @@ from srdatalog.ir.dialects.iir.cf import (
   TiledBallotBlock,
   VarRef,
 )
-from srdatalog.ir.dialects.iir.expr import BinOp
+from srdatalog.ir.dialects.iir.expr import BinOp, IndexExpr, MemberCall
 from srdatalog.ir.dialects.iir.expr.ops import bin_op_chain
 from srdatalog.ir.dialects.parallel.data.block_group import (
   BgRootCjMulti,
@@ -692,7 +692,7 @@ def _lower_root_cj_multi(
   loop_inner_stmts: list[Op] = [
     Bind(
       name=root_val_var,
-      expr=RawString(text=f'root_unique_values[{y_idx_var}]'),
+      expr=IndexExpr(arr=VarRef(name='root_unique_values'), idx=VarRef(name=y_idx_var)),
     ),
     BlankLine(),
   ]
@@ -1178,14 +1178,14 @@ def _lower_nested_cart_tiled(
   stmts.append(
     Bind(
       name=lane_var,
-      expr=RawString(text=f'{ctx.tile_var}.thread_rank()'),
+      expr=MemberCall(obj=VarRef(name=ctx.tile_var), method='thread_rank', args=()),
       type_decl='uint32_t',
     )
   )
   stmts.append(
     Bind(
       name=group_size_var,
-      expr=RawString(text=f'{ctx.tile_var}.size()'),
+      expr=MemberCall(obj=VarRef(name=ctx.tile_var), method='size', args=()),
       type_decl='uint32_t',
     )
   )
@@ -1681,14 +1681,14 @@ def _lower_nested_cart(
   stmts.append(
     Bind(
       name=lane_var,
-      expr=RawString(text=f'{ctx.tile_var}.thread_rank()'),
+      expr=MemberCall(obj=VarRef(name=ctx.tile_var), method='thread_rank', args=()),
       type_decl='uint32_t',
     )
   )
   stmts.append(
     Bind(
       name=group_size_var,
-      expr=RawString(text=f'{ctx.tile_var}.size()'),
+      expr=MemberCall(obj=VarRef(name=ctx.tile_var), method='size', args=()),
       type_decl='uint32_t',
     )
   )


### PR DESCRIPTION
## Summary

Per [`docs/stage4_iir_vocabulary.md`](docs/stage4_iir_vocabulary.md) Categories B + D.

**Stacked on PR #20** (S4.1 + S4.2). Auto-rebases.

Single commit (`346c573`) — adds 3 new ops + migrates 5 RawString sites.

## New ops in `iir.expr`

```python
IndexExpr(arr: Op, idx: Op)               → renders <arr>[<idx>]
MemberAccess(obj: Op, member: str)        → renders <obj>.<member>
MemberCall(obj: Op, method: str, args: tuple[Op, ...])
                                          → renders <obj>.<method>(<args>)
```

`MemberAccess` landed alongside `MemberCall` as a natural pair; no call sites use it yet (Category E in S4.5 will). All three follow the Triton-style `@register_render` registration pattern.

## Migration

| Category | Sites | Pattern |
|---|---|---|
| B | 4 | `tile.thread_rank()`, `tile.size()` → `MemberCall` (no-arg) |
| D | 1 | `root_unique_values[y_idx_var]` → `IndexExpr` |

RawString count in `sorted_array/lowerings.py`: **40 → 35** (5 cleared).

## Stage 4 cumulative progress

| Category | Status | Sites cleared |
|---|---|---|
| A — bare identifier | ✅ done (PR #20) | 1 |
| B — member-method call | ✅ done (this PR) | 4 |
| C — arithmetic expr | ✅ done (PR #20) | 5 |
| D — array index | ✅ done (this PR) | 1 |
| **Subtotal cleared** | | **11 of 46** |
| E, F, G, H, I, J, K, L, M | ⬜ pending | 35 remaining |

## Test plan

- [x] `python -m pytest tests/` — **1071 passed, 5 skipped**
- [x] `python -m ruff check src tests` — clean
- [x] `python -m ruff format --check src tests tools examples` — clean
- [x] Smoke: `IndexExpr(VarRef('arr'), VarRef('i'))` → `'arr[i]'`; `MemberCall(VarRef('tile'), 'ballot', (VarRef('v'),))` → `'tile.ballot(v)'`
- [x] Byte-equivalence preserved end-to-end

## Stage 4 status

- ✅ S4.0 (PR #19) — inventory
- ✅ S4.1 + S4.2 (PR #20) — Categories A + C
- ✅ S4.3 (this PR) — Categories B + D
- ⬜ S4.4 — Category G (`IfReturn`, `IfContinue`)
- ⬜ S4.5 — Categories E, F, I (`MemberAccess` already landed; needs `Ternary`, `BoolNot`, `Assign`)
- ⬜ S4.6 — Category L (multi-line emission blocks; hardest)
- ⬜ S4.7 — discipline test pinning RawString count
- ⬜ S4.8 — R1–R5 rewrites
- ⬜ S4.9 — op-level dispatch in PassDriver

🤖 Generated with [Claude Code](https://claude.com/claude-code)