### PR TITLE
S4.5: Parens/Ternary/Assign — Cat E/F/H/I (7 more sites, 24/46 cleared)

### DIFF
--- a/src/srdatalog/ir/codegen/cuda/render/iir_cf.py
+++ b/src/srdatalog/ir/codegen/cuda/render/iir_cf.py
@@ -14,6 +14,7 @@ from __future__ import annotations
 from srdatalog.ir.codegen.cuda.render import EmitCtx, emit, emit_expr, register_render
 from srdatalog.ir.dialects.iir.cf.ops import (
   AddCount,
+  Assign,
   Bind,
   BlankLine,
   Block,
@@ -66,6 +67,11 @@ def _render_blank_line(op: BlankLine, ctx: EmitCtx) -> str:
 @register_render(Bind, mode='stmt')
 def _render_bind(op: Bind, ctx: EmitCtx) -> str:
   return f'{ctx.ind()}{op.type_decl} {op.name} = {emit_expr(op.expr, ctx)};\n'
+
+
+@register_render(Assign, mode='stmt')
+def _render_assign(op: Assign, ctx: EmitCtx) -> str:
+  return f'{ctx.ind()}{op.target} = {emit_expr(op.value, ctx)};\n'
 
 
 @register_render(IfReturnIfNot, mode='stmt')

--- a/src/srdatalog/ir/codegen/cuda/render/iir_expr.py
+++ b/src/srdatalog/ir/codegen/cuda/render/iir_expr.py
@@ -12,8 +12,23 @@ from srdatalog.ir.dialects.iir.expr.ops import (
   IntLit,
   MemberAccess,
   MemberCall,
+  Parens,
+  Ternary,
   UnaryOp,
 )
+
+
+@register_render(Parens, mode='expr')
+def _render_parens(op: Parens, ctx: EmitCtx) -> str:
+  return f'({emit_expr(op.expr, ctx)})'
+
+
+@register_render(Ternary, mode='expr')
+def _render_ternary(op: Ternary, ctx: EmitCtx) -> str:
+  '''Renders `<cond> ? <then> : <else>` with no surrounding parens.
+  Caller wraps in `Parens(...)` if precedence with the surrounding
+  context requires it.'''
+  return f'{emit_expr(op.cond, ctx)} ? {emit_expr(op.then_, ctx)} : {emit_expr(op.else_, ctx)}'
 
 
 @register_render(IntLit, mode='expr')

--- a/src/srdatalog/ir/dialects/iir/cf/__init__.py
+++ b/src/srdatalog/ir/dialects/iir/cf/__init__.py
@@ -18,6 +18,7 @@ from __future__ import annotations
 from srdatalog.ir.core import Dialect
 from srdatalog.ir.dialects.iir.cf.ops import (
   AddCount,
+  Assign,
   Bind,
   BlankLine,
   Block,
@@ -47,6 +48,7 @@ DIALECT = Dialect(
   name='iir.cf',
   ops=[
     AddCount,
+    Assign,
     BlankLine,
     Block,
     Bind,
@@ -76,6 +78,7 @@ DIALECT = Dialect(
 __all__ = [
   'DIALECT',
   'AddCount',
+  'Assign',
   'BlankLine',
   'Bind',
   'Block',

--- a/src/srdatalog/ir/dialects/iir/cf/ops.py
+++ b/src/srdatalog/ir/dialects/iir/cf/ops.py
@@ -85,6 +85,24 @@ class VarRef(Op):
 
 @final
 @dataclass(frozen=True, slots=True)
+class Assign(Op):
+  '''Assignment statement: `<target> = <value>;`.
+
+  `target` is a string (the var name being assigned). `value` is an
+  expression-shaped Op. Renders to `<target> = <value>;` followed by
+  newline.
+
+  Used for compound forms like `x = x && cond;` or
+  `x = (cond) ? a : b;` that the lowering would otherwise emit as
+  RawString-wrapped C++ statements.
+  '''
+
+  target: str
+  value: Op
+
+
+@final
+@dataclass(frozen=True, slots=True)
 class IfReturnIfNot(Op):
   '''`if (!<cond>) return;` — the validity guard pattern.'''
 

--- a/src/srdatalog/ir/dialects/iir/cf/print.py
+++ b/src/srdatalog/ir/dialects/iir/cf/print.py
@@ -13,6 +13,7 @@ from __future__ import annotations
 
 from srdatalog.ir.dialects.iir.cf.ops import (
   AddCount,
+  Assign,
   Bind,
   BlankLine,
   Block,
@@ -41,6 +42,7 @@ from srdatalog.ir.print_iir import _bool, _ind, _quoted, _str_tuple, print_iir
 
 OPS: tuple[type, ...] = (
   AddCount,
+  Assign,
   BlankLine,
   Bind,
   Block,
@@ -86,6 +88,10 @@ def print_op(op, indent: int = 0) -> str:
 
   if isinstance(op, BlankLine):
     return p + '(blank-line)'
+
+  if isinstance(op, Assign):
+    value = print_iir(op.value, indent + 1)
+    return p + f'(assign #:target {op.target}\n' + p + '  #:value\n' + value + ')'
 
   # --- Bindings & references ---
 

--- a/src/srdatalog/ir/dialects/iir/expr/__init__.py
+++ b/src/srdatalog/ir/dialects/iir/expr/__init__.py
@@ -30,12 +30,14 @@ from srdatalog.ir.dialects.iir.expr.ops import (
   IntLit,
   MemberAccess,
   MemberCall,
+  Parens,
+  Ternary,
   UnaryOp,
 )
 
 DIALECT = Dialect(
   name='iir.expr',
-  ops=[BinOp, IndexExpr, IntLit, MemberAccess, MemberCall, UnaryOp],
+  ops=[BinOp, IndexExpr, IntLit, MemberAccess, MemberCall, Parens, Ternary, UnaryOp],
 )
 
 
@@ -60,5 +62,7 @@ __all__ = [
   'IntLit',
   'MemberAccess',
   'MemberCall',
+  'Parens',
+  'Ternary',
   'UnaryOp',
 ]

--- a/src/srdatalog/ir/dialects/iir/expr/ops.py
+++ b/src/srdatalog/ir/dialects/iir/expr/ops.py
@@ -19,6 +19,38 @@ from srdatalog.ir.core import Op
 
 @final
 @dataclass(frozen=True, slots=True)
+class Parens(Op):
+  '''Explicit parenthesization: `(<expr>)`.
+
+  Renders to `(<expr>)`. Use when the expression must be parenthesized
+  for either C++ precedence correctness OR for byte-equivalence with
+  legacy text-based emitters (which often had explicit parens that
+  precedence rules would otherwise allow to be elided).
+
+  Per docs/stage4_iir_vocabulary.md S4.5: lowerings that previously
+  embedded `'( <subexpr> )'` in RawString text wrap the `<subexpr>`
+  Op in `Parens(...)` to preserve the rendering exactly.
+  '''
+
+  expr: Op
+
+
+@final
+@dataclass(frozen=True, slots=True)
+class Ternary(Op):
+  '''Conditional expression: `<cond> ? <then_> : <else_>`.
+
+  Renders to `<cond> ? <then_> : <else_>` with no surrounding parens.
+  Wrap in `Parens` if precedence with the surrounding context requires it.
+  '''
+
+  cond: Op
+  then_: Op
+  else_: Op
+
+
+@final
+@dataclass(frozen=True, slots=True)
 class IntLit(Op):
   '''Integer literal.
 
@@ -131,6 +163,8 @@ __all__ = [
   'IntLit',
   'MemberAccess',
   'MemberCall',
+  'Parens',
+  'Ternary',
   'UnaryOp',
   'bin_op_chain',
 ]

--- a/src/srdatalog/ir/dialects/iir/expr/print.py
+++ b/src/srdatalog/ir/dialects/iir/expr/print.py
@@ -8,11 +8,22 @@ from srdatalog.ir.dialects.iir.expr.ops import (
   IntLit,
   MemberAccess,
   MemberCall,
+  Parens,
+  Ternary,
   UnaryOp,
 )
 from srdatalog.ir.print_iir import _ind, print_iir
 
-OPS: tuple[type, ...] = (BinOp, IndexExpr, IntLit, MemberAccess, MemberCall, UnaryOp)
+OPS: tuple[type, ...] = (
+  BinOp,
+  IndexExpr,
+  IntLit,
+  MemberAccess,
+  MemberCall,
+  Parens,
+  Ternary,
+  UnaryOp,
+)
 
 
 def print_op(op, indent: int = 0) -> str:
@@ -24,6 +35,31 @@ def print_op(op, indent: int = 0) -> str:
   if isinstance(op, UnaryOp):
     expr = print_iir(op.expr, indent + 1)
     return p + f'(unary-op #:op-str "{op.op_str}"\n' + p + '  #:expr\n' + expr + ')'
+
+  if isinstance(op, Parens):
+    expr = print_iir(op.expr, indent + 1)
+    return p + '(parens\n' + expr + ')'
+
+  if isinstance(op, Ternary):
+    cond = print_iir(op.cond, indent + 1)
+    then_ = print_iir(op.then_, indent + 1)
+    else_ = print_iir(op.else_, indent + 1)
+    return (
+      p
+      + '(ternary\n'
+      + p
+      + '  #:cond\n'
+      + cond
+      + '\n'
+      + p
+      + '  #:then\n'
+      + then_
+      + '\n'
+      + p
+      + '  #:else\n'
+      + else_
+      + ')'
+    )
 
   if isinstance(op, BinOp):
     lhs = print_iir(op.lhs, indent + 1)

--- a/src/srdatalog/ir/dialects/relation/sorted_array/lowerings.py
+++ b/src/srdatalog/ir/dialects/relation/sorted_array/lowerings.py
@@ -24,6 +24,7 @@ import srdatalog.ir.mir.types as mir
 from srdatalog.ir.core import Op
 from srdatalog.ir.dialects.iir.cf import (
   AddCount,
+  Assign,
   Bind,
   BlankLine,
   Block,
@@ -46,7 +47,16 @@ from srdatalog.ir.dialects.iir.cf import (
   TiledBallotBlock,
   VarRef,
 )
-from srdatalog.ir.dialects.iir.expr import BinOp, IndexExpr, IntLit, MemberCall, UnaryOp
+from srdatalog.ir.dialects.iir.expr import (
+  BinOp,
+  IndexExpr,
+  IntLit,
+  MemberAccess,
+  MemberCall,
+  Parens,
+  Ternary,
+  UnaryOp,
+)
 from srdatalog.ir.dialects.iir.expr.ops import bin_op_chain
 
 
@@ -748,21 +758,42 @@ def _lower_root_cj_multi(
       hint_lo = ctx.fresh('hint_lo')
       hint_hi = ctx.fresh('hint_hi')
       loop_inner_stmts.append(Bind(name=hint_lo, expr=VarRef(name=y_idx_var), type_decl='uint32_t'))
+      _num_rows = MemberAccess(obj=VarRef(name=src_view), member='num_rows_')
       loop_inner_stmts.append(
         Bind(
           name=hint_hi,
-          expr=RawString(text=f'{src_view}.num_rows_ - (num_unique_root_keys - {y_idx_var} - 1)'),
+          expr=BinOp(
+            op_str='-',
+            lhs=_num_rows,
+            rhs=Parens(
+              expr=bin_op_chain(
+                '-',
+                [VarRef(name='num_unique_root_keys'), VarRef(name=y_idx_var), IntLit(value=1)],
+              ),
+            ),
+          ),
           type_decl='uint32_t',
         )
       )
       loop_inner_stmts.append(
-        RawString(
-          text=f'{hint_hi} = ({hint_hi} <= {src_view}.num_rows_) ? '
-          f'{hint_hi} : {src_view}.num_rows_;'
+        Assign(
+          target=hint_hi,
+          value=Ternary(
+            cond=Parens(expr=BinOp(op_str='<=', lhs=VarRef(name=hint_hi), rhs=_num_rows)),
+            then_=VarRef(name=hint_hi),
+            else_=_num_rows,
+          ),
         )
       )
       loop_inner_stmts.append(
-        RawString(text=f'{hint_hi} = ({hint_hi} > {hint_lo}) ? {hint_hi} : {src_view}.num_rows_;')
+        Assign(
+          target=hint_hi,
+          value=Ternary(
+            cond=Parens(expr=BinOp(op_str='>', lhs=VarRef(name=hint_hi), rhs=VarRef(name=hint_lo))),
+            then_=VarRef(name=hint_hi),
+            else_=_num_rows,
+          ),
+        )
       )
       loop_inner_stmts.append(
         Bind(
@@ -1398,17 +1429,21 @@ def _lower_negation(
     else:
       check_var = info.var_name
 
+    _not_valid = UnaryOp(
+      op_str='!',
+      expr=MemberCall(obj=VarRef(name=check_var), method='valid', args=()),
+    )
     fold_var = ctx.ws_cartesian_valid_var or ctx.tiled_cartesian_valid_var
     if fold_var:
-      stmts.append(RawString(text=f'{fold_var} = {fold_var} && (!{check_var}.valid());'))
-      stmts.append(body_op)
-    else:
       stmts.append(
-        If(
-          cond=RawString(text=f'!{check_var}.valid()'),
-          body=body_op,
+        Assign(
+          target=fold_var,
+          value=BinOp(op_str='&&', lhs=VarRef(name=fold_var), rhs=Parens(expr=_not_valid)),
         )
       )
+      stmts.append(body_op)
+    else:
+      stmts.append(If(cond=_not_valid, body=body_op))
     return Block(stmts=tuple(stmts))
 
   # Standard path: const_args path not yet lowered here (only the
@@ -1460,17 +1495,21 @@ def _lower_negation(
     )
 
   stmts.append(Bind(name=neg_handle_var, expr=parent_expr))
+  _not_valid = UnaryOp(
+    op_str='!',
+    expr=MemberCall(obj=VarRef(name=neg_handle_var), method='valid', args=()),
+  )
   fold_var = ctx.ws_cartesian_valid_var or ctx.tiled_cartesian_valid_var
   if fold_var:
-    stmts.append(RawString(text=f'{fold_var} = {fold_var} && (!{neg_handle_var}.valid());'))
-    stmts.append(body_op)
-  else:
     stmts.append(
-      If(
-        cond=RawString(text=f'!{neg_handle_var}.valid()'),
-        body=body_op,
+      Assign(
+        target=fold_var,
+        value=BinOp(op_str='&&', lhs=VarRef(name=fold_var), rhs=Parens(expr=_not_valid)),
       )
     )
+    stmts.append(body_op)
+  else:
+    stmts.append(If(cond=_not_valid, body=body_op))
   return Block(stmts=tuple(stmts))
 
 


### PR DESCRIPTION
## Summary

Per [`docs/stage4_iir_vocabulary.md`](docs/stage4_iir_vocabulary.md) Categories E, F, H (clean tier), I.

**Stacked on PR #22**. Single commit (`c76bf5d`); 7 sites cleared.

## New ops

```
iir.expr.Parens(expr)               → '(<expr>)'        explicit grouping
iir.expr.Ternary(cond, then_, else_) → '<c> ? <t> : <e>'  conditional
iir.cf.Assign(target: str, value)   → '<target> = <value>;'  assignment stmt
```

**Why Parens is its own op**: BinOp / UnaryOp / Ternary render without surrounding parens (matches the existing RawString-with-bare-text behavior). When the lowering needs explicit grouping — either for C++ precedence correctness OR for byte-equivalence with legacy text that had explicit parens — it wraps in `Parens(...)`. Avoids the "always-parenthesize" trap that would break byte-equivalence elsewhere.

## Migration

| Cat | Sites | What | Replacement |
|---|---|---|---|
| E | 1 | `src_view.num_rows_ - (...)` | `BinOp('-', MemberAccess(...), Parens(bin_op_chain('-', [...])))` |
| F | 2 | `hint_hi = (X) ? hint_hi : src_view.num_rows_;` | `Assign(target, Ternary(Parens(BinOp(...)), then_, else_))` |
| H | 2 (clean) | `fold = fold && (!check.valid());` | `Assign(fold, BinOp('&&', VarRef(fold), Parens(UnaryOp('!', MemberCall(...)))))` |
| I | 2 | `cond=RawString('!check.valid()')` | `cond=UnaryOp('!', MemberCall(VarRef(check), 'valid', ()))` |

The 3rd Cat H site at line 1070 stays as RawString — its `cond_expr` is the Filter MIR op's user-supplied code field (legitimate Category J).

RawString count in `sorted_array/lowerings.py`: **29 → 22** (7 cleared).

## Stage 4 cumulative progress

| Category | Status | Sites |
|---|---|---|
| A bare identifier | ✅ PR #20 | 1 |
| B member-method call | ✅ PR #21 | 4 |
| C arithmetic expr | ✅ PR #20 | 5 |
| D array index | ✅ PR #21 | 1 |
| E compound arith | ✅ this PR | 1 |
| F ternary expression | ✅ this PR | 2 |
| G if-return/continue | ✅ PR #22 | 6 |
| H boolean fold (clean) | ✅ this PR | 2 |
| I validity-check cond | ✅ this PR | 2 |
| **Cleared so far** | | **24 of 46** |
| H (user-code site) | ⚠ Cat J | 1 |
| J user code | ⚠ legitimate | 1 |
| K tile-dispatch | ⬜ | 2 |
| L multi-line blocks | ⬜ | ~20 (hardest) |
| M handle-alias decls | ⬜ | several |

After this PR, all "expression-shaped" categories are done. Only the multi-line emission blocks (Category L) remain as substantive work.

## Test plan

- [x] `python -m pytest tests/` — **1071 passed, 5 skipped**
- [x] `python -m ruff check src tests` — clean
- [x] `python -m ruff format --check src tests tools examples` — clean
- [x] Smoke verified all renderers produce byte-equivalent output:
  - Cat F: `'hint_hi = (hint_hi > hint_lo) ? hint_hi : src_view.num_rows_;'` ✓
  - Cat E: `'src_view.num_rows_ - (num_unique_root_keys - y_idx - 1)'` ✓
- [x] Byte-equivalence preserved end-to-end

## iir.expr vocabulary so far (8 ops)

- `BinOp` (S4.2) — binary operator with op_str
- `bin_op_chain` (S4.2) — left-fold helper for n-ary chains
- `IndexExpr` (S4.3) — subscript expression
- `MemberAccess` (S4.3) — `obj.member`
- `MemberCall` (S4.3) — `obj.method(args)`
- `IntLit` (S4.4) — integer literal
- `UnaryOp` (S4.4) — unary operator with op_str
- `Parens` (S4.5) — explicit grouping
- `Ternary` (S4.5) — conditional expression

## Stage 4 status

- ✅ S4.0–S4.5 (24/46 sites cleared)
- ⬜ S4.6 — Category L (multi-line emission blocks; hardest tier; ~20 sites)
- ⬜ S4.7 — discipline test pinning RawString count
- ⬜ S4.8 — R1–R5 rewrites
- ⬜ S4.9 — op-level dispatch in PassDriver

🤖 Generated with [Claude Code](https://claude.com/claude-code)