### PR TITLE
Bundle C step 1: encapsulate _PLUGIN_REGISTRY into PluginRegistry class

### DIFF
--- a/docs/milestones.md
+++ b/docs/milestones.md
@@ -159,7 +159,7 @@ below is the index.
 | **S3A.5** | Formalize R1–R5 (sorted_array §11 rewrites) as `Rewrite` instances | ⬜ deferred to Stage 4 | The R1-R5 are entangled with `RawString` construction in lowerings.py. Cleanly extracting them needs the new structured ops Stage 4 introduces. |
 | **S3A.6** | `PassDriver` dependency validation + decorator infra | ✅ Bundle B | `@lowering`/`@rewrite`/`@verifier` decorators + `validate_dependencies()` raises `PassDependencyError` on unmet `consumes`. Op-level dispatch deferred (no production consumer yet). |
 | **S3A.7** | Wire `Dialect.verifier` into PassDriver | ✅ Bundle B | All 6 dialects ship a no-op verifier; `PassDriver.verify_all` walks them. Real per-dialect invariants land incrementally. |
-| **S3A.8** | Per-`Codegen` plugin registry; explicit `register_*` calls (no side effects) | ⬜ Bundle C | **A6 + A7.** |
+| **S3A.8** | Per-`Codegen` plugin registry; explicit `register_*` calls (no side effects) | 🟡 Bundle C step 1 ✅ | **A6 + A7.** A7 ✅ since `register_default_plugins()` (no import-time side effects). A6 step 1 ✅: `_PLUGIN_REGISTRY` encapsulated into `PluginRegistry` class with module-level singleton; new code can hold its own instance. Full per-`Codegen` threading (kill the singleton) deferred — needs `EmitCtx` to carry a `PluginRegistry` reference, which ripples to ~15 `context.py` shim sites. |
 | **S3A.9** | (Cleanup) no double `compile_to_hir`; relocate `block_group.py` emit | ✅ PR #13 + Bundle A | |
 
 **S3A acceptance gate:**
@@ -180,18 +180,20 @@ below is the index.
 
 ### Stage 3B — unify HIR/MIR onto the Op/Dialect framework (planning only)
 
-**Status:** *planning only.* Land Stage 3A first. After 3A, re-evaluate
-whether 3B is the right next move or whether HIR/MIR should stay as their
-own frozen-dataclass IRs with typed adapters at the framework boundary.
+**Status:** *planning only.* Stage 3A landed. **Scope correction (post-Stage-4 close-out):** S3B.1 (HIR onto Op) is the **wrong abstraction** — HIR types (`HirProgram`, `HirStratum`, `HirRuleVariant`, `RelationDecl`) are *planning records* with mutable list fields that get filled in by passes (e.g., `strata: list[HirStratum]`, `required_indices: dict[str, list[list[int]]]`). Forcing them onto `frozen=True, slots=True` `Op` would require rebuilding the whole HIR on every pass touch — the semantics are wrong. HIR should stay as plain dataclass planning records with typed adapters at the framework boundary. **Only MIR (60 op classes) is the right target for Op-promotion.**
 
-| ID | Description | Discipline rule |
-|---|---|---|
-| **S3B.1** | Convert HIR types in [hir/types.py](../src/srdatalog/ir/hir/types.py) to `Op`/`Type` subclasses. | D1, D2, D3, D4, D11 |
-| **S3B.2** | Convert MIR types in [mir/types.py](../src/srdatalog/ir/mir/types.py) similarly. | D1, D2, D3, D4, D11 |
-| **S3B.3** | Replace the ~15 `dataclasses.replace`-style mutation sites with strategy combinators from [core/strategy.py](../src/srdatalog/ir/core/strategy.py). | D6, D7 |
-| **S3B.4** | Migrate the monolithic [hir/lower.py](../src/srdatalog/ir/hir/lower.py) into per-op `Lowering`s registered on the HIR dialect (uses S3A.4 + S3A.6 infra). | (composability) |
-| **S3B.5** | Lift HIR passes (`stratify`, `split`, `semi_naive`, `plan`, `index`, `rule_rewrite`) onto `core/passes.py`. | unifies pass infra |
-| **S3B.6** | Replace the hardcoded sequence in [pipeline.py:80-88](../src/srdatalog/ir/pipeline.py#L80-L88) with `compiler.run(passes=[...])`, allowing external code to reorder/insert/skip passes. | (composability) |
+| ID | Description | Discipline rule | Status |
+|---|---|---|---|
+| ~~**S3B.1**~~ | ~~Convert HIR types to `Op`/`Type` subclasses.~~ | — | ❌ **Dropped — wrong abstraction.** HIR types are planning records, not op trees; see scope correction above. |
+| **S3B.2** | Convert MIR types in [mir/types.py](../src/srdatalog/ir/mir/types.py) to `@dataclass(frozen=True, slots=True)` + `Op` subclass. 60 classes; risk is mutation breakage (`pipeline.append(...)`-style sites). | D1, D2, D3, D4, D11 | ⬜ |
+| **S3B.3** | Replace the ~15 `dataclasses.replace`-style mutation sites with strategy combinators from [core/strategy.py](../src/srdatalog/ir/core/strategy.py). | D6, D7 | ⬜ |
+| **S3B.4** | Migrate the monolithic [hir/lower.py](../src/srdatalog/ir/hir/lower.py) into per-op `Lowering`s registered on the HIR dialect (uses S3A.4 + S3A.6 infra). | (composability) | ⬜ |
+| **S3B.5** | Lift HIR passes (`stratify`, `split`, `semi_naive`, `plan`, `index`, `rule_rewrite`) onto `core/passes.py`. | unifies pass infra | ⬜ |
+| **S3B.6** | Replace the hardcoded sequence in [pipeline.py:80-88](../src/srdatalog/ir/pipeline.py#L80-L88) with `compiler.run(passes=[...])`, allowing external code to reorder/insert/skip passes. | (composability) | ⬜ |
+
+S3B.4–S3B.6 cover HIR's *passes* (which are program-level transformations, fitting `Lowering`/`Rewrite` shape) — these still apply even though S3B.1 (HIR types onto Op) was dropped. The split: HIR types stay as plain records; HIR *passes* go onto the framework.
+
+After S3B.2 lands, S4.8 (R1–R5 from `ir_lowering_semantics.md` §11 as `@rewrite` instances on MIR) becomes tractable.
 
 **Honest scope note (added after Bundle B planning):** Stage 3A's
 "framework realization" is **structural** — the registry holds

--- a/src/srdatalog/ir/codegen/cuda/plugin.py
+++ b/src/srdatalog/ir/codegen/cuda/plugin.py
@@ -141,56 +141,206 @@ def new_default_plugin() -> IndexPlugin:
 
 
 # -----------------------------------------------------------------------------
-# Global registry
+# PluginRegistry — encapsulated state (Bundle C / S3A.8 close-out)
 # -----------------------------------------------------------------------------
 
-_PLUGIN_REGISTRY: dict[str, IndexPlugin] = {}
-_DEFAULT_PLUGIN: IndexPlugin = new_default_plugin()
+
+class PluginRegistry:
+  '''A per-instance plugin registry. Each instance owns:
+
+    * `_by_type`: cpp_type -> IndexPlugin (the registered plugins).
+    * `_default`: the fallback plugin for `index_type=""` and unknown types.
+
+  This is the encapsulation step of the A6 (no module-global state)
+  cleanup. Today, a single module-level singleton (`_default_registry`)
+  backs the legacy module-function API (`register_index_plugin`,
+  `resolve_plugin`, `plugin_gen_X`). New code can construct its own
+  `PluginRegistry` and call methods on it directly — and a future Compiler
+  instance can hold its own `PluginRegistry` to fully eliminate the
+  module-global state per the dialect contract.
+
+  Methods mirror the legacy module-level functions one-for-one so the
+  refactor is mechanical at the call sites that adopt the instance
+  form.
+  '''
+
+  def __init__(self, default: IndexPlugin | None = None) -> None:
+    self._by_type: dict[str, IndexPlugin] = {}
+    self._default: IndexPlugin = default if default is not None else new_default_plugin()
+
+  # --- Registration / lookup ----------------------------------------
+
+  def register(self, plugin: IndexPlugin) -> None:
+    '''Register `plugin` keyed by its `cpp_type`. Idempotent: re-registering
+    the same `cpp_type` overwrites the previous binding (matches Nim's
+    compile-time registration semantics, which the CUDA emit was ported
+    from).'''
+    self._by_type[plugin.cpp_type] = plugin
+
+  def resolve(self, index_type: str) -> IndexPlugin:
+    '''Look up by C++ type. Empty string OR unknown type returns the
+    default plugin. Substring match (either direction) lets partial type
+    strings resolve, mirroring Nim's resolvePlugin behavior.'''
+    if not index_type:
+      return self._default
+    if index_type in self._by_type:
+      return self._by_type[index_type]
+    for key, plugin in self._by_type.items():
+      if key in index_type or index_type in key:
+        return plugin
+    return self._default
+
+  # --- Introspection (for tests + diagnostics) ----------------------
+
+  def __contains__(self, cpp_type: str) -> bool:
+    '''True iff `cpp_type` has a registered plugin (does NOT consider
+    substring fallback; for that, use `resolve(cpp_type) is not default`).'''
+    return cpp_type in self._by_type
+
+  def registered_types(self) -> frozenset[str]:
+    '''Snapshot of all registered cpp_types (defensive copy — mutating
+    the result has no effect on the registry).'''
+    return frozenset(self._by_type)
+
+  # ------------------------------------------------------------------
+
+  def extra_headers_for_types(self, index_types: list[str]) -> list[str]:
+    '''Collect unique C++ headers declared by the plugins that
+    `index_types` resolve to. Empty strings are skipped.'''
+    out: list[str] = []
+    for t in index_types:
+      if not t:
+        continue
+      for h in self.resolve(t).cpp_headers:
+        if h not in out:
+          out.append(h)
+    return out
+
+  # --- Expression-level dispatch (mirror module-level wrappers) -----
+
+  def gen_root_handle(self, view_var: str, index_type: str = '') -> str:
+    return self.resolve(index_type).gen_root_handle(view_var)
+
+  def gen_prefix(
+    self,
+    handle: str,
+    key: str,
+    view_var: str,
+    mode: PrefixMode,
+    index_type: str = '',
+  ) -> str:
+    return self.resolve(index_type).gen_prefix(handle, key, view_var, mode)
+
+  def gen_prefix_lower_bound(
+    self,
+    handle: str,
+    key: str,
+    view_var: str,
+    mode: PrefixMode,
+    index_type: str = '',
+  ) -> str:
+    return self.resolve(index_type).gen_prefix_lower_bound(handle, key, view_var, mode)
+
+  def gen_degree(self, handle: str, index_type: str = '') -> str:
+    return self.resolve(index_type).gen_degree(handle)
+
+  def gen_valid(self, handle: str, index_type: str = '') -> str:
+    return self.resolve(index_type).gen_valid(handle)
+
+  def gen_get_value_at(self, handle: str, view_var: str, idx: str, index_type: str = '') -> str:
+    return self.resolve(index_type).gen_get_value_at(handle, view_var, idx)
+
+  def gen_get_value(self, view_var: str, col: int, pos: str, index_type: str = '') -> str:
+    return self.resolve(index_type).gen_get_value(view_var, col, pos)
+
+  def gen_child(self, handle: str, idx: str, index_type: str = '') -> str:
+    return self.resolve(index_type).gen_child(handle, idx)
+
+  def gen_child_range(
+    self,
+    handle: str,
+    pos: str,
+    key: str,
+    tile: str,
+    view_var: str,
+    index_type: str = '',
+  ) -> str:
+    return self.resolve(index_type).gen_child_range(handle, pos, key, tile, view_var)
+
+  def gen_iterators(self, handle: str, view_var: str, index_type: str = '') -> str:
+    return self.resolve(index_type).gen_iterators(handle, view_var)
+
+  def view_count(self, version: str, index_type: str = '') -> int:
+    return self.resolve(index_type).view_count(version)
+
+  def gen_host_view_setup(
+    self,
+    idx_expr: str,
+    version: str,
+    index_type: str = '',
+  ) -> list[str]:
+    return self.resolve(index_type).gen_host_view_setup(idx_expr, version)
+
+
+# -----------------------------------------------------------------------------
+# Module-level default registry (legacy API back-compat)
+# -----------------------------------------------------------------------------
+#
+# All module-level functions below operate on this singleton. Tests and
+# new per-Compiler code can construct their own PluginRegistry instances
+# and call methods on those directly — see `PluginRegistry` above.
+
+_default_registry: PluginRegistry = PluginRegistry()
+
+# Back-compat alias — refers to the same dict the registry uses
+# internally. Existing tests that capture/restore registry state via
+# direct dict access continue to work; new code should call methods
+# on the PluginRegistry instance instead.
+_PLUGIN_REGISTRY: dict[str, IndexPlugin] = _default_registry._by_type
+
+
+def get_default_registry() -> PluginRegistry:
+  '''Public accessor for the module-level default registry. Intended for
+  callers that want to inspect or temporarily replace the registry (e.g.
+  test fixtures). Production code should call `register_index_plugin`
+  / `resolve_plugin` / `plugin_gen_X` for back-compat, or hold its own
+  `PluginRegistry` instance.'''
+  return _default_registry
 
 
 def register_index_plugin(plugin: IndexPlugin) -> None:
-  '''Register a plugin by its `cpp_type` string. Called from each index
-  module at import time (mirroring Nim's compile-time registration).
-  '''
-  _PLUGIN_REGISTRY[plugin.cpp_type] = plugin
+  '''Register a plugin on the module-level default registry. Called by
+  `codegen.cuda.register_default_plugins()` at compile entry-time;
+  no module-import-time side effects (per S3A.8 / A7 cleanup).'''
+  _default_registry.register(plugin)
 
 
 def resolve_plugin(index_type: str) -> IndexPlugin:
-  '''Look up plugin by C++ type; empty string / unknown type returns the
-  default (DSAI). Substring match lets partial type strings resolve, matching
-  Nim's resolvePlugin behavior.
-  '''
-  if not index_type:
-    return _DEFAULT_PLUGIN
-  if index_type in _PLUGIN_REGISTRY:
-    return _PLUGIN_REGISTRY[index_type]
-  for key, plugin in _PLUGIN_REGISTRY.items():
-    if key in index_type or index_type in key:
-      return plugin
-  return _DEFAULT_PLUGIN
+  '''Look up by C++ type on the module-level default registry. Empty
+  string / unknown type returns the default (DSAI). Substring match
+  lets partial type strings resolve — mirrors Nim's resolvePlugin.'''
+  return _default_registry.resolve(index_type)
 
 
 def get_extra_headers_for_types(index_types: list[str]) -> list[str]:
   '''Collect unique C++ headers declared by the plugins resolving from
   `index_types`. Empty strings are skipped.'''
-  out: list[str] = []
-  for t in index_types:
-    if not t:
-      continue
-    for h in resolve_plugin(t).cpp_headers:
-      if h not in out:
-        out.append(h)
-  return out
+  return _default_registry.extra_headers_for_types(index_types)
 
 
 # -----------------------------------------------------------------------------
 # Plugin-dispatched expression wrappers (the public API every other
 # codegen module calls into). `index_type=""` always hits the DSAI default.
+#
+# All thin shims over `_default_registry`'s methods — kept as
+# module-level functions for back-compat with the many call sites in
+# `codegen/cuda/context.py` etc. New code should prefer holding its own
+# PluginRegistry and calling methods on it directly.
 # -----------------------------------------------------------------------------
 
 
-def plugin_gen_root_handle(view_var: str, index_type: str = "") -> str:
-  return resolve_plugin(index_type).gen_root_handle(view_var)
+def plugin_gen_root_handle(view_var: str, index_type: str = '') -> str:
+  return _default_registry.gen_root_handle(view_var, index_type)
 
 
 def plugin_gen_prefix(
@@ -198,9 +348,9 @@ def plugin_gen_prefix(
   key: str,
   view_var: str,
   mode: PrefixMode,
-  index_type: str = "",
+  index_type: str = '',
 ) -> str:
-  return resolve_plugin(index_type).gen_prefix(handle, key, view_var, mode)
+  return _default_registry.gen_prefix(handle, key, view_var, mode, index_type)
 
 
 def plugin_gen_prefix_lower_bound(
@@ -208,34 +358,29 @@ def plugin_gen_prefix_lower_bound(
   key: str,
   view_var: str,
   mode: PrefixMode,
-  index_type: str = "",
+  index_type: str = '',
 ) -> str:
-  return resolve_plugin(index_type).gen_prefix_lower_bound(
-    handle,
-    key,
-    view_var,
-    mode,
-  )
+  return _default_registry.gen_prefix_lower_bound(handle, key, view_var, mode, index_type)
 
 
-def plugin_gen_degree(handle: str, index_type: str = "") -> str:
-  return resolve_plugin(index_type).gen_degree(handle)
+def plugin_gen_degree(handle: str, index_type: str = '') -> str:
+  return _default_registry.gen_degree(handle, index_type)
 
 
-def plugin_gen_valid(handle: str, index_type: str = "") -> str:
-  return resolve_plugin(index_type).gen_valid(handle)
+def plugin_gen_valid(handle: str, index_type: str = '') -> str:
+  return _default_registry.gen_valid(handle, index_type)
 
 
-def plugin_gen_get_value_at(handle: str, view_var: str, idx: str, index_type: str = "") -> str:
-  return resolve_plugin(index_type).gen_get_value_at(handle, view_var, idx)
+def plugin_gen_get_value_at(handle: str, view_var: str, idx: str, index_type: str = '') -> str:
+  return _default_registry.gen_get_value_at(handle, view_var, idx, index_type)
 
 
-def plugin_gen_get_value(view_var: str, col: int, pos: str, index_type: str = "") -> str:
-  return resolve_plugin(index_type).gen_get_value(view_var, col, pos)
+def plugin_gen_get_value(view_var: str, col: int, pos: str, index_type: str = '') -> str:
+  return _default_registry.gen_get_value(view_var, col, pos, index_type)
 
 
-def plugin_gen_child(handle: str, idx: str, index_type: str = "") -> str:
-  return resolve_plugin(index_type).gen_child(handle, idx)
+def plugin_gen_child(handle: str, idx: str, index_type: str = '') -> str:
+  return _default_registry.gen_child(handle, idx, index_type)
 
 
 def plugin_gen_child_range(
@@ -244,25 +389,25 @@ def plugin_gen_child_range(
   key: str,
   tile: str,
   view_var: str,
-  index_type: str = "",
+  index_type: str = '',
 ) -> str:
-  return resolve_plugin(index_type).gen_child_range(handle, pos, key, tile, view_var)
+  return _default_registry.gen_child_range(handle, pos, key, tile, view_var, index_type)
 
 
-def plugin_gen_iterators(handle: str, view_var: str, index_type: str = "") -> str:
-  return resolve_plugin(index_type).gen_iterators(handle, view_var)
+def plugin_gen_iterators(handle: str, view_var: str, index_type: str = '') -> str:
+  return _default_registry.gen_iterators(handle, view_var, index_type)
 
 
-def plugin_view_count(version: str, index_type: str = "") -> int:
-  return resolve_plugin(index_type).view_count(version)
+def plugin_view_count(version: str, index_type: str = '') -> int:
+  return _default_registry.view_count(version, index_type)
 
 
 def plugin_gen_host_view_setup(
   idx_expr: str,
   version: str,
-  index_type: str = "",
+  index_type: str = '',
 ) -> list[str]:
-  return resolve_plugin(index_type).gen_host_view_setup(idx_expr, version)
+  return _default_registry.gen_host_view_setup(idx_expr, version, index_type)
 
 
 # -----------------------------------------------------------------------------

--- a/tests/test_cuda_plugin.py
+++ b/tests/test_cuda_plugin.py
@@ -188,6 +188,93 @@ def test_chained_prefix_with_last_lower_bound():
   )
 
 
+# -----------------------------------------------------------------------------
+# PluginRegistry instance form (Bundle C — encapsulated state)
+# -----------------------------------------------------------------------------
+
+
+def test_registry_fresh_instance_resolves_to_default():
+  '''A fresh PluginRegistry has DSAI as its default and no registered
+  plugins; resolve("") and resolve(unknown) both return DSAI.'''
+  from srdatalog.ir.codegen.cuda.plugin import PluginRegistry
+
+  reg = PluginRegistry()
+  assert reg.resolve("").name == "DeviceSortedArrayIndex"
+  assert reg.resolve("Some::Unknown::Index").name == "DeviceSortedArrayIndex"
+  assert reg.registered_types() == frozenset()
+
+
+def test_registry_register_then_resolve_exact():
+  from srdatalog.ir.codegen.cuda.plugin import PluginRegistry
+
+  reg = PluginRegistry()
+  custom = IndexPlugin(
+    name="MyIndex",
+    cpp_type="My::Index",
+    cpp_headers=["my_index.h"],
+    gen_root_handle=lambda v: f"MyHandle({v})",
+  )
+  reg.register(custom)
+  assert reg.resolve("My::Index").name == "MyIndex"
+  assert reg.gen_root_handle("v", "My::Index") == "MyHandle(v)"
+  assert "My::Index" in reg
+  assert reg.registered_types() == frozenset({"My::Index"})
+
+
+def test_registry_substring_match_resolves_partial_type():
+  '''resolve("My::Index<int, 4>") matches the registered "My::Index"
+  because of the substring fallback (mirrors Nim's resolvePlugin).'''
+  from srdatalog.ir.codegen.cuda.plugin import PluginRegistry
+
+  reg = PluginRegistry()
+  reg.register(
+    IndexPlugin(name="Mine", cpp_type="My::Index", gen_degree=lambda h: f"{h}.deg_mine()")
+  )
+  assert reg.resolve("My::Index<int, 4>").name == "Mine"
+  assert reg.gen_degree("h", "My::Index<int, 4>") == "h.deg_mine()"
+
+
+def test_registry_register_is_idempotent_overwrite():
+  '''Re-registering the same cpp_type overwrites the previous entry.'''
+  from srdatalog.ir.codegen.cuda.plugin import PluginRegistry
+
+  reg = PluginRegistry()
+  reg.register(IndexPlugin(name="V1", cpp_type="X"))
+  reg.register(IndexPlugin(name="V2", cpp_type="X"))
+  assert reg.resolve("X").name == "V2"
+  assert reg.registered_types() == frozenset({"X"})
+
+
+def test_registry_extra_headers_for_types_dedupes_and_skips_empty():
+  from srdatalog.ir.codegen.cuda.plugin import PluginRegistry
+
+  reg = PluginRegistry()
+  reg.register(IndexPlugin(name="A", cpp_type="A_T", cpp_headers=["a.h", "shared.h"]))
+  reg.register(IndexPlugin(name="B", cpp_type="B_T", cpp_headers=["b.h", "shared.h"]))
+  got = reg.extra_headers_for_types(["", "A_T", "B_T", "A_T"])
+  assert got == ["a.h", "shared.h", "b.h"]
+
+
+def test_registry_instances_are_isolated():
+  '''Two PluginRegistry instances do not share state.'''
+  from srdatalog.ir.codegen.cuda.plugin import PluginRegistry
+
+  reg_a = PluginRegistry()
+  reg_b = PluginRegistry()
+  reg_a.register(IndexPlugin(name="OnlyInA", cpp_type="A::Only"))
+  assert "A::Only" in reg_a
+  assert "A::Only" not in reg_b
+  assert reg_b.resolve("A::Only").name == "DeviceSortedArrayIndex"
+
+
+def test_get_default_registry_returns_singleton():
+  '''The module-level default registry is a singleton; back-compat
+  module functions all delegate to it.'''
+  from srdatalog.ir.codegen.cuda.plugin import get_default_registry
+
+  assert get_default_registry() is get_default_registry()
+
+
 if __name__ == "__main__":
   import inspect
 

--- a/tests/test_ir_no_import_side_effects.py
+++ b/tests/test_ir_no_import_side_effects.py
@@ -4,10 +4,15 @@ Per docs/stage3a_execution_plan.md §6.1: importing a module under
 `ir/dialects/` must not mutate state in any *other* module. The
 historical violation: importing `srdatalog.ir.dialects.relation.d2l`
 triggered a side-effect import of `d2l/cuda.py`, which called
-`register_index_plugin(two_level_plugin)` and mutated
-`codegen/cuda/plugin._PLUGIN_REGISTRY`. After S3A.8 the registration
-is explicit (`codegen.cuda.register_default_plugins()`); importing
-the dialect alone does nothing to the codegen registry.
+`register_index_plugin(two_level_plugin)` and mutated the codegen
+plugin registry. After S3A.8 the registration is explicit
+(`codegen.cuda.register_default_plugins()`); importing the dialect
+alone does nothing to the codegen registry.
+
+Bundle C (PluginRegistry encapsulation) replaced the bare
+`_PLUGIN_REGISTRY` dict with a `PluginRegistry` class — these tests
+now read state via `get_default_registry().registered_types()` /
+`in get_default_registry()` instead of poking the private dict.
 
 The test runs in a subprocess because Python caches modules — a
 second import of d2l in the same process is a no-op even if the
@@ -42,14 +47,14 @@ def test_d2l_import_does_not_mutate_codegen_plugin_registry():
 import sys
 
 # Snapshot before any d2l-related imports.
-import srdatalog.ir.codegen.cuda.plugin as p
-before = dict(p._PLUGIN_REGISTRY)
+from srdatalog.ir.codegen.cuda.plugin import get_default_registry
+before = get_default_registry().registered_types()
 
 # Import the dialect.
 import srdatalog.ir.dialects.relation.d2l  # noqa: F401
 
 # Snapshot after.
-after = dict(p._PLUGIN_REGISTRY)
+after = get_default_registry().registered_types()
 
 if before != after:
     added = set(after) - set(before)
@@ -72,12 +77,12 @@ def test_d2l_cuda_module_import_does_not_mutate_registry():
   code = """
 import sys
 
-import srdatalog.ir.codegen.cuda.plugin as p
-before = dict(p._PLUGIN_REGISTRY)
+from srdatalog.ir.codegen.cuda.plugin import get_default_registry
+before = get_default_registry().registered_types()
 
 import srdatalog.ir.dialects.relation.d2l.cuda  # noqa: F401
 
-after = dict(p._PLUGIN_REGISTRY)
+after = get_default_registry().registered_types()
 
 if before != after:
     print(f'FAIL: importing d2l.cuda mutated registry. diff={set(after) ^ set(before)}',
@@ -96,10 +101,10 @@ def test_register_default_plugins_does_register_d2l():
   code = """
 import sys
 
-import srdatalog.ir.codegen.cuda.plugin as p
+from srdatalog.ir.codegen.cuda.plugin import get_default_registry
 import srdatalog.ir.dialects.relation.d2l.cuda  # safe per the test above
 
-before = 'SRDatalog::GPU::Device2LevelIndex' in p._PLUGIN_REGISTRY
+before = 'SRDatalog::GPU::Device2LevelIndex' in get_default_registry()
 if before:
     print(f'FAIL: d2l already registered before explicit call', file=sys.stderr)
     sys.exit(1)
@@ -107,7 +112,7 @@ if before:
 from srdatalog.ir.codegen.cuda import register_default_plugins
 register_default_plugins()
 
-if 'SRDatalog::GPU::Device2LevelIndex' not in p._PLUGIN_REGISTRY:
+if 'SRDatalog::GPU::Device2LevelIndex' not in get_default_registry():
     print(f'FAIL: register_default_plugins did not register d2l', file=sys.stderr)
     sys.exit(1)
 print('OK')
@@ -136,8 +141,8 @@ prog = Program(rules=[
     (path(X, Z) <= edge(X, Y) & path(Y, Z)).named('Rec'),
 ])
 
-import srdatalog.ir.codegen.cuda.plugin as p
-before = 'SRDatalog::GPU::Device2LevelIndex' in p._PLUGIN_REGISTRY
+from srdatalog.ir.codegen.cuda.plugin import get_default_registry
+before = 'SRDatalog::GPU::Device2LevelIndex' in get_default_registry()
 if before:
     print('FAIL: d2l already registered before compile_program', file=sys.stderr)
     sys.exit(1)
@@ -147,7 +152,7 @@ from srdatalog.ir.pipeline import compile_program
 # api.compile_kernel_body which calls register_default_plugins().
 compile_program(prog, 'TestProj')
 
-if 'SRDatalog::GPU::Device2LevelIndex' not in p._PLUGIN_REGISTRY:
+if 'SRDatalog::GPU::Device2LevelIndex' not in get_default_registry():
     print('FAIL: d2l not registered after compile_program', file=sys.stderr)
     sys.exit(1)
 print('OK')


### PR DESCRIPTION
## Summary

A6 cleanup half-step. Module-global `_PLUGIN_REGISTRY` and `_DEFAULT_PLUGIN` in `codegen/cuda/plugin.py` are now an instance of a new `PluginRegistry` class, with a module-level singleton `_default_registry` backing the legacy module-function API.

**Stacked on PR #25.** Single commit (`7ad4cd4`).

## Why this matters

* **Testability.** Tests can construct their own `PluginRegistry` and exercise it in isolation — no global-state save/restore dance. 7 new tests cover the instance form directly.
* **Future per-Compiler isolation.** A `Compiler` instance can eventually hold its own `PluginRegistry` (threading via `EmitCtx`); the API call-shape stays identical. This PR doesn't do the threading — that's the second step, blocked on `EmitCtx` already carrying enough state for ~15 `context.py` shim sites to switch over.
* **No production behavior change.** All 12 `plugin_gen_X` wrappers + `register_index_plugin`/`resolve_plugin`/`get_extra_headers_for_types` are preserved as module functions delegating to `_default_registry`. A back-compat `_PLUGIN_REGISTRY` module attribute aliases the registry's internal dict so existing tests that capture/restore state by direct dict access continue to work.

## API additions

```python
class PluginRegistry:
    def __init__(self, default: IndexPlugin | None = None) -> None: ...

    # Registration / lookup
    def register(self, plugin: IndexPlugin) -> None: ...
    def resolve(self, index_type: str) -> IndexPlugin: ...
    def extra_headers_for_types(self, index_types: list[str]) -> list[str]: ...

    # Introspection
    def __contains__(self, cpp_type: str) -> bool: ...
    def registered_types(self) -> frozenset[str]: ...

    # Method-form mirrors of all 12 plugin_gen_X wrappers
    def gen_root_handle(self, view_var: str, index_type: str = '') -> str: ...
    def gen_prefix(self, handle, key, view_var, mode, index_type='') -> str: ...
    # ... etc

def get_default_registry() -> PluginRegistry: ...
```

## What's deferred (Bundle C step 2)

Full per-`Compiler` threading — i.e. eliminating the singleton entirely. Requires:
1. Adding a `plugin_registry: PluginRegistry` field to `EmitCtx`.
2. Switching ~15 `context.py` shim sites + the `complete_runner.py` callsite to read `ctx.plugin_registry.gen_X(...)` instead of `plugin_gen_X(...)`.
3. Tearing down the module-level singleton + back-compat alias.

Not done in this PR because the threading ripples wide; this step lays the structural groundwork (the class exists; the API call-shape is decided).

## milestones.md updates

- **S3A.8** marked 🟡 (step 1 ✅; full per-Codegen threading deferred). Both A7 and A6-step-1 are now done.
- **Stage 3B scope correction** (significant): **S3B.1 (HIR onto Op) dropped as wrong abstraction.** HIR types are mutable planning records (`HirProgram.strata: list[HirStratum]`, `HirStratum.required_indices: dict`), not op trees. Forcing them onto `frozen=True, slots=True` `Op` would require rebuilding the whole HIR on every pass touch — wrong semantics. **Only MIR (60 op classes) is the right Op-promotion target.** S3B.4–S3B.6 (HIR *passes* onto framework) still apply — the split is "HIR types stay as records; HIR passes go onto the framework."

## Test plan

- [x] `python -m pytest` — **1098 passed, 4 skipped** (was 1091; +7 new PluginRegistry tests).
- [x] `python -m ruff check src tests` — clean.
- [x] `python -m ruff format --check src tests tools examples` — clean.
- [x] All existing `_PLUGIN_REGISTRY` direct-poking tests still pass via the back-compat alias.
- [x] Side-effects discipline tests updated to use `get_default_registry().registered_types()` instead of `_PLUGIN_REGISTRY` (cleaner; no implementation-detail coupling).

🤖 Generated with [Claude Code](https://claude.com/claude-code)