### PR TITLE
Layer 0: redesign package — 8 design docs (architectural rescope)

### DIFF
--- a/docs/code_discipline.md
+++ b/docs/code_discipline.md
@@ -1,0 +1,298 @@
+---
+orphan: true
+---
+
+# Code Discipline — Forbidden, Required, Enforced
+
+This is the contract that prevents the redesign from regressing into
+the "framework on top of imperative monolith" anti-pattern that
+[`compiler_redesign.md`](compiler_redesign.md) §1 diagnoses.
+
+**Sign-off rule:** every PR after Layer 0 (this redesign package) must
+satisfy every requirement here. CI failures on discipline tests are
+**hard blocks** — only an explicit override comment from the project
+owner unblocks them, and the override must include reasoning recorded
+in the PR.
+
+## 1. Target code structure
+
+Every file's location is determined by its role. Adding a file to the
+wrong directory fails CI.
+
+```
+src/srdatalog/
+  core/                          # Framework ONLY. No dialect knowledge.
+    op.py                        # Op, Type bases
+    dialect.py                   # Dialect, Compiler, registration
+    passes.py                    # LoweringPass, RewritePass, ProgramPass
+    lower_ctx.py                 # Small LowerCtx (5 fields, frozen)
+    strategy.py                  # bottom_up/top_down/repeat combinators
+    plugin.py                    # Entry-point discovery, register_plugin
+
+  dialects/                      # Every dialect. Built-in AND plugin-installed.
+    hir/
+      types.py                   # Planning records (NOT Op-subclassed)
+      passes/                    # ONE FILE PER PASS
+        stratify.py
+        split.py
+        semi_naive.py
+        plan.py
+        index.py
+        temprel.py
+        temp_index.py
+    mir/
+      types.py                   # Generic MIR ops (Op-subclassed, frozen)
+      pragma_ops/                # ONE FILE PER WRAP OP
+        dedup_gate.py
+        block_group_root.py
+        ws_scope.py
+    iir/
+      cf/{ops,print,__init__}.py
+      expr/{ops,print,__init__}.py
+    relation/
+      sorted_array/
+        ops.py                   # Op definitions ONLY
+        types.py                 # Type definitions ONLY
+        print.py                 # Print form ONLY
+        lowerings/               # ONE FILE PER MIR OP
+          lower_mir_scan.py
+          lower_mir_filter.py
+          lower_mir_insert_into.py
+          ...
+        rewrites.py              # @rewrite registrations only
+      d2l/                       # Same shape as sorted_array
+    parallel/
+      data/                      # ParallelFor, GridStrideLoop
+      block_group/               # NEW sub-dialect (Phase 2C)
+      atomic_ws/                 # NEW sub-dialect (Phase 2C)
+
+  codegen/
+    cuda/
+      render/                    # ONE FILE PER DIALECT
+        iir_cf.py
+        iir_expr.py
+        sorted_array.py
+        d2l.py
+        parallel_data.py
+        parallel_block_group.py  # NEW
+        parallel_atomic_ws.py    # NEW
+      pass.py                    # CudaRenderPass
+
+  pragmas/                       # Each pragma is a plugin module. INCLUDING built-ins.
+    dedup_hash.py                # @pragma(name="dedup_hash", on=mir.ExecutePipeline)
+    block_group.py
+    work_stealing.py
+    tiled_cartesian.py
+
+  pipeline.py                    # ONLY DEFAULT_PIPELINE definition + entry
+  dsl.py                         # Default Python DSL frontend (also a plugin)
+  __init__.py                    # Compiler.with_default_plugins()
+```
+
+**Three location rules:**
+
+1. **`core/` knows nothing about specific dialects, ops, pragmas, or
+   targets.** Adding a `from srdatalog.ir.dialects` import to any file
+   in `core/` fails CI.
+2. **One concept per file.** `lowerings/lower_mir_scan.py` lowers
+   `mir.Scan` and nothing else. No 2500-LOC files.
+3. **Built-in pragmas live in `pragmas/`, not buried in dialect
+   lowerings.** Each pragma is a plugin module. The DSL
+   `Rule(pragmas={"dedup_hash": True})` works because
+   `pragmas/dedup_hash.py` is auto-loaded.
+
+## 2. Forbidden code shapes (CI-enforced)
+
+Each row gets a discipline test in `tests/test_discipline_*.py`.
+**A test failure here is a hard PR block.**
+
+| ID | Forbidden pattern | Why | Discipline test |
+|---|---|---|---|
+| **D1** | `if ctx.<pragma>:` (or any pragma name) outside `pragmas/<pragma>.py` | Pragma flags are partial-evaluation triggers, not branch keys. They live in ONE place. | `test_no_pragma_flags_outside_pragma_modules` — greps `ctx\.<pragma_name>\b` across `src/`, allowlist = `pragmas/<pragma>.py` |
+| **D2** | Direct call to `lower_scan_pipeline(...)` or any monolith lowering function | Production must go through `Compiler.run(pipeline=...)`. No bypass. | `test_no_direct_monolith_lowering_calls` — after Layer 3, `lower_scan_pipeline` doesn't exist; during migration, `USE_DECLARATIVE` is ratchet-only |
+| **D3** | `isinstance(op, mir.X)` dispatch chain | Cross-dialect dispatch goes through `@lowering` registry, not isinstance. | `test_no_dispatch_isinstance_chains` — AST scan; allowlist = inside one `@lowering`-decorated function body or inside `core/` |
+| **D4** | Module-import side effects (registering, mutating globals at import time) | Per S3A.8 / A7. | `test_ir_no_import_side_effects` (already exists, extended) |
+| **D5** | New `RawString(...)` call site anywhere in `src/srdatalog/ir/` | Per Stage 4 contract. | `test_iir_no_raw_string_growth` (already exists, whole-tree) |
+| **D6** | `from srdatalog.core import` referencing dialect symbols | Core is dialect-agnostic. | `test_core_has_no_dialect_imports` — AST scan of `core/*.py` |
+| **D7** | New `if`-branch in an existing lowering function (where a `@lowering` registration is the right shape) | This is the "moving code around" anti-pattern. | `test_lowering_files_have_one_lowering_each` — files matching `lower_mir_*.py` must contain exactly ONE `@lowering` decoration |
+| **D8** | Hardcoded pragma names in core or in the default pipeline | Pragmas are plugin-discovered. Core doesn't know names. | `test_core_has_no_hardcoded_pragma_names` — grep |
+| **D9** | `@lowering` / `@rewrite` / `@pragma` registration with no caller-exercised path | The infrastructure-without-consumer anti-pattern (the original sin). | `test_every_registration_is_exercised` — every registration must be hit by at least one production-path test (coverage assertion) |
+| **D10** | New field added to `LowerCtx` | `LowerCtx` is fixed at 5 fields after F3. Extending it requires a doc amendment. | `test_lower_ctx_field_count_pinned_at_five` — counts dataclass fields, must be exactly 5 |
+| **D11** | New file in `core/` after Layer 1 | Core is frozen post-foundation. | `test_core_module_set_pinned` — pins the file list under `core/` |
+| **D12** | Removal of an op from `USE_DECLARATIVE` set during migration | The migration ratchet is monotonic. | `test_use_declarative_is_monotonic` — git-history check (or test fixture pin) |
+
+The load-bearing test is **D9**. A registration that no production test
+triggers is dead infra. CI fails until either the registration is
+removed or a test exercises it via `Compiler.run`. This is the
+mechanism that prevents the "build infra, never use it" cycle from
+repeating.
+
+## 3. Required code shapes (positive contract)
+
+| ID | Required | Reason | Discipline test |
+|---|---|---|---|
+| **R1** | Every `Pass` instance referenced in `DEFAULT_PIPELINE` is registered with the `Compiler` | No orphan passes | `test_default_pipeline_passes_all_registered` |
+| **R2** | Every dialect ships a `@verifier` (even if no-op) | Per S3A.7 | already enforced, kept |
+| **R3** | Every concrete IIR op has either `@register_render(target=cuda)` OR a `@rewrite` registered | Per `ir_dialect_contract.md` §1 (LEAF-or-COMPOUND contract) | `verify_renderability` (already wired in production via `_apply_dialect_rewrites`) |
+| **R4** | Every concrete MIR op has a registered `@lowering(target=IIR, source=mir.X)` | Cross-IR completeness | `test_every_mir_op_has_lowering` |
+| **R5** | Every named pragma the DSL can produce has a `@pragma` registration | Closed-form pragma surface, fail-loud on typos | `test_dsl_pragma_names_are_registered` |
+| **R6** | Every PR adds NEW files only; existing-file edits are limited to additions in designated registry sets (`DEFAULT_PIPELINE`, `USE_DECLARATIVE`, plugin entry points, `__all__`) | Anti-monolith | per-PR review checklist (§4) |
+| **R7** | Every NEW class / function has at least one production-path call site | Anti-dead-infra | overlaps with D9 |
+
+## 4. Per-PR Definition of Done
+
+A PR is **not done** until ALL of these are satisfied. Reviewer
+explicitly checks each by ticking the box in the PR template.
+
+```markdown
+[ ] Discipline CI passes — all tests in tests/test_discipline_*.py
+[ ] No new `if`-branch added to an existing lowering — new file under
+    lowerings/ or pragmas/ instead
+[ ] Every new @lowering / @rewrite / @pragma / @register_render
+    registration has a test that exercises it via the production
+    Compiler.run path (NOT a synthetic in-test compiler)
+[ ] Byte-equivalence preserved — full byte-equivalence suite green
+    OR documented divergence with golden update + reviewer sign-off
+[ ] No new file in core/ (core is frozen post-Layer-1)
+[ ] No new pragma name appears in core/ — all pragma logic in pragmas/
+[ ] Diff size: ONLY new files under the assigned scope + single-line
+    additions to designated registry sets
+[ ] LowerCtx not extended (LowerCtx is fixed at 5 fields)
+[ ] PR description references the design doc section that authorizes
+    this change
+[ ] Reviewer comment: "Verified no shortcut" — explicit ack required
+```
+
+The PR template (`.github/pull_request_template.md`) enforces this
+checklist as the body. Reviewer must check every box before merge.
+
+## 5. Enforcement architecture
+
+Three layers of enforcement, defense-in-depth.
+
+```
+┌──────────────────────────────────────────────────────┐
+│ Layer A: CI discipline tests (mechanical)            │
+│   tests/test_discipline_*.py                         │
+│   Fail PR on any forbidden / required violation.     │
+│   ~12 tests, each enforcing one rule from §2/§3.     │
+│   Hard block; only owner-override unblocks.          │
+└──────────────────────────────────────────────────────┘
+                       │
+┌──────────────────────────────────────────────────────┐
+│ Layer B: Per-PR template (procedural)                │
+│   .github/pull_request_template.md                   │
+│   Reviewer must tick every box (§4).                 │
+│   Any unchecked box blocks merge.                    │
+└──────────────────────────────────────────────────────┘
+                       │
+┌──────────────────────────────────────────────────────┐
+│ Layer C: Design-doc reference (architectural)        │
+│   PR body MUST reference docs/<design>.md§X that     │
+│   authorizes the change. If no design auth → PR      │
+│   rejected.                                          │
+│                                                      │
+│   Discipline rules themselves are NOT edited inside  │
+│   feature PRs — they're amended in their own         │
+│   design-update PR with explicit owner sign-off.     │
+└──────────────────────────────────────────────────────┘
+```
+
+Layer A catches mechanical shortcuts. Layer B catches procedural
+shortcuts. Layer C catches scope creep.
+
+## 6. Migration-period special discipline
+
+During Layer 2 (parallel waves), the legacy monolith still exists as
+a fallback. Two extra rules apply for the duration:
+
+- **`USE_DECLARATIVE` is monotonically growing.** A PR can only ADD to
+  it. Removing requires a documented reason and explicit owner
+  sign-off. CI enforces (D12).
+- **Every `USE_DECLARATIVE` addition has a paired `@lowering`
+  registration in the same commit.** The new file under
+  `lowerings/lower_mir_<op>.py` defines the registration; the
+  single-line addition to `USE_DECLARATIVE` flips production over to
+  it. CI checks the cross-reference: every member of `USE_DECLARATIVE`
+  must have a corresponding `@lowering(source=mir.X)` registered.
+
+After Layer 3 cleanup, both rules are obsolete (legacy monolith
+deleted; `USE_DECLARATIVE` flag deleted).
+
+## 7. The "no useless complicated pseudo refactor" test
+
+Past PRs in this repo have been the failure mode this redesign
+forbids: ship infrastructure (a Lowering registration, a decorator, a
+new module) without making it the production path. The framework
+existed alongside the imperative monolith; the monolith continued to
+do the work; the framework was decoration.
+
+**A PR satisfies this discipline iff it changes the production path,
+not just the metadata around it.** Concretely:
+
+- Adding a `@lowering` for `mir.Scan` is **not done** until removing
+  the corresponding `if isinstance(head, mir.Scan):` branch from
+  `lower_scan_pipeline` (or, during migration, until `mir.Scan ∈
+  USE_DECLARATIVE`).
+- Adding a `@pragma` for `dedup_hash` is **not done** until the
+  corresponding `if ctx.dedup_hash:` branch in the lowering is
+  unreachable (after `MirPragmaPass` clears the flag).
+- Adding a sub-dialect for `parallel.block_group` is **not done**
+  until `if ctx.bg_enabled:` is unreachable in production paths.
+
+Discipline test D9 (`test_every_registration_is_exercised`) is the
+mechanical floor. The reviewer's "Verified no shortcut" comment in §4
+is the human ceiling. Both must hold.
+
+## 8. CI test inventory
+
+The discipline test suite (`tests/test_discipline_*.py`):
+
+| Test file | Enforces |
+|---|---|
+| `test_discipline_no_pragma_branches.py` | D1 |
+| `test_discipline_no_monolith_calls.py` | D2 |
+| `test_discipline_no_isinstance_chains.py` | D3 |
+| `test_discipline_no_import_side_effects.py` | D4 (extends existing test) |
+| `test_iir_no_raw_string_growth.py` | D5 (already exists, whole-tree) |
+| `test_discipline_core_isolation.py` | D6, D8, D11 |
+| `test_discipline_one_lowering_per_file.py` | D7 |
+| `test_discipline_registrations_exercised.py` | D9 |
+| `test_discipline_lower_ctx_pinned.py` | D10 |
+| `test_discipline_use_declarative_monotonic.py` | D12 |
+| `test_discipline_pipeline_completeness.py` | R1, R4, R5 |
+| `test_codegen_completeness.py` | R3 (existing — verify_renderability) |
+
+Most ship in Layer 1 (foundation). All must be green for any Layer 2+
+PR to merge. Each test is < 100 LOC; the entire discipline suite
+should run in < 1 second.
+
+## 9. Amendment process
+
+Discipline rules are not negotiable inside feature PRs. To amend a
+rule:
+
+1. Open a separate `discipline-amendment/<id>` branch.
+2. The PR body must explain WHY the rule is wrong (with concrete
+   evidence — e.g., a real refactor it forbids that should be
+   allowed).
+3. Owner approval required.
+4. The amendment lands as a docs-only PR before any code PR that
+   relies on the new rule.
+
+This is the "stop the parallel work, revise the discipline doc, then
+resume" process from `compiler_redesign.md` §10.
+
+## 10. Sign-off
+
+This document represents the contract every contributor (human or
+agent) operates under. Sign-off includes:
+
+- [ ] CI discipline tests are hard PR blocks (no warning-only mode).
+- [ ] Layer A + Layer B + Layer C enforcement architecture is in place
+  before Layer 2 parallel work starts.
+- [ ] The "no useless complicated pseudo refactor" test in §7 is the
+  ceiling-and-floor for every PR.
+- [ ] Discipline amendments follow §9; never inside a feature PR.
+
+Reviewer initials and date below.

--- a/docs/compiler_redesign.md
+++ b/docs/compiler_redesign.md
@@ -1,0 +1,460 @@
+---
+orphan: true
+---
+
+# Compiler Redesign — Spec
+
+This is the architectural spine for the redesign committed to in May 2026.
+It supersedes the implicit "imperative monolith with framework decoration"
+shape of the current compiler. The companion docs are:
+
+- [`ir_derivation_topology.md`](ir_derivation_topology.md) — the IR layer
+  graph + per-dialect tables + sub-dialect criteria.
+- [`code_discipline.md`](code_discipline.md) — code structure, forbidden
+  and required patterns, per-PR Definition of Done, CI enforcement.
+- [`phase_a_mir_onto_op.md`](phase_a_mir_onto_op.md) — MIR onto `Op`
+  migration plan.
+- [`phase_b_lowering_dispatcher.md`](phase_b_lowering_dispatcher.md) —
+  per-MIR-op `@lowering` migration plan.
+- [`phase_c_pragma_materialization.md`](phase_c_pragma_materialization.md)
+  — `@pragma` decorator + sub-dialect topology for built-in pragmas.
+- [`phase_d_hir_passes.md`](phase_d_hir_passes.md) — per-HIR-pass migration
+  to `ProgramPass`.
+- [`phase_e_plugin_extensibility.md`](phase_e_plugin_extensibility.md) —
+  entry-point discovery, `register_plugin`, what's "core" vs "default
+  plugin set", how to ship an external pragma / dialect.
+
+## 1. The diagnosis
+
+The current compiler has framework infrastructure on the renderer and
+plugin axes, and an imperative monolith on the lowering axis:
+
+- `_STMT_HANDLERS[type(op)]` dispatch — real, P1-shaped, additive.
+- `PluginRegistry.resolve(index_type)` — real, P2-shaped, additive.
+- `lower_scan_pipeline(...)` — 2500-LOC monolith with `if isinstance(...)`
+  chains and `if ctx.<pragma>:` branches threaded through every code
+  path.
+
+The `@lowering(SA_DIALECT, mir.ExecutePipeline)` decoration is metadata
+only — the registered Lowering instance is never queried by production;
+production calls `lower_scan_pipeline(...)` directly. Adding a new
+pragma today still means: edit `LoweringCtx`, edit `compile_kernel_body`
+to thread it, edit `lower_scan_pipeline` branches.
+
+This is the "framework on top of imperative monolith" anti-pattern.
+The framework adds cost (extra abstraction surface, dual dispatch
+mental model) without delivering its benefit (additive extensibility).
+
+## 2. The target
+
+**100 % dialect-pass-driven compiler.** Every transformation is a
+registered `Pass`. `Compiler.run` drives them. Source code does
+nothing imperative — it composes passes and supplies pragma-driven
+rewrite rules.
+
+```
+Compiler.run(prog, pipeline=[Pass1, Pass2, ...])
+   each Pass operates on registered (Lowering | Rewrite | ProgramPass) instances
+   no imperative if/isinstance dispatch in user code
+   pragma → typed-op-insertion → typed-op-lowering → typed-op-rendering
+```
+
+Pragma flow becomes:
+
+```
+Rule(pragmas={"dedup_hash": True})
+  → HirRuleVariant(pragmas={"dedup_hash": True})
+  → HirToMirLowering: produces ExecutePipeline(pragmas={"dedup_hash": True})
+  → MirPragmaPass: walks @pragma registrations
+       @pragma(name="dedup_hash") fires, wraps InsertInto in DedupGate,
+       removes "dedup_hash" from op.pragmas
+  → MirOptPass: R1–R5 fixpoint
+  → MirToIirLowering: per-MIR-op @lowering, including DedupGate →
+       sorted_array.DedupTryInsert
+  → IirCanonicalizePass: COMPOUND ops decomposed to LEAF
+  → CudaRenderPass: target-plugin-defined render
+  → "C++ source text"
+```
+
+No `if ctx.dedup_hash` anywhere. The flag is materialized as a typed
+op insertion at MIR time and consumed by the lowering for that op type.
+
+## 3. The language is a configuration of the compiler
+
+This is the load-bearing extensibility constraint. The core ships only
+the framework. Every language feature — every pragma, every relation
+type, every aggregation, every parallelism strategy, every DSL frontend
+— is a plugin registration against the core, including the things we
+currently consider "built-in".
+
+```
+srdatalog-core (this repo, ~1000 LOC):
+  Op, Type, Dialect, Compiler
+  Pass kinds: LoweringPass, RewritePass, ProgramPass
+  PassDriver, dispatchers, registries
+  Plugin discovery (entry points + explicit register_plugin)
+
+srdatalog-lang (this repo, default plugin set):
+  HIR / MIR / IIR dialects + their default ops
+  Default rewrites for built-in pragmas (in pragmas/*.py)
+  Default DSL frontend (Python Program(rules=[...]))
+
+srdatalog-target-cuda (this repo, default target plugin):
+  target.cuda dialect + render registry
+  Per-IIR-op renderers
+  PluginRegistry of index types
+
+External package (some-third-party on PyPI):
+  pip install some-third-party
+  → entry-point auto-loads
+  → registers a new @pragma + sub-dialect + lowering
+  → end-users write Rule(pragmas={"that_pragma": True}) and it works
+  → core never knew about it
+```
+
+This forces:
+
+- **No hardcoded pragma names anywhere in core.** `Rule.pragmas` is an
+  open dict (`tuple[tuple[str, Any], ...]` after Phase A freezing).
+  Each pragma's `@pragma` registration declares which key it reads.
+- **No central pragma list.** `MirPragmaPass` walks the registry of
+  registered pragmas; their order is data (declared `before:`/`after:`
+  topology).
+- **No central dialect list in core.** Plugins register dialects with
+  the running `Compiler`. Dependency declarations on Lowering/Rewrite
+  (`consumes`/`produces`) let the driver validate that required dialects
+  are registered.
+- **Plugin discovery via entry points.** `pyproject.toml`:
+  ```toml
+  [project.entry-points."srdatalog.plugins"]
+  cuda_target = "srdatalog_target_cuda:register"
+  ```
+  `Compiler.with_default_plugins()` walks entry points to load. For
+  tests / custom configs, plugins register manually.
+
+See [`phase_e_plugin_extensibility.md`](phase_e_plugin_extensibility.md)
+for the worked-example.
+
+## 4. The three Pass kinds
+
+The framework recognizes exactly three kinds of `Pass`. Every step in
+every `Compiler.run` pipeline is one of these; nothing else.
+
+```python
+class Pass(ABC):
+    """Abstract base for every compile-pipeline step."""
+    name: str
+    consumes: tuple[str, ...]   # dialect names (for dependency validation)
+    produces: tuple[str, ...]
+    def apply(self, prog, compiler) -> NewProg: ...
+
+
+class LoweringPass(Pass):
+    """Cross-dialect, source-driven, per-op dispatch.
+
+    Walks the input tree. For each op, looks up the registered
+    @lowering(target=<this pass's target>, source=type(op)) and applies
+    it. Result is in the target dialect (or a recursive call back into
+    the dispatcher for child ops).
+
+    Used for HIR → MIR, MIR → IIR.
+    """
+    target_dialect: Dialect
+
+
+class RewritePass(Pass):
+    """Intra-dialect, op-driven, per-op dispatch.
+
+    Walks the input tree. For each op, looks up registered
+    @rewrite(<this pass's dialect>, type(op)) and applies it. The
+    result must be in the same dialect (or a known set of declared
+    consumes/produces dialects).
+
+    Optionally fixpoint: applies until a full pass produces no change.
+
+    Used for MIR pragma materialization (one-shot), MIR opts (R1–R5,
+    fixpoint), IIR canonicalization (fixpoint).
+    """
+    dialect: Dialect
+    until_fixpoint: bool
+
+
+class ProgramPass(Pass):
+    """Whole-program. Used for HIR planning passes that operate on
+    HirProgram as a unit (stratify, semi-naive variant generation,
+    plan, index selection).
+
+    HIR types are mutable planning records (not Op-subclassed), so
+    they can't be walked by LoweringPass / RewritePass per-op
+    dispatch. ProgramPass is the explicit escape hatch for
+    whole-program transformations.
+
+    Used ONLY for HIR planning. MIR / IIR transformations must be
+    LoweringPass or RewritePass.
+    """
+    fn: Callable[[Any, Compiler], Any]
+```
+
+Pipelines are composed declaratively as data:
+
+```python
+DEFAULT_PIPELINE = [
+    # HIR planning (ProgramPass)
+    StratifyPass(), SplitPass(), SemiNaivePass(),
+    PlanPass(), IndexSelectionPass(),
+    TempRelSynthesisPass(), TempIndexRegistrationPass(),
+
+    # HIR → MIR (LoweringPass)
+    HirToMirLowering(),
+
+    # MIR — pragma materialization (one-shot RewritePass)
+    MirPragmaPass(),
+
+    # MIR — opts (fixpoint RewritePass)
+    MirOptPass(),
+
+    # MIR → IIR (LoweringPass)
+    MirToIirLowering(),
+
+    # IIR canonicalization (fixpoint RewritePass)
+    IirCanonicalizePass(),
+
+    # Render (terminal target-plugin pass)
+    CudaRenderPass(),
+]
+
+result = Compiler.with_default_plugins().run(prog, pipeline=DEFAULT_PIPELINE)
+```
+
+Users (and tests) can swap, reorder, insert custom passes. **The
+pipeline is data**, not buried inside `compile_kernel_body` control flow.
+
+## 5. `LowerCtx` — small (5 fields)
+
+`LowerCtx` is the per-pass state carried into every `@lowering`
+function. It is intentionally small. Anything not on this list is
+either:
+
+- Passed explicitly via lowering function arguments (lexical scope).
+- Materialized as a typed op insertion (pragma flags).
+- Looked up on the `Compiler` (registries).
+
+```python
+@dataclass(frozen=True)
+class LowerCtx:
+    """Per-pass state. 5 fields. Frozen — replace via dataclasses.replace.
+
+    See docs/phase_b_lowering_dispatcher.md §3 for field-by-field design.
+    """
+    compiler: Compiler         # for cross-dialect dispatch + registries
+    name_gen: NameGen          # name_gen.fresh(prefix) → str
+    view_layout: ViewLayout    # per-relation view_var_names + slot bases
+    plugin_registry: PluginRegistry  # per-Compiler plugin registry
+    target: str                # render target (e.g. 'cuda') for cross-target hooks
+
+    # The dispatch method (NOT a field — a method using `compiler`):
+    def lower(self, op) -> Op:
+        """Look up @lowering(target=this_pass, source=type(op)) and apply.
+        Recursive entry; lowerings call this for child ops."""
+        ...
+```
+
+What is NOT on `LowerCtx`:
+
+- ❌ `dedup_hash`, `tiled_cartesian`, `bg_enabled`, `ws_enabled`, ...
+  (pragma flags) — these are op insertions; once materialized, they
+  vanish.
+- ❌ `is_counting`, `inside_cartesian` — phase / scope flags, become
+  op-level (`Phase(C, body)` vs `Phase(M, body)` per the spec
+  §6, lexical via explicit `Scope` parameter to lowerings that need it).
+- ❌ `output_var`, `output_var_overrides` — output naming becomes a
+  property of the `WriteOutput` op or its containing scope.
+- ❌ `bound_vars`, `cartesian_bound_vars`, `handle_vars`,
+  `pre_narrow_infos` — lexical scope, passed explicitly via
+  `Scope` parameter.
+
+This decomposition is the point of the redesign. The current
+`LoweringCtx` (~25 fields) IS the imperative monolith — every flag is
+a branch trigger. The new `LowerCtx` removes the branch triggers; the
+removed information is either materialized as ops or passed explicitly.
+
+## 6. Pragmas are partial evaluation
+
+A pragma is a known-at-compile-time fact about a rule (`dedup_hash =
+True`). The compiler partially-evaluates the rule's lowering for that
+fact, producing specialized code. The "specialization" is the
+substitution of one MIR op (generic) with a wrap op + lowering chain
+(specialized).
+
+```python
+# The contract:
+
+@pragma(name="dedup_hash", on=mir.ExecutePipeline,
+        value_type=bool,
+        before=("count_as_product",), after=())
+def materialize_dedup_hash(op, ctx):
+    """Per docs/compiler_redesign.md §6 (partial evaluation): when
+    op.pragmas['dedup_hash'] is True, specialize the IR by inserting
+    DedupGate wrap ops, then clear the flag. Downstream passes never
+    see the flag — they only see the wrap ops.
+    """
+    if not op.pragmas.get("dedup_hash"):
+        return None  # pragma didn't apply — leave op unchanged
+    new_pipeline = tuple(
+        mir.DedupGate(inner=child) if isinstance(child, mir.InsertInto)
+        else child
+        for child in op.pipeline
+    )
+    new_pragmas = {k: v for k, v in op.pragmas.items() if k != "dedup_hash"}
+    return op.replace(pipeline=new_pipeline, pragmas=tuple(new_pragmas.items()))
+```
+
+`MirPragmaPass` walks the registry of `@pragma` registrations,
+topologically sorts them by `before:`/`after:`, and applies each in
+order. After all pragmas have run, `op.pragmas` is empty for every
+op in the tree. Any remaining pragma key is a registration error
+(a pragma name appeared in DSL but no `@pragma` claims it) — caught
+by a discipline test (see [`code_discipline.md`](code_discipline.md)).
+
+External plugins use the same `@pragma` decorator. The core knows
+about no specific pragmas — even built-in ones (dedup_hash,
+block_group, work_stealing, tiled_cartesian) live in `pragmas/*.py`
+as plugin modules.
+
+See [`phase_c_pragma_materialization.md`](phase_c_pragma_materialization.md)
+for the per-pragma design.
+
+## 7. Sub-dialect criteria
+
+A new sub-dialect is justified when **at least two** of the following
+hold:
+
+| Criterion | Example |
+|---|---|
+| New op vocabulary that other dialects might consume | `parallel.atomic_ws.WSScope` referenced by IIR rendering AND by potential future runners |
+| Materially different codegen scaffolding | `parallel.block_group` requires per-warp work-balance setup outside the kernel body |
+| Owns a registered codegen-target plugin / index plugin | `relation.d2l` ships `gen_root_handle` / `view_count` |
+| Independent rewrite vocabulary | `parallel.tiled_cartesian` has tiled-emission rewrites touching multiple ops |
+| Could plausibly be authored by an external party | future `relation.lsm⟨K⟩` is per-spec a separate dialect |
+
+A new sub-dialect is **not** justified for:
+
+- A flag that just toggles two render branches (one rewrite is enough)
+- A small per-rule helper op that only one lowering site uses (just
+  an op in an existing dialect)
+- A pure renderer variation (additional `@register_render` for the
+  same op)
+
+Applying these to the four built-in pragmas:
+
+| Pragma | Sub-dialect? | Rationale |
+|---|---|---|
+| `dedup_hash` | **No** — keep `DedupTryInsert` in `relation.sorted_array` | One COMPOUND op. External re-use unlikely until a second relation dialect needs dedup; refactor to `relation.dedup` then. |
+| `block_group` | **Yes — `parallel.block_group`** | Multiple ops (BgRootCJ, BgWorkBalance), distinct codegen scaffolding, runner integration. |
+| `work_stealing` | **Yes — `parallel.atomic_ws`** | Multiple ops + WCOJTask runner integration. Pragma + scheduling impact. |
+| `tiled_cartesian` | **No** — `SaTiledCartesian2D` stays in `relation.sorted_array` | Tightly coupled to sorted-array index access. Factor out only when a second data-structure dialect needs it. |
+
+So we end up with **two new sub-dialects** for built-in pragmas:
+`parallel.block_group`, `parallel.atomic_ws`. Not four.
+
+See [`ir_derivation_topology.md`](ir_derivation_topology.md) for the
+full dialect graph and per-dialect tables.
+
+## 8. Migration policy
+
+Big-bang risks byte-equivalence catastrophically. Per-MIR-op migration
+with a feature flag is the safe path.
+
+```python
+# In compile_kernel_body, during migration:
+USE_DECLARATIVE: frozenset[type] = frozenset({mir.Scan, mir.InsertInto})
+# Ratchets up over time. CI enforces monotonic growth.
+
+def lower_via_dispatcher(op, ctx):
+    if type(op) in USE_DECLARATIVE:
+        return ctx.lower(op)              # framework path
+    return _legacy_imperative_lower(op, ctx)  # legacy fallback
+```
+
+Each PR migrates exactly **one** MIR op type:
+
+1. New file `dialects/relation/sorted_array/lowerings/lower_mir_<op>.py`
+   contains exactly one `@lowering(target=IIR, source=mir.<Op>)`.
+2. Single-line addition to `USE_DECLARATIVE` set.
+3. Per-op byte-equivalence test (golden against legacy fallback).
+4. Full suite stays green.
+
+After all 60 MIR ops are migrated: delete `_legacy_imperative_lower`,
+`lower_scan_pipeline`, `LoweringCtx`, `USE_DECLARATIVE` flag.
+
+This is the only way to keep the test suite green throughout. See
+[`phase_b_lowering_dispatcher.md`](phase_b_lowering_dispatcher.md) for
+the per-op migration order and per-op acceptance gate.
+
+## 9. What this redesign does NOT promise
+
+- **It does not promise a faster compiler.** The point is extensibility,
+  not throughput. The dispatch overhead of `ctx.lower(op)` is one dict
+  lookup per op — irrelevant compared to file I/O at the codegen edge.
+- **It does not promise byte-equivalence in every case.** The
+  per-MIR-op migration aims to preserve byte-equivalence by reproducing
+  the legacy text exactly, but some emission quirks may not survive
+  decomposition. Where they don't, golden updates with reviewer sign-off
+  are explicit.
+- **It does not deliver a working second target.** It enables one (a
+  CPU/WASM target plugin can ship as a separate package), but actually
+  building one is post-redesign work.
+- **It does not retire any feature.** Every pragma, every relation
+  dialect, every lowering quirk currently in the codebase has an
+  equivalent in the new shape; the migration plans demonstrate this
+  per-feature.
+
+## 10. Phase order + parallelism
+
+| Phase | Scope | Agents | PRs |
+|---|---|---|---|
+| **0: Design docs** | This package | 1 | 1 (this PR) |
+| **1: Foundation (sequential)** | Pass kinds, MIR onto Op, LowerCtx, plugin discovery, declarative pipeline shim | 1 | 5 |
+| **2A: Per-MIR-op lowering** | Each PR migrates one MIR op type | up to 5 in parallel | ~10 |
+| **2B: Per-HIR-pass migration** | Each PR converts one HIR pass to ProgramPass | up to 3 in parallel | 7 |
+| **2C: Per-pragma materialization** | Each PR adds one pragma + (if criteria met) sub-dialect | up to 4 in parallel | 4 |
+| **2D: Plugin extensibility validation** | Re-ship one or two built-in features (e.g. an aggregation, a semiring) as plugin registrations to validate the extension model | 2 | 2 |
+| **3: Cleanup (sequential)** | Delete monolith, legacy LoweringCtx, all `if ctx.X` branches | 1 | 1 |
+
+**Approval gates** at every phase boundary. The user signs off on a
+phase's design before its execution starts, and on its execution before
+the next phase begins.
+
+## 11. Anti-patterns this redesign forbids
+
+The redesign is only worth doing if these are made structurally
+impossible. See [`code_discipline.md`](code_discipline.md) for the full
+list and CI enforcement.
+
+| Anti-pattern | Forbidden because |
+|---|---|
+| `if ctx.<pragma>:` outside the pragma's own materialization rewrite | Pragma flags are partial-eval triggers, not branch keys. |
+| Direct call to `lower_scan_pipeline(...)` (or any monolith) from production | Production goes through `Compiler.run(pipeline=...)`. No bypass. |
+| `isinstance(op, mir.X)` dispatch chain | Cross-dialect dispatch goes through `@lowering` registry. |
+| Module-import side effects in dialect modules | Import = no mutation. Registration = explicit. |
+| Hardcoded pragma name strings in core | Pragmas are plugin-discovered; core has no list. |
+| New `if`-branch in an existing lowering function | Every new lowering is a NEW file. Editing an existing branch is the "moving code around" anti-pattern. |
+| Registration with no production-path consumer | Dead infra. Discipline test requires every `@lowering` / `@rewrite` / `@pragma` to be exercised. |
+
+## 12. Approval
+
+This document represents an architectural commitment. Sign-off includes:
+
+- [ ] The Pass kinds in §4 are the only Pass kinds.
+- [ ] `LowerCtx` is fixed at 5 fields per §5 (extensions require a
+  doc amendment).
+- [ ] Pragmas are partial evaluation per §6; pragma flags vanish after
+  `MirPragmaPass`.
+- [ ] Sub-dialect criteria from §7 are the only justification for
+  factoring; no more sub-dialects than necessary.
+- [ ] Migration is per-MIR-op with monotonic `USE_DECLARATIVE` flag
+  per §8.
+- [ ] Phase order from §10 is respected; approval gate at each phase.
+- [ ] Anti-patterns from §11 are CI-enforced; PR fails if violated.
+
+Reviewer initials and date below.

--- a/docs/ir_derivation_topology.md
+++ b/docs/ir_derivation_topology.md
@@ -1,0 +1,383 @@
+---
+orphan: true
+---
+
+# IR Derivation Topology
+
+The graph every contributor needs to share. Defines:
+
+- The IR layers and how they relate.
+- The dialects within each layer.
+- The Pass kinds that move ops between dialects (`LoweringPass`) or
+  rewrite within a dialect (`RewritePass` / `ProgramPass`).
+- Where each extension point lives (sub-dialect creation, pragma
+  registration, target plugin).
+
+Companion to [`compiler_redesign.md`](compiler_redesign.md). Read that
+first for the architectural spine; this doc fills in the per-dialect
+detail and the dataflow graph.
+
+## 1. The IR derivation graph
+
+```
+                      ┌──────────────────────────┐
+                      │  FRONTEND (plugin)       │
+                      │  Default: Python DSL     │
+                      │  srdatalog.dsl.Program   │
+                      └────────────┬─────────────┘
+                                   │ no IR pass — direct construction
+                                   ▼
+                      ┌──────────────────────────┐
+                      │  HIR (planning records)  │
+                      │  srdatalog.ir.hir.types  │
+                      │                          │
+                      │  Mutable. Not Op-subclassed. │
+                      │  Contains:               │
+                      │   HirProgram             │
+                      │   HirStratum             │
+                      │   HirRuleVariant         │
+                      │   AccessPattern          │
+                      │   RelationDecl           │
+                      └────────────┬─────────────┘
+                                   │
+                ┌──────────────────┴────────────────┐
+                ▼                                   ▼
+   ┌──────────────────────────┐         ┌──────────────────────────┐
+   │ ProgramPass chain (HIR)  │  loop   │ Each pass re-emits a     │
+   │  StratifyPass            │  ────→  │ HirProgram (mutated      │
+   │  SplitPass               │         │ in-place per pass).      │
+   │  SemiNaivePass           │         │                          │
+   │  PlanPass                │         │ Each pass is a single    │
+   │  IndexSelectionPass      │         │ file under hir/passes/.  │
+   │  TempRelSynthesisPass    │         │                          │
+   │  TempIndexRegistration   │         │                          │
+   └──────────────────────────┘         └──────────────────────────┘
+                │
+                │ LoweringPass: HirToMirLowering
+                │   (maps HirRuleVariant → mir.ExecutePipeline,
+                │    carrying pragmas as a generic dict)
+                ▼
+   ┌──────────────────────────────────────────────────────────────┐
+   │  MIR (frozen Op tree)                                        │
+   │  srdatalog.ir.dialects.mir                                   │
+   │                                                              │
+   │  All Op-subclassed (Phase A). Two op groups:                 │
+   │                                                              │
+   │  mir.types  ─ generic ops:                                   │
+   │     Program, ExecutePipeline, Scan, ColumnJoin,              │
+   │     CartesianJoin, Filter, ConstantBind, Aggregate,          │
+   │     Negation, InsertInto, InjectCppHook, ColumnSource, ...   │
+   │                                                              │
+   │  mir.pragma_ops  ─ wrap ops inserted by @pragma rewrites:    │
+   │     DedupGate, BlockGroupRoot, WSScope, ...                  │
+   │     (+ ops shipped by external @pragma plugins)              │
+   └────────────┬─────────────────────────────────────────────────┘
+                │
+                ├─ RewritePass: MirPragmaPass (one-shot)
+                │   walks @pragma registry, each registration fires
+                │   when its trigger condition matches; inserts wrap ops
+                │   from mir.pragma_ops; clears the pragma key.
+                │
+                ├─ RewritePass: MirOptPass (fixpoint)
+                │   R1–R5 from ir_lowering_semantics.md §11
+                │   (count-as-product, hint introduction, etc.)
+                │
+                │ LoweringPass: MirToIirLowering
+                │   per-MIR-op @lowering registrations live in
+                │   dialects/relation/<ds>/lowerings/lower_mir_*.py
+                ▼
+   ┌──────────────────────────────────────────────────────────────┐
+   │  IIR (multi-dialect frozen Op tree)                          │
+   │                                                              │
+   │  STRUCTURAL dialects (LEAF, all-renderable):                 │
+   │    iir.cf       Block, BracedBlock, Bind, If, IfReturn,      │
+   │                 IfContinue, ParallelFor, GridStrideLoop,     │
+   │                 IntersectIter, LaneZeroGuard, Phase,         │
+   │                 Assign, IndexedAssign, StmtExpr, Comment,    │
+   │                 BlankLine, IndentBlock, OuterAnchor,         │
+   │                 TiledBallotBlock, WriteOutput, AddCount,     │
+   │                 RawString (transition-only), UserCode,       │
+   │                 VarRef                                       │
+   │    iir.expr     BinOp, UnaryOp, Parens, Ternary, IntLit,     │
+   │                 MemberAccess, MemberCall, FuncCall,          │
+   │                 IndexExpr, CCast, StaticCast,                │
+   │                 PostfixIncrement                             │
+   │                                                              │
+   │  DATA-STRUCTURE dialects (mostly LEAF, some COMPOUND):       │
+   │    relation.sorted_array  SaRoot, SaPref{Coop,Seq}, SaHint,  │
+   │                           SaDegree, SaValid, SaGetVal*,      │
+   │                           SaIterators, SaChildRange,         │
+   │                           SaTiledCartesian2D,                │
+   │                           DedupTryInsert (COMPOUND)          │
+   │    relation.d2l           D2lSegmentLoop                     │
+   │    relation.lsm⟨K⟩  (future, plugin-shipped)                 │
+   │    relation.uf      (future, plugin-shipped)                 │
+   │                                                              │
+   │  PARALLELISM dialects (LEAF, codegen-aware):                 │
+   │    parallel.data           ParallelFor, GridStrideLoop       │
+   │    parallel.block_group    BgRootCJ, BgWorkBalance           │
+   │    parallel.atomic_ws      WSCount, WSEmit, WSScope          │
+   │                                                              │
+   │  Each plugin can ship any number of dialects.                │
+   └────────────┬─────────────────────────────────────────────────┘
+                │
+                ├─ RewritePass: IirCanonicalizePass (fixpoint)
+                │   COMPOUND ops decomposed to LEAF
+                │   (e.g. DedupTryInsert → BracedBlock + Bind + If +
+                │    MemberCall, per the rewrite registered on
+                │    sorted_array)
+                │
+                │ verify_renderability(target='cuda') runs after
+                │ fixpoint; loud failure on any unhandled op.
+                ▼
+   ┌──────────────────────────────────────────────────────────────┐
+   │  TARGET RENDER (per plugin-shipped target)                   │
+   │                                                              │
+   │   target.cuda      @register_render(Op) per dialect          │
+   │                    in codegen/cuda/render/*.py               │
+   │   target.cpp_tbb   (future, plugin-shipped)                  │
+   │   target.metal     (future, plugin-shipped)                  │
+   │                                                              │
+   │  Each target ships its own render module; the @register_render │
+   │  registry is per-target. Adding a target = ship a plugin.    │
+   └──────────────────────────┬───────────────────────────────────┘
+                              │
+                              ▼
+                       Source code text
+```
+
+## 2. Edge legend
+
+- **Vertical arrows between layer boxes** = `LoweringPass` (cross-IR
+  transformation; source dialect → target dialect).
+- **Self-loops at each layer** = `RewritePass` (within-dialect; same
+  source and target dialect).
+- **HIR has only `ProgramPass`es.** HIR types are not `Op`-subclassed
+  (planning records); per-op dispatch isn't applicable.
+- **MIR & IIR have full `LoweringPass + RewritePass` capability.** Both
+  are frozen Op trees walkable by the framework.
+- **Render is the terminal stage.** It's a target-plugin-defined
+  per-op dispatch (the existing `@register_render` registry). It
+  produces text, not IR.
+
+## 3. Per-dialect tables
+
+### 3.1 HIR (planning, not Op-subclassed)
+
+| Type | Role |
+|---|---|
+| `HirProgram` | Top-level container: strata + relation_decls + global indices. |
+| `HirStratum` | A single SCC + its rule variants. |
+| `HirRuleVariant` | One delta variant of a rule (semi-naive). Carries `pragmas` dict. |
+| `AccessPattern` | Per-clause access pattern (after planning). |
+| `RelationDecl` | Relation declaration (name, types, semiring, index_type, ...). |
+
+| Pass | Kind | Notes |
+|---|---|---|
+| `StratifyPass` | ProgramPass | SCC analysis on the rule dependency graph. |
+| `SplitPass` | ProgramPass | Splits multi-head rules into single-head variants. |
+| `SemiNaivePass` | ProgramPass | Generates delta variants for recursive rules. |
+| `PlanPass` | ProgramPass | Chooses var_order / clause_order per variant (heuristic + user overrides). |
+| `IndexSelectionPass` | ProgramPass | Computes required indices per relation. |
+| `TempRelSynthesisPass` | ProgramPass | Synthesizes temp relations (e.g. semi-join helpers). |
+| `TempIndexRegistrationPass` | ProgramPass | Registers indices for synthesized temps. |
+
+Plugin extension: a third party can ship a new HIR pass by registering
+a new `ProgramPass` instance and inserting it into the pipeline at a
+specified position (per [`phase_d_hir_passes.md`](phase_d_hir_passes.md)).
+
+### 3.2 MIR (Phase A: all Op-subclassed)
+
+#### 3.2.1 Generic ops (`mir.types`)
+
+| Op | Role | Has pragmas dict? |
+|---|---|---|
+| `Program` | Top-level container; sequence of (`ExecutePipeline | InjectCppHook`, is_recursive) tuples. | No |
+| `ExecutePipeline` | A single rule variant lowered to a pipeline. | **Yes** |
+| `Scan` | Iterate a relation. | No |
+| `ColumnJoin` | Multi-source column-join (CJ_multi). | No |
+| `CartesianJoin` | Cartesian join. | No |
+| `Filter` | User-supplied predicate. | No |
+| `ConstantBind` | User-supplied expression bound to a var. | No |
+| `Aggregate` | Aggregation clause. | No |
+| `Negation` | Negation clause. | No |
+| `InsertInto` | Materialize / count into output relation. | No |
+| `InjectCppHook` | Inline raw C++ from pragma. | No |
+| `ColumnSource` | Source descriptor (rel_name, version, index, prefix_vars). Field, not stand-alone op. | No |
+
+#### 3.2.2 Pragma wrap ops (`mir.pragma_ops`)
+
+These are inserted by `@pragma` rewrites during `MirPragmaPass`. They
+live in `dialects/mir/pragma_ops/<pragma>.py`.
+
+| Op | Inserted by pragma | Wraps |
+|---|---|---|
+| `DedupGate` | `dedup_hash` | `InsertInto` |
+| `BlockGroupRoot` | `block_group` | Root op of pipeline (Scan / ColumnJoin) |
+| `WSScope` | `work_stealing` | Body of ExecutePipeline |
+| (future) | (any external pragma) | (anything that pragma's rewrite touches) |
+
+| Pass | Kind | Fixpoint? | Notes |
+|---|---|---|---|
+| `MirPragmaPass` | RewritePass | one-shot | Walks `@pragma` registry; each registration fires per its trigger; pragma key cleared after firing. |
+| `MirOptPass` | RewritePass | fixpoint | R1–R5: count-as-product, unused-var elision, hint introduction, negation pre-narrow, phase specialization. |
+| `HirToMirLowering` | LoweringPass | source=HIR, target=MIR | Per-`HirRuleVariant` `@lowering` registration. |
+
+### 3.3 IIR (multi-dialect)
+
+#### 3.3.1 Structural dialects (LEAF, all-renderable)
+
+##### `iir.cf` (control flow + scaffolding)
+
+| Op | Renderer | Notes |
+|---|---|---|
+| `Block`, `BracedBlock`, `IndentBlock`, `BlankLine` | LEAF | Sequencing / scoping. |
+| `Bind`, `Assign`, `IndexedAssign`, `StmtExpr` | LEAF | Statement-form bindings. |
+| `If`, `IfReturn`, `IfReturnIfNot`, `IfContinue`, `IfContinueIfNot` | LEAF | Branches. |
+| `ParallelFor`, `GridStrideLoop`, `IntersectIter` | LEAF | Loops. |
+| `CartesianFlatLoop`, `Cartesian2DDecompose`, `CartesianNDecompose` | LEAF | Cartesian ops. |
+| `LaneZeroGuard`, `OuterAnchor`, `Phase` | LEAF | Indent / phase. |
+| `TiledBallotBlock` | LEAF | Tiled ballot write. |
+| `WriteOutput`, `AddCount` | LEAF | Output emission. |
+| `Comment` | LEAF | Comment line. |
+| `RawString` | LEAF (transition-only) | See `compiler_redesign.md` §11. |
+| `UserCode` | LEAF (Category J) | User-supplied expression text. |
+| `VarRef` | LEAF (both stmt + expr modes) | Identifier reference. |
+
+##### `iir.expr` (expression vocabulary)
+
+| Op | Renderer | Notes |
+|---|---|---|
+| `BinOp` | LEAF | `<lhs> <op> <rhs>` |
+| `UnaryOp` | LEAF | `<op><expr>` |
+| `Parens` | LEAF | `(<expr>)` |
+| `Ternary` | LEAF | `<c> ? <t> : <e>` |
+| `IntLit` | LEAF | `<value><suffix>` (suffix for `1u`, `0ULL`, ...) |
+| `MemberAccess`, `MemberCall` | LEAF | `<obj>.<member>`, `<obj>.<method>(...)` |
+| `FuncCall` | LEAF | `<name>(...)` |
+| `IndexExpr` | LEAF | `<arr>[<idx>]` |
+| `CCast`, `StaticCast` | LEAF | `(T)x`, `static_cast<T>(x)` |
+| `PostfixIncrement` | LEAF | `<expr>++` |
+
+#### 3.3.2 Data-structure dialects
+
+##### `relation.sorted_array`
+
+| Op | Renderer | Notes |
+|---|---|---|
+| `SaRoot`, `SaPrefCoop`, `SaPrefSeq`, `SaHint` | LEAF | Handle construction / narrowing. |
+| `SaDegree`, `SaValid`, `SaGetVal`, `SaGetValAt`, `SaGetValAtPos` | LEAF | Handle queries. |
+| `SaIterators`, `SaChildRange` | LEAF | Iteration support. |
+| `SaTiledCartesian2D` | LEAF | Tiled-Cartesian emission scaffold. |
+| `DedupTryInsert` | **COMPOUND** | Decomposes to `BracedBlock + Bind + If + MemberCall` via `@rewrite`. |
+
+##### `relation.d2l`
+
+| Op | Renderer | Notes |
+|---|---|---|
+| `D2lSegmentLoop` | LEAF | HEAD/FULL segment-loop wrapping. |
+
+#### 3.3.3 Parallelism dialects
+
+##### `parallel.data` (existing, LEAF)
+
+`ParallelFor`, `GridStrideLoop` (re-exports from iir.cf historically;
+to be moved here in Phase B).
+
+##### `parallel.block_group` (Phase 2C; new)
+
+| Op | Renderer | Notes |
+|---|---|---|
+| `BgRootCJ` | LEAF | Block-group root iteration (per-warp work-balanced). |
+| `BgWorkBalance` | LEAF | Per-warp work-balance setup. |
+
+##### `parallel.atomic_ws` (Phase 2C; new)
+
+| Op | Renderer | Notes |
+|---|---|---|
+| `WSCount` | LEAF | Per-thread `local_count++`. |
+| `WSEmit` | LEAF | Atomic-WS emission. |
+| `WSScope` | LEAF | Outer scope for WS body. |
+
+| Pass | Kind | Fixpoint? | Notes |
+|---|---|---|---|
+| `MirToIirLowering` | LoweringPass | source=MIR, target=IIR | Per-MIR-op `@lowering` registrations. |
+| `IirCanonicalizePass` | RewritePass | fixpoint | Decomposes COMPOUND ops to LEAF; verifies renderability after. |
+| `CudaRenderPass` | RenderPass (terminal) | n/a | Walks the IIR tree; emits text via `@register_render`. |
+
+## 4. Sub-dialect criteria (re-stated for reference)
+
+A new sub-dialect is justified when **at least two** of the following
+hold:
+
+| Criterion | Example |
+|---|---|
+| New op vocabulary other dialects might consume | `parallel.atomic_ws.WSScope` referenced by IIR rendering AND potential future runners |
+| Materially different codegen scaffolding | `parallel.block_group` requires per-warp work-balance setup outside the kernel body |
+| Owns a registered codegen-target plugin / index plugin | `relation.d2l` ships its own `gen_root_handle` / `view_count` |
+| Independent rewrite vocabulary | `parallel.tiled_cartesian` has tiled-emission rewrites touching multiple ops |
+| Could plausibly be authored by an external party | future `relation.lsm⟨K⟩` |
+
+A new sub-dialect is NOT justified for:
+
+- A flag that just toggles two render branches (one rewrite is enough).
+- A small per-rule helper op that only one lowering site uses (just an
+  op in an existing dialect).
+- A pure renderer variation (additional `@register_render` for the
+  same op).
+
+## 5. Extension points (where plugins hook in)
+
+| Want to add | Where | How |
+|---|---|---|
+| **A new pragma** (e.g. `my_dedup_v2`) | `pragmas/<pragma>.py` (built-in) or external package | `@pragma(name=..., on=mir.X, value_type=T)` decorator. May ship a wrap op in a new `mir/pragma_ops/<pragma>.py`. May ship a sub-dialect if criteria met. |
+| **A new index type** (e.g. LSM⟨K⟩) | `dialects/relation/<index>/` (built-in) or external package | New dialect package with ops, types, lowerings, render module. Register via `Compiler.register_dialect(...)` or entry point. |
+| **A new parallelism strategy** | `dialects/parallel/<strategy>/` (built-in) or external package | New sub-dialect with ops + lowering. |
+| **A new render target** (e.g. CPU/WASM) | `codegen/<target>/` (built-in) or external package as `srdatalog-target-<name>` | New render module; `@register_render(Op, target='<target>')` per IIR op. Plus a `<Target>RenderPass` instance and any target-specific PluginRegistry. |
+| **A new HIR pass** | `dialects/hir/passes/<pass>.py` or external package | New `ProgramPass` instance; insert into pipeline at specified position. |
+| **A new DSL frontend** | New entry point `srdatalog.frontend` | Module that produces `HirProgram` from some source format (text, JSON, ...). |
+
+See [`phase_e_plugin_extensibility.md`](phase_e_plugin_extensibility.md)
+for the worked example.
+
+## 6. Discipline boundaries this topology enforces
+
+The topology graph defines what's allowed where:
+
+- `core/` knows only about `Op`, `Type`, `Dialect`, `Compiler`, the
+  three Pass kinds, and the dispatchers. It does NOT import from any
+  `dialects/`. Discipline test: `test_core_has_no_dialect_imports`.
+- `dialects/<X>/` knows about `core/` and (for cross-dialect lowerings)
+  about the dialects it produces ops for. It does NOT know about
+  `codegen/`. Discipline test:
+  `test_dialects_have_no_codegen_imports`.
+- `codegen/<target>/` knows about `core/` and ALL of `dialects/`
+  (because it renders IR ops). It does NOT mutate dialect state.
+- `pragmas/<pragma>.py` knows about `core/` and ONLY the dialects
+  whose ops it wraps / inserts. Discipline test:
+  `test_pragma_module_imports_are_minimal`.
+
+## 7. Versioning + back-compat
+
+- The dialect interface (`Dialect` dataclass shape, registration
+  protocol) is part of `core/`'s public API. Breaking changes to it
+  require a major version bump.
+- Specific dialect ops are part of the dialect's API. Breaking changes
+  to op fields require a minor version bump on the owning plugin.
+- Pragma names registered by built-in plugins are part of the language
+  surface. Adding new built-in pragmas is additive; removing them is
+  breaking.
+
+## 8. Open extensions noted but out of scope
+
+- **Cross-target rewrites** (rewrites parameterized by render target)
+  — possible future addition; not in scope of this redesign.
+- **Multi-target single-compile** (compile once, render to N targets)
+  — possible future addition; the IIR' subset can be rendered by any
+  target plugin in principle, but no production use case yet.
+- **Incremental compilation** (re-lower only changed rules) — possible
+  future addition; would extend `Compiler.run` with a memoization
+  layer.
+
+These are noted to clarify they are not load-bearing for the redesign
+and not in any current phase.

--- a/docs/phase_a_mir_onto_op.md
+++ b/docs/phase_a_mir_onto_op.md
@@ -1,0 +1,225 @@
+---
+orphan: true
+---
+
+# Phase A — MIR onto `Op`
+
+Foundation for the framework-driven compiler. Promote every MIR type
+to a `frozen=True, slots=True` `Op` subclass so that
+`apply_rewrites_to_fixpoint` and the `LoweringPass` dispatcher can
+walk MIR.
+
+Companion to [`compiler_redesign.md`](compiler_redesign.md) §10
+(phase order) and [`code_discipline.md`](code_discipline.md)
+(forbidden / required patterns).
+
+## 1. Goal
+
+After Phase A:
+
+- Every MIR type is a `@dataclass(frozen=True, slots=True)` `Op`
+  subclass.
+- The `mir.Program` tree is a frozen Op tree, walkable by
+  `core.passes._walk(prog)`.
+- `mir.ExecutePipeline` carries `pragmas: tuple[tuple[str, Any], ...]`
+  (open key/value list) instead of named bool fields
+  (`dedup_hash`, `work_stealing`, ...).
+- All sites that mutate MIR in-place (`pipeline.append(...)`,
+  `node.handle_start = ...`) have been replaced with
+  `dataclasses.replace(...)` or proper builders.
+- A new dialect `mir` is registered with the `Compiler` at startup.
+- Discipline tests pin: every MIR type is Op-subclassed, no in-place
+  mutation, every MIR op has a registered `@lowering`.
+
+Phase A does NOT yet:
+
+- Replace `lower_scan_pipeline` (Phase B).
+- Materialize pragmas as op insertions (Phase C).
+- Register `@lowering` per MIR op (Phase B).
+
+It only changes the shape of the MIR data so subsequent phases can
+operate on it.
+
+## 2. MIR type inventory
+
+60 classes in `src/srdatalog/ir/mir/types.py`. Categorized:
+
+### 2.1 Generic ops (kept)
+
+| Class | Field signature | Notes |
+|---|---|---|
+| `Program` | `steps: tuple[ProgramStep, ...]` | Top-level container. |
+| `ProgramStep` | `node: Op, is_recursive: bool` | Tuple becomes Op subclass too. |
+| `ExecutePipeline` | `pipeline: tuple[Op, ...], source_specs: tuple[ColumnSource, ...], dest_specs: tuple[InsertInto, ...], rule_name: str, pragmas: tuple[tuple[str, Any], ...]` | **`pragmas` field replaces `dedup_hash`, `work_stealing`, `block_group`, `fanout`, `count`, `tiled_cartesian`, ...** |
+| `InjectCppHook` | `code: str, before_or_after: str` | |
+| `ColumnSource` | `rel_name: str, version: Version, index: tuple[int, ...], prefix_vars: tuple[str, ...], handle_start: int, clause_idx: int` | Lists → tuples. |
+| `Scan` | `vars: tuple[str, ...], rel_name: str, version: Version, index: tuple[int, ...], prefix_vars: tuple[str, ...], handle_start: int` | Lists → tuples. |
+| `ColumnJoin` | `var_name: str, sources: tuple[ColumnSource, ...], handle_start: int` | |
+| `CartesianJoin` | `vars: tuple[str, ...], sources: tuple[ColumnSource, ...], var_from_source: tuple[tuple[str, ...], ...], handle_start: int` | Nested lists → nested tuples. |
+| `Filter` | `vars: tuple[str, ...], code: str` | |
+| `ConstantBind` | `var_name: str, code: str, deps: tuple[str, ...]` | |
+| `Aggregate` | `result_var: str, func: str, source: ColumnSource, prefix_vars: tuple[str, ...]` | |
+| `Negation` | `source: ColumnSource, prefix_vars: tuple[str, ...]` | |
+| `InsertInto` | `rel_name: str, version: Version, vars: tuple[str, ...], index: tuple[int, ...]` | |
+| `CreateFlatView` | `rel_name: str, version: Version, index: tuple[int, ...]` | |
+| `InnerPipeline` | `pipeline: tuple[Op, ...]` | |
+| `ProbeJoin` | (per current types.py) | |
+| ... (remaining ~40 types) | | |
+
+### 2.2 Pragma fields removed from `ExecutePipeline`
+
+Currently: 6 named bool fields. After Phase A: removed entirely,
+replaced by the open `pragmas` dict.
+
+| Removed field | Lives now as | Materialized by |
+|---|---|---|
+| `dedup_hash: bool` | `pragmas[("dedup_hash", True)]` | Phase C: `pragmas/dedup_hash.py` |
+| `work_stealing: bool` | `pragmas[("work_stealing", True)]` | Phase C: `pragmas/work_stealing.py` |
+| `block_group: bool` | `pragmas[("block_group", True)]` | Phase C: `pragmas/block_group.py` |
+| `fanout: bool` | `pragmas[("fanout", True)]` | Phase C: `pragmas/fanout.py` (or stay imperative if no consumer) |
+| `count: bool` | `pragmas[("count", True)]` | Phase C: `pragmas/count.py` |
+| `tiled_cartesian: bool` | (computed, not user-set — kept as field OR passed through pragmas; decision in Phase C) | |
+
+The DSL's `Rule(dedup_hash=True)` becomes sugar over
+`Rule.with_pragma("dedup_hash", True)`. The DSL change is part of
+Phase A (so the pipeline plumbing produces the right MIR shape),
+but the pragma materialization to wrap ops is Phase C.
+
+## 3. Mutation site inventory
+
+Every site that mutates a MIR instance must change to
+`dataclasses.replace(...)` or an explicit builder. Inventory (to be
+verified by exhaustive grep in the F2 PR):
+
+### 3.1 Known mutation sites
+
+| Site | Mutation | Replacement |
+|---|---|---|
+| `hir/lower.py:lower_hir_to_mir_steps` | `pipeline.append(...)` while building MIR steps | Build a `list[Op]` locally, then `mir.Program(steps=tuple(local_list))` at the end |
+| `mir/passes.py:apply_all_mir_passes` | Mutates `step.pipeline` in place during reorder passes | Each pass returns a new `ProgramStep` via `dataclasses.replace` |
+| `dialects/relation/sorted_array/lowerings.py` | Reads `node.handle_start` after mutation (assigned by `assign_handle_positions`) | `assign_handle_positions` returns a new pipeline with `handle_start` set, doesn't mutate |
+| `codegen/cuda/api.py:assign_handle_positions` | Sets `.handle_start` on `Scan` / `ColumnJoin` / `CartesianJoin` / `ColumnSource` | Returns a new pipeline with replacements; existing pipeline unchanged |
+| `codegen/cuda/complete_runner.py` | Reads (does not mutate) | No change |
+
+### 3.2 Verification approach
+
+A new discipline test `test_no_mir_mutation_outside_replace`:
+- AST-scans every `*.py` file under `src/`
+- For every assignment `obj.<attr> = ...` where `obj` is statically
+  inferable as an `Op` subclass instance — fails CI.
+- Allowlist: code inside `core/` (the framework owns `Op` itself).
+
+Implementation: a small AST visitor; ~50 LOC test. Not perfect
+static analysis but catches the common patterns.
+
+## 4. PR breakdown
+
+Phase A is 3 PRs, sequential.
+
+### PR A1: `feat/mir-onto-op-types` (~600 LOC diff)
+
+Just the type changes. Production still uses legacy `LoweringCtx`,
+legacy `lower_scan_pipeline`. Byte-equivalence preserved.
+
+- Convert all 60 MIR types in `mir/types.py` to
+  `@dataclass(frozen=True, slots=True)` + `Op` subclass.
+- Convert every `list[X]` field to `tuple[X, ...]`.
+- Replace `dedup_hash` / `work_stealing` / `block_group` /
+  `fanout` / `count` / `tiled_cartesian` named fields on
+  `ExecutePipeline` with `pragmas: tuple[tuple[str, Any], ...]`.
+- Add `mir.Program.replace(...)` helpers if needed for ergonomics.
+- New `mir/__init__.py` registers `mir` Dialect with all op types.
+- Tests: every MIR type round-trips through `dataclasses.replace`,
+  is hashable, is walkable by `core.passes._walk`.
+- Discipline tests added: `test_mir_ops_are_frozen_op_subclasses`,
+  `test_mir_program_walkable`.
+
+### PR A2: `feat/mir-fix-mutation-sites` (~400 LOC diff)
+
+The mechanical change. With frozen MIR, every mutation site fails;
+this PR fixes them all.
+
+- `hir/lower.py:lower_hir_to_mir_steps` — build via tuple, never
+  append-mutate.
+- `mir/passes.py` — each pass returns new instances via
+  `dataclasses.replace`.
+- `codegen/cuda/api.py:assign_handle_positions` — return new
+  pipeline.
+- DSL `Rule.with_plan(dedup_hash=True, ...)` — produces
+  `pragmas=(("dedup_hash", True),)` instead of named fields.
+- HIR `HirRuleVariant.pragmas: dict[str, Any]` field added (existing
+  bool fields kept during migration, deprecated).
+- Discipline test added: `test_no_mir_mutation_outside_replace`.
+- Byte-equivalence: full suite green.
+
+### PR A3: `feat/mir-pragmas-field-only` (~200 LOC diff)
+
+The cleanup. With mutation sites fixed and the new shape in place,
+remove the deprecated named bool fields entirely.
+
+- Remove `ExecutePipeline.dedup_hash` etc. — only `pragmas` remains.
+- Remove `HirRuleVariant.dedup_hash` etc. — only `pragmas` remains.
+- Update `compile_kernel_body` to read `ep.pragmas.get("dedup_hash")`
+  during the migration period (Phase B/C will eliminate this read
+  entirely).
+- Update DSL `PlanEntry` to drop named bool fields.
+- Update tests to construct `pragmas=(("dedup_hash", True),)` directly.
+
+After A3: MIR has the final Phase A shape. Phase B can begin.
+
+## 5. Byte-equivalence strategy
+
+Phase A doesn't change the lowering, so the emitted CUDA must be
+byte-identical. The risk is that the field re-shape (lists → tuples,
+named pragma fields → dict) breaks something subtle.
+
+Per-PR gate:
+
+- A1: full suite green. Type tests added.
+- A2: full byte-equivalence suite green (272 runner + 253 jit-batch).
+  Mutation-site fixes are mechanical; if a fix changes order or
+  identity, byte-equivalence catches it.
+- A3: full byte-equivalence suite green. The named-field removal
+  changes only the DSL surface; `compile_kernel_body` reads pragmas
+  via `ep.pragmas.get(...)` instead of `ep.dedup_hash`.
+
+If byte-equivalence breaks at any step, the PR is blocked until the
+divergence is either (a) traced to a Phase A bug and fixed, or (b)
+documented as an explicit acceptable change with golden update +
+owner sign-off.
+
+## 6. Discipline tests added in Phase A
+
+| Test | Enforces | PR |
+|---|---|---|
+| `test_mir_ops_are_frozen_op_subclasses` | Every type in `mir/types.py` subclasses `Op` and is `frozen=True, slots=True` | A1 |
+| `test_mir_program_walkable` | `mir.Program(...)` is walkable by `core.passes._walk` (yields all descendant ops) | A1 |
+| `test_no_mir_mutation_outside_replace` | AST scan: no `obj.<attr> = ...` assignments to statically-inferred `Op` instances outside `core/` | A2 |
+| `test_every_mir_op_has_lowering` | Every concrete MIR op type has at least one `@lowering(target=IIR, source=mir.X)` registration. **Stub passes initially** (raises `pytest.xfail` until Phase B); enforces by Phase B end | A1 (stub) |
+| `test_pragmas_field_is_open_dict` | `ExecutePipeline.pragmas` is `tuple[tuple[str, Any], ...]`; no named pragma bool fields exist | A3 |
+
+## 7. Risks + mitigations
+
+| Risk | Mitigation |
+|---|---|
+| `frozen=True` breaks mutation in code we missed | A2's discipline test catches it; CI fails on any regression. |
+| `slots=True` breaks `dataclasses.replace` for some types | Tested in A1 round-trip tests; if any type fails, fall back to `frozen=True` only for that type with a documented reason. |
+| Tuple-of-tuple fields for nested structures (`var_from_source`) become awkward | Provide a `Mir.cartesian_join(vars=..., sources=..., var_from_source=...)` factory that accepts list inputs and converts. |
+| Hashability breaks for types containing dicts (e.g., `Aggregate.func: str` if some site stores a dict) | Audit during A1; convert any dict fields to tuple-of-tuples. |
+| HIR↔MIR boundary: HIR is mutable, MIR is frozen — risk of "almost-Op" data crossing | The boundary is `lower_hir_to_mir_steps`. It builds MIR from scratch; no reference shared. |
+
+## 8. Sign-off
+
+Phase A is complete iff:
+
+- [ ] All three PRs (A1, A2, A3) merged.
+- [ ] Discipline tests in §6 all green.
+- [ ] Byte-equivalence preserved through every PR (or documented
+  divergence with sign-off).
+- [ ] No `mir.X` reference in `src/` constructs the named pragma
+  bool fields (`dedup_hash=`, etc.) — only `pragmas=`.
+- [ ] `mir.Program(...)` is walkable by `_walk` end-to-end (test
+  fixture covers a real compile output).
+
+After Phase A sign-off, Phase B (per-MIR-op `@lowering` migration)
+unblocks.

--- a/docs/phase_b_lowering_dispatcher.md
+++ b/docs/phase_b_lowering_dispatcher.md
@@ -1,0 +1,354 @@
+---
+orphan: true
+---
+
+# Phase B — `LoweringPass` dispatcher + per-MIR-op migration
+
+The phase that actually deletes the imperative monolith. Every MIR op
+gets one `@lowering` registration in its own file; the per-op feature
+flag (`USE_DECLARATIVE`) ratchets up monotonically; the legacy
+`lower_scan_pipeline` shrinks until it disappears.
+
+Companion to [`compiler_redesign.md`](compiler_redesign.md) §8
+(migration policy) and [`code_discipline.md`](code_discipline.md) §6
+(migration-period rules).
+
+## 1. Goal
+
+After Phase B:
+
+- Every concrete MIR op has an `@lowering(target=IIR, source=mir.X)`
+  registered in its own file under
+  `dialects/relation/sorted_array/lowerings/lower_mir_<op>.py`.
+- `LoweringPass(source=MIR, target=IIR)` is a real, dispatching pass:
+  walks the MIR tree, looks up registrations by op type, applies them.
+- `lower_scan_pipeline` and `_legacy_imperative_lower` are deleted.
+- `LoweringCtx` (the legacy 25-field god-object) is replaced by the
+  small `LowerCtx` (5 fields).
+- `compile_kernel_body` is reduced to `compiler.run(prog,
+  pipeline=DEFAULT_PIPELINE)`.
+
+Phase B does NOT yet:
+
+- Materialize pragmas as op insertions (Phase C).
+- Touch HIR pass framework migration (Phase D).
+- Touch plugin extensibility validation (post-Layer-2).
+
+## 2. `LoweringPass` algorithm
+
+```python
+class LoweringPass(Pass):
+    """Cross-dialect, source-driven, per-op dispatch.
+
+    For every Op in the input tree:
+      1. Look up registered @lowering(target=self.target_dialect,
+         source=type(op)).
+      2. If found, apply it. The lowering function returns either:
+         (a) An Op in the target dialect (the lowered form).
+         (b) An Op that itself contains source-dialect children;
+             the dispatcher recurses on those children.
+      3. If NOT found, raise LoweringMissingError(op_type, target).
+         Discipline test R4 (test_every_mir_op_has_lowering)
+         catches this at registration time, but the runtime check
+         is the safety net.
+
+    LoweringCtx provides:
+      - ctx.lower(op) → Op  (recursive dispatch entry; lowerings
+        call this for child ops)
+      - the small fixed LowerCtx state (5 fields per
+        compiler_redesign.md §5).
+    """
+    target_dialect: Dialect
+
+    def apply(self, prog, compiler):
+        ctx = LowerCtx(
+            compiler=compiler,
+            name_gen=NameGen(),
+            view_layout=ViewLayout.from_program(prog, compiler),
+            plugin_registry=compiler.plugin_registry_for(self.target_dialect),
+            target=self.target_dialect.name,
+        )
+        return ctx.lower(prog)
+```
+
+Key properties:
+
+- **Source-driven dispatch.** The walker is parameterized over the
+  source op's type, not the target. One pass = one source-to-target
+  direction.
+- **Recursive entry.** `ctx.lower(op)` is the only way to dispatch.
+  Lowerings call it for their own children; no manual isinstance
+  trees inside lowering bodies.
+- **Stateless across ops.** `ctx` is frozen; `name_gen.fresh(...)`
+  and `view_layout` are the only mutation-via-replacement points.
+- **No fallback path.** Either an op has a lowering or compilation
+  fails loudly.
+
+## 3. `LowerCtx` field-by-field
+
+```python
+@dataclass(frozen=True)
+class LowerCtx:
+    """Per-pass state. Frozen — replace via `dataclasses.replace`.
+
+    DISCIPLINE: This dataclass has exactly 5 fields. Adding a 6th
+    requires a doc amendment per code_discipline.md §9.
+    """
+    compiler: Compiler
+    name_gen: NameGen
+    view_layout: ViewLayout
+    plugin_registry: PluginRegistry
+    target: str
+
+    def lower(self, op: Op) -> Op:
+        """Dispatch entry; looks up @lowering(target=self.target,
+        source=type(op)) and applies it."""
+        ...
+```
+
+### 3.1 `compiler: Compiler`
+
+The running Compiler instance. Lets a lowering call back into other
+registries (e.g. resolve a sub-dialect's renderer) when needed. The
+compiler reference is the back-pointer that unifies cross-pass state.
+
+### 3.2 `name_gen: NameGen`
+
+```python
+class NameGen:
+    """Counter-backed unique name generator.
+
+    Mutating: name_gen.fresh('h_X') bumps internal counter.
+
+    Production parity: bump order matches legacy `LoweringCtx.fresh()`
+    so byte-equivalence holds. Specifically, the per-rule counter
+    starts at 0 for each kernel body and bumps in the same order the
+    legacy emitter did.
+    """
+    def fresh(self, prefix: str) -> str: ...
+```
+
+The one mutable state in `LowerCtx`. Wrapped so the dataclass itself
+stays frozen.
+
+### 3.3 `view_layout: ViewLayout`
+
+```python
+@dataclass(frozen=True)
+class ViewLayout:
+    """Per-relation view variable names + slot bases.
+
+    Computed once at the start of each LoweringPass.apply from
+    `prog`'s declared views and the registered index plugins
+    (so D2L FULL_VER takes 2 slots etc.). Read-only during lowering.
+    """
+    view_var_names: dict[str, str]   # handle_idx → view var name
+    slot_bases: dict[str, int]       # handle_idx → base slot
+```
+
+Replaces the legacy `LoweringCtx.view_var_names` +
+`LoweringCtx.view_slot_bases` pair.
+
+### 3.4 `plugin_registry: PluginRegistry`
+
+The per-Compiler `PluginRegistry` (encapsulated in PR #26). Lowerings
+call `ctx.plugin_registry.gen_root_handle(view_var, index_type)` etc.
+instead of the module-level `plugin_gen_root_handle(...)` shims.
+
+### 3.5 `target: str`
+
+Identifies the active render target (`'cuda'`, future `'cpp_tbb'`,
+`'metal'`, ...). Used by lowerings that need target-conditional
+behavior — though the goal is that lowerings are target-agnostic and
+target-specifics live in render or in target-specific plugins.
+
+### 3.6 What is NOT on `LowerCtx`
+
+| Removed field | Lives now as |
+|---|---|
+| `is_counting`, `inside_cartesian` | Lexical scope, passed via `Scope` parameter to lowerings that need it. Or op-level (`Phase(C, body)` vs `Phase(M, body)`). |
+| `dedup_hash`, `tiled_cartesian`, `bg_enabled`, `ws_enabled` | Op insertions (Phase C); consumed by Phase B's lowering for the wrap op. |
+| `output_var`, `output_var_overrides` | Property of `WriteOutput`/`AddCount` op or its containing scope. |
+| `bound_vars`, `cartesian_bound_vars`, `handle_vars`, `pre_narrow_infos` | Lexical scope; explicit `Scope` parameter. |
+| `debug` | Compiler-level option; on `compiler` if needed. |
+| `tile_var` | Op-level (e.g., `LaneZeroGuard.tile_var: str` or compile-time constant on the kernel envelope). |
+
+The `Scope` parameter idea:
+
+```python
+@dataclass(frozen=True)
+class Scope:
+    """Lexical scope, passed explicitly to lowerings that need it."""
+    bound_vars: tuple[str, ...]
+    cartesian_bound_vars: tuple[str, ...]
+    handle_vars: dict[str, str]
+    is_counting: bool
+    inside_cartesian: bool
+
+@lowering(target=IIR, source=mir.Filter)
+def lower_filter(op: mir.Filter, ctx: LowerCtx, scope: Scope) -> Op:
+    body = ctx.lower(child_op, scope.entering_filter())
+    ...
+```
+
+The dispatcher passes `Scope.empty()` at the top level; each lowering
+function decides how to update Scope when recursing.
+
+## 4. Per-MIR-op work-unit table (Wave 2A)
+
+Each PR migrates exactly one MIR op type. New file
+`dialects/relation/sorted_array/lowerings/lower_mir_<op>.py`. Single
+`@lowering` decoration. Single addition to `USE_DECLARATIVE`.
+
+| Wave 2A PR | Branch | MIR op | Difficulty | Migration order |
+|---|---|---|---|---|
+| **B-Filter** | `feat/lower-mir-filter` | `mir.Filter` | easy | 1 |
+| **B-ConstantBind** | `feat/lower-mir-constant-bind` | `mir.ConstantBind` | easy | 2 |
+| **B-Scan** | `feat/lower-mir-scan` | `mir.Scan` | medium | 3 |
+| **B-InsertInto** | `feat/lower-mir-insert-into` | `mir.InsertInto` | medium | 4 |
+| **B-CJ-single** | `feat/lower-mir-cj-single` | `mir.ColumnJoin` (single-source) | medium | 5 |
+| **B-CJ-multi** | `feat/lower-mir-cj-multi` | `mir.ColumnJoin` (multi-source) | hard | 6 |
+| **B-Cart** | `feat/lower-mir-cart` | `mir.CartesianJoin` | hard | 7 |
+| **B-Aggregate** | `feat/lower-mir-aggregate` | `mir.Aggregate` | hard | 8 |
+| **B-Negation** | `feat/lower-mir-negation` | `mir.Negation` | hard | 9 |
+| **B-ExecutePipeline** | `feat/lower-mir-execute-pipeline` | `mir.ExecutePipeline` | medium | 10 |
+
+Migration order is a recommendation, not a hard sequence — Wave 2A
+PRs can land in any order as long as they're file-disjoint and the
+foundation (Phase A + F4) is in.
+
+### 4.1 Per-PR template
+
+```python
+# File: dialects/relation/sorted_array/lowerings/lower_mir_scan.py
+
+from srdatalog.core import lowering
+from srdatalog.dialects.iir.cf import IIR_CF
+from srdatalog.dialects import mir
+from srdatalog.dialects.relation.sorted_array.types import SaHandle
+# ... other imports
+
+@lowering(target=IIR_CF, source=mir.Scan)
+def lower_mir_scan(op: mir.Scan, ctx: LowerCtx, scope: Scope) -> Op:
+    """Lower mir.Scan to iir.cf — root scan over a relation.
+
+    Per docs/phase_b_lowering_dispatcher.md §4 — one lowering per
+    file; production parity preserved against the legacy
+    `_lower_root_scan` branch.
+    """
+    # ... pure function, returns one Op ...
+```
+
+```python
+# Single-line addition to dialects/relation/sorted_array/__init__.py:
+
+USE_DECLARATIVE: frozenset[type] = frozenset({
+    mir.Filter,
+    mir.ConstantBind,
+    mir.Scan,           # ← added by this PR
+})
+```
+
+### 4.2 Per-PR acceptance gate
+
+Beyond the global per-PR Done definition (`code_discipline.md` §4):
+
+- The migrated op produces the same IIR tree as the legacy branch on
+  every fixture that exercises it.
+- The CUDA emit (post-IIR canonicalization + render) is byte-identical
+  to legacy.
+- A new test `test_lower_mir_<op>_byte_equivalent` runs the migrated
+  path on every relevant fixture and asserts byte equality.
+
+If byte-equivalence fails:
+
+1. First — debug. Likely a missed scope-parameter, a name-counter
+   bump-order mismatch, or a missing structured op (Stage 4 vocabulary
+   gap).
+2. If irreducible — document the divergence, update the affected
+   golden(s), get owner sign-off, ship.
+
+## 5. Migration ratchet (`USE_DECLARATIVE`)
+
+```python
+# In dialects/relation/sorted_array/__init__.py
+
+# DISCIPLINE: This set is monotonically growing during Phase B.
+# Removing an entry requires owner sign-off (see code_discipline.md
+# D12).
+USE_DECLARATIVE: frozenset[type] = frozenset({
+    # filled in by Wave 2A PRs, one entry per PR
+})
+```
+
+In `compile_kernel_body` (during migration):
+
+```python
+def lower_via_dispatcher(op, ctx_legacy):
+    if type(op) in USE_DECLARATIVE:
+        # New framework path
+        new_ctx = LowerCtx.from_legacy(ctx_legacy)
+        return new_ctx.lower(op)
+    # Legacy fallback — disappears in Layer 3 cleanup
+    return _legacy_imperative_lower(op, ctx_legacy)
+```
+
+Discipline test `test_use_declarative_is_monotonic`:
+
+- Reads the `USE_DECLARATIVE` set from the current commit.
+- Compares against the previous commit (or a pinned baseline).
+- Fails CI if any op was removed.
+
+## 6. Cleanup PR (Layer 3)
+
+After all 60 MIR op types are in `USE_DECLARATIVE`:
+
+```diff
+-USE_DECLARATIVE: frozenset[type] = frozenset({...all 60 types...})
+-
+-def lower_via_dispatcher(op, ctx_legacy):
+-    if type(op) in USE_DECLARATIVE:
+-        new_ctx = LowerCtx.from_legacy(ctx_legacy)
+-        return new_ctx.lower(op)
+-    return _legacy_imperative_lower(op, ctx_legacy)
+-
+-def _legacy_imperative_lower(op, ctx):
+-    ...  # 2500 LOC deleted
+```
+
+Plus:
+
+- Delete `LoweringCtx` (replaced by `LowerCtx`).
+- Delete `lower_scan_pipeline` (replaced by the `LoweringPass`
+  dispatcher).
+- `compile_kernel_body` reduces to one call:
+  `compiler.run(prog, pipeline=DEFAULT_PIPELINE)`.
+
+The Layer 3 PR should not introduce NEW logic — it's pure deletion +
+the `compile_kernel_body` simplification.
+
+## 7. Risks + mitigations
+
+| Risk | Mitigation |
+|---|---|
+| The `Scope` parameter design doesn't fit some legacy lowerings (e.g., the negation pre-narrow tracking) | F3 (LowerCtx skeleton) PR establishes Scope; migrate the Scope-easiest ops first (Filter, ConstantBind) to validate before tackling Negation |
+| Name-counter bump order differs between legacy and new path | Per-PR byte-equivalence test catches it; if irreducible, the new ordering can be documented and goldens updated (owner sign-off) |
+| Some MIR ops have such complex lowering that one file becomes large again | Split into helpers within the same file. The discipline rule is "one `@lowering` per file", not "the file is small". Helpers are fine. |
+| Two parallel agents pick the same MIR op | Wave 2A's branch-naming convention (`feat/lower-mir-<op>`) makes conflicts visible; single-line `USE_DECLARATIVE` additions create predictable merge conflicts that signal the duplication |
+
+## 8. Sign-off
+
+Phase B is complete iff:
+
+- [ ] All 10 Wave 2A PRs (one per MIR op family) merged.
+- [ ] Layer 3 cleanup PR merged: `lower_scan_pipeline` deleted,
+  `LoweringCtx` deleted, `USE_DECLARATIVE` flag deleted.
+- [ ] `test_every_mir_op_has_lowering` (R4) passes (no longer xfail).
+- [ ] `compile_kernel_body` is < 50 LOC and contains no `if
+  isinstance(op, ...)` chains.
+- [ ] Byte-equivalence preserved across the entire fixture set (or
+  documented divergences with owner sign-off).
+- [ ] `LowerCtx` still has exactly 5 fields (D10).
+
+After Phase B sign-off, Phase C (pragma materialization) and Phase D
+(HIR passes onto framework) unblock.

--- a/docs/phase_c_pragma_materialization.md
+++ b/docs/phase_c_pragma_materialization.md
@@ -1,0 +1,373 @@
+---
+orphan: true
+---
+
+# Phase C — Pragma materialization (`@pragma` + sub-dialects)
+
+The phase that deletes `if ctx.<pragma>:` branches. Each pragma
+becomes a typed op insertion at MIR time; the lowering for the
+inserted op handles the codegen specialization. Pragma flags vanish
+after `MirPragmaPass`; downstream code never reads them.
+
+Companion to [`compiler_redesign.md`](compiler_redesign.md) §6
+(partial-eval framing) and §7 (sub-dialect criteria), and
+[`ir_derivation_topology.md`](ir_derivation_topology.md) §3.2.2
+(pragma wrap ops).
+
+## 1. Goal
+
+After Phase C:
+
+- Every built-in pragma (`dedup_hash`, `block_group`, `work_stealing`,
+  `tiled_cartesian`, `count`, `fanout`) lives in a single file under
+  `pragmas/<pragma>.py`.
+- Each pragma module exports a `@pragma`-decorated function that
+  reads `op.pragmas[<name>]` and inserts the appropriate wrap op
+  into the MIR tree.
+- `MirPragmaPass` is in `DEFAULT_PIPELINE` after `HirToMirLowering`
+  and before `MirOptPass` / `MirToIirLowering`.
+- After `MirPragmaPass` runs, `op.pragmas` is empty for every op in
+  the tree. Discipline test enforces this.
+- Two new sub-dialects exist: `parallel.block_group`,
+  `parallel.atomic_ws`. Each ships its own ops + lowerings + render.
+- `LoweringCtx` has no pragma fields. `lower_scan_pipeline` (about
+  to be deleted in Layer 3) has no `if ctx.<pragma>:` branches.
+
+Phase C does NOT yet:
+
+- Delete the legacy `lower_scan_pipeline` (Layer 3).
+- Migrate HIR passes (Phase D).
+
+## 2. The `@pragma` decorator contract
+
+```python
+def pragma(
+    *,
+    name: str,
+    on: type,                                  # MIR op type the pragma reads from
+    value_type: type = bool,                   # expected type of pragmas[name]
+    before: tuple[str, ...] = (),
+    after: tuple[str, ...] = (),
+) -> Callable:
+    """Register a pragma materialization rewrite.
+
+    The decorated function fires during MirPragmaPass on every op
+    of type `on` where `op.pragmas.get(name)` is truthy. It returns
+    the transformed op (typed wrap-op insertion) with the pragma
+    cleared, OR None to skip.
+
+    `before` / `after` declare ordering against other registered
+    pragmas. MirPragmaPass topo-sorts.
+
+    `value_type` is checked at DSL construction time
+    (`Rule.with_pragma(name, value)`) — fail-loud on type mismatch.
+    """
+```
+
+### 2.1 Worked example: `pragmas/dedup_hash.py`
+
+```python
+"""Pragma: dedup_hash — atomically deduplicate emitted tuples via a
+GPU hash table.
+
+Trigger: rule pragma {"dedup_hash": True}.
+Materialization: wrap each InsertInto in a DedupGate at MIR time;
+   the lowering for DedupGate emits the dedup-table try_insert + if_p
+   gate (which decomposes via the existing sorted_array.DedupTryInsert
+   COMPOUND op rewrite).
+"""
+from srdatalog.core import pragma
+from srdatalog.dialects import mir
+from srdatalog.dialects.mir.pragma_ops import DedupGate
+
+@pragma(
+    name="dedup_hash",
+    on=mir.ExecutePipeline,
+    value_type=bool,
+    before=("count_as_product",),  # R1 must consider DedupGate as InsertInto-equivalent
+    after=(),
+)
+def materialize_dedup_hash(op, ctx):
+    if not op.pragmas.get("dedup_hash"):
+        return None
+    new_pipeline = tuple(
+        DedupGate(inner=child) if isinstance(child, mir.InsertInto)
+        else child
+        for child in op.pipeline
+    )
+    new_pragmas = tuple(
+        (k, v) for (k, v) in op.pragmas if k != "dedup_hash"
+    )
+    return op.replace(pipeline=new_pipeline, pragmas=new_pragmas)
+```
+
+The corresponding `mir.pragma_ops.DedupGate`:
+
+```python
+# File: dialects/mir/pragma_ops/dedup_gate.py
+
+from dataclasses import dataclass
+from typing import final
+from srdatalog.core import Op
+
+@final
+@dataclass(frozen=True, slots=True)
+class DedupGate(Op):
+    """MIR wrap op: dedup-hash gate around an emission op.
+
+    Inserted by pragmas/dedup_hash.py during MirPragmaPass. Lowered
+    by dialects/relation/sorted_array/lowerings/lower_mir_dedup_gate.py
+    to the existing sorted_array.DedupTryInsert COMPOUND op.
+    """
+    inner: Op
+```
+
+The lowering for `DedupGate`:
+
+```python
+# File: dialects/relation/sorted_array/lowerings/lower_mir_dedup_gate.py
+
+from srdatalog.core import lowering
+from srdatalog.dialects.iir.cf import IIR_CF
+from srdatalog.dialects.mir.pragma_ops import DedupGate
+from srdatalog.dialects.relation.sorted_array.ops import DedupTryInsert
+
+@lowering(target=IIR_CF, source=DedupGate)
+def lower_dedup_gate(op: DedupGate, ctx, scope):
+    inner_iir = ctx.lower(op.inner, scope)
+    # Build the try_insert args from the inner InsertInto's vars
+    # (extracted from op.inner before lowering).
+    args = tuple(VarRef(name=v) for v in op.inner.vars)
+    return DedupTryInsert(args=args, then_body=inner_iir)
+```
+
+The chain: `Rule(pragmas=("dedup_hash",True))` →
+HIR → MIR(`ExecutePipeline.pragmas=("dedup_hash",True), pipeline=[...,InsertInto]`) →
+`MirPragmaPass(materialize_dedup_hash)` → MIR(`pragmas=(), pipeline=[...,DedupGate(InsertInto)]`) →
+`MirToIirLowering(lower_dedup_gate)` → IIR(`...,DedupTryInsert(args, InsertInto-IIR)`) →
+`IirCanonicalizePass` (existing rewrite) → IIR(`...,BracedBlock(Bind, If(MemberCall, ...))`) →
+`CudaRenderPass` → C++ text.
+
+No `ctx.dedup_hash` anywhere.
+
+## 3. `MirPragmaPass` algorithm
+
+```python
+class MirPragmaPass(RewritePass):
+    """One-shot RewritePass: materializes every registered @pragma.
+
+    Walks the registry of @pragma registrations, topo-sorts by
+    declared before/after constraints, applies each registration's
+    rewrite to the MIR tree.
+
+    After this pass, op.pragmas is empty for every op in the tree.
+    Discipline test test_pragmas_empty_after_materialization
+    enforces this.
+    """
+    dialect = MIR_DIALECT
+    until_fixpoint = False  # one-shot
+
+    def apply(self, prog, compiler):
+        registrations = compiler.pragma_registrations()
+        ordered = topo_sort(registrations,
+                            key=lambda r: (r.before, r.after))
+        for reg in ordered:
+            prog = self._apply_one(prog, reg, compiler)
+        # Discipline: after all materialize, no pragmas survive
+        for op in walk(prog):
+            if hasattr(op, 'pragmas') and op.pragmas:
+                raise UnconsumedPragmaError(op, op.pragmas)
+        return prog
+
+    def _apply_one(self, prog, reg, compiler):
+        # Walk prog; for each op of type reg.on with pragma key
+        # reg.name truthy, apply reg.fn.
+        ...
+```
+
+`UnconsumedPragmaError` fires if a pragma name appeared in the DSL
+but no `@pragma` registration consumed it. Catches typos
+(`Rule(pragmas={"didup_hash": True})` ≠ `dedup_hash`) loudly at
+compile time.
+
+## 4. Per-built-in-pragma design
+
+| Pragma | Module | Wrap op | Sub-dialect for IIR? | Lowering target |
+|---|---|---|---|---|
+| `dedup_hash` | `pragmas/dedup_hash.py` | `mir.pragma_ops.DedupGate` | No (uses existing `sorted_array.DedupTryInsert`) | `lowerings/lower_mir_dedup_gate.py` in `relation.sorted_array` |
+| `block_group` | `pragmas/block_group.py` | `mir.pragma_ops.BlockGroupRoot` | **Yes — `parallel.block_group`** (new) | `lowerings/lower_mir_block_group_root.py` in `parallel.block_group` |
+| `work_stealing` | `pragmas/work_stealing.py` | `mir.pragma_ops.WSScope` | **Yes — `parallel.atomic_ws`** (new) | `lowerings/lower_mir_ws_scope.py` in `parallel.atomic_ws` |
+| `tiled_cartesian` | `pragmas/tiled_cartesian.py` | (no MIR wrap op — handled by MIR rewrite that picks alternative `@lowering` for `mir.CartesianJoin` based on a tag) | No (uses existing `sorted_array.SaTiledCartesian2D`) | augments existing `lowerings/lower_mir_cart.py` |
+| `count` | `pragmas/count.py` | (currently a phase flag; becomes `mir.pragma_ops.CountPhase(body)` wrap) | No — `iir.cf.Phase(C, body)` already exists | augments existing lowerings |
+| `fanout` | `pragmas/fanout.py` | (TBD; investigate existing usage) | No or new — decide during PR | TBD |
+
+### 4.1 `parallel.block_group` (new sub-dialect)
+
+```
+src/srdatalog/dialects/parallel/block_group/
+  ops.py              BgRootCJ, BgWorkBalance, BgRootIteration ops
+  print.py            Print forms
+  __init__.py         DIALECT registration
+  lowerings/
+    lower_mir_block_group_root.py   # @lowering(IIR_CF, BlockGroupRoot)
+
+src/srdatalog/codegen/cuda/render/
+  parallel_block_group.py           # @register_render(Op) per op
+```
+
+Per `compiler_redesign.md` §7 sub-dialect criteria, `parallel.block_group`
+qualifies because:
+
+- Multiple ops (BgRootCJ, BgWorkBalance, ...).
+- Distinct codegen scaffolding (per-warp work-balance setup outside
+  the kernel body — visible in runner-level emit).
+- External re-use plausible (a future runner library could consume
+  these ops for scheduling decisions).
+
+### 4.2 `parallel.atomic_ws` (new sub-dialect)
+
+```
+src/srdatalog/dialects/parallel/atomic_ws/
+  ops.py              WSCount, WSEmit, WSScope, WSCartesianValid
+  print.py
+  __init__.py
+  lowerings/
+    lower_mir_ws_scope.py           # @lowering(IIR_CF, WSScope)
+
+src/srdatalog/codegen/cuda/render/
+  parallel_atomic_ws.py
+```
+
+Same justification: multiple ops, distinct codegen + runner
+integration (WCOJTask queue), external re-use plausible.
+
+### 4.3 Pragmas that are NOT new sub-dialects
+
+`dedup_hash` — uses existing `sorted_array.DedupTryInsert`. Stays
+where it is until a non-sorted-array dialect needs dedup; refactor
+to `relation.dedup` then.
+
+`tiled_cartesian` — uses existing `sorted_array.SaTiledCartesian2D`.
+Tightly coupled to sorted-array index access; factor out only when a
+second data-structure dialect needs it.
+
+`count` — phase flag becomes `iir.cf.Phase(C, body)` wrap (already
+defined per the spec).
+
+## 5. PR breakdown
+
+Phase C is 4-6 PRs in parallel (Wave 2C from the partition).
+
+| PR | Branch | Adds |
+|---|---|---|
+| **C1** | `feat/pragma-decorator-and-pass` | `core/pragma.py` — `@pragma` decorator + `MirPragmaPass`. Discipline test `test_pragmas_empty_after_materialization`. No pragmas registered yet — pass is a no-op. |
+| **C2** | `feat/pragma-dedup-hash` | `mir/pragma_ops/dedup_gate.py`, `pragmas/dedup_hash.py`, `lowerings/lower_mir_dedup_gate.py`. Removes `if ctx.dedup_hash:` branches from sorted_array lowerings. Byte-equivalence preserved. |
+| **C3** | `feat/pragma-block-group` | New `parallel.block_group` sub-dialect (full package), `pragmas/block_group.py`. Removes `if ctx.bg_enabled:` branches. Byte-equivalence preserved. |
+| **C4** | `feat/pragma-work-stealing` | New `parallel.atomic_ws` sub-dialect, `pragmas/work_stealing.py`. Removes `if ctx.ws_enabled:` branches. WS runner-level changes deferred (not in scope here). |
+| **C5** | `feat/pragma-tiled-cartesian` | `pragmas/tiled_cartesian.py`, augmented `lower_mir_cart.py`. Removes `if ctx.tiled_cartesian:` branches. |
+| **C6** | `feat/pragma-count-and-fanout` | `pragmas/count.py`, `pragmas/fanout.py`. Removes remaining `is_counting` / `fanout` branches. |
+
+C1 must land first (the framework). C2–C6 can land in parallel.
+
+### 5.1 Per-PR acceptance gate (Wave 2C)
+
+Beyond the global per-PR Done definition:
+
+- The migrated pragma's old `if ctx.<pragma>:` branches are
+  **deleted** from the codebase (or marked `# DEAD CODE — to remove
+  in Layer 3` if they're inside `_legacy_imperative_lower` and
+  Phase B hasn't migrated the host op yet).
+- A new test `test_pragma_<name>_end_to_end` exercises the pragma via
+  `Compiler.run` on a fixture that triggers it; asserts the wrap op
+  appears in MIR-after-`MirPragmaPass`, asserts the lowered IIR is
+  correct, asserts the rendered CUDA is byte-equivalent to legacy.
+- `test_pragmas_empty_after_materialization` still passes (no leak).
+- Discipline test `test_no_pragma_flags_outside_pragma_modules` (D1)
+  runs against the migrated pragma name — fails if any
+  `ctx.<pragma>` reference exists outside `pragmas/<pragma>.py`.
+
+## 6. DSL surface change
+
+The DSL needs to accept open-form pragmas without breaking back-compat.
+
+### 6.1 Current DSL
+
+```python
+PlanEntry(
+    delta=-1,
+    var_order=("x", "y"),
+    fanout=False,
+    work_stealing=True,
+    block_group=False,
+    dedup_hash=True,
+    ...
+)
+```
+
+### 6.2 Phase A intermediate (named fields still accepted, sugar over
+pragmas dict)
+
+```python
+# Same call still works (back-compat sugar):
+PlanEntry(dedup_hash=True, work_stealing=True)
+
+# Internally constructs:
+PlanEntry(pragmas=tuple([("dedup_hash", True), ("work_stealing", True)]))
+```
+
+### 6.3 Phase C target
+
+```python
+# Generic call (the new canonical form):
+PlanEntry(pragmas=tuple([("dedup_hash", True)]))
+
+# Or via the .with_pragma builder (sugar, type-checked):
+PlanEntry().with_pragma("dedup_hash", True).with_pragma("work_stealing", True)
+
+# External pragmas (zero changes to DSL or core):
+PlanEntry().with_pragma("my_custom_optimization", {"strategy": "hybrid"})
+```
+
+`with_pragma(name, value)` looks up the registered pragma's
+`value_type` and validates `value`. Unknown name → loud error
+("no pragma 'my_custom_optimization' registered; did you forget to
+install some-pragma-package?").
+
+## 7. Discipline tests added in Phase C
+
+| Test | Enforces | PR |
+|---|---|---|
+| `test_pragmas_empty_after_materialization` | `op.pragmas` is empty for every op after `MirPragmaPass` | C1 |
+| `test_pragma_registry_completeness` (R5) | Every pragma name the DSL can produce has a `@pragma` registration | C1 |
+| `test_no_pragma_flags_outside_pragma_modules` (D1) | `ctx.<pragma>` not referenced outside `pragmas/<pragma>.py` | C1 (per pragma, ratchets per PR) |
+| `test_pragma_value_type_validated_at_dsl` | `Rule.with_pragma("dedup_hash", "yes")` raises (string ≠ bool) | C1 |
+| `test_pragma_<name>_end_to_end` | Per-pragma round-trip from DSL through `Compiler.run` to byte-equivalent CUDA | C2–C6 (one per pragma) |
+
+## 8. Risks + mitigations
+
+| Risk | Mitigation |
+|---|---|
+| Pragma ordering matters and topo-sort is wrong | Each pragma declares `before` / `after` explicitly; conflicts surface as topo-sort errors at registration time, not at runtime |
+| `parallel.block_group` lowering misses some scaffolding the legacy emit had | Per-PR byte-equivalence test on every fixture; if any divergence, debug or document with sign-off |
+| Removing the `if ctx.bg_enabled:` branch breaks fixtures that were running through it | Migration order: land C1 first (no behavior change), then C2 (single pragma) and verify byte-equiv before C3+ |
+| `count` pragma is currently a `is_counting` *phase flag* (not a per-rule pragma) — might not fit the `@pragma` shape | Investigate during C6 design; might need a separate `PhasePass` mechanism. If so, document and defer count migration to a Phase D follow-up |
+
+## 9. Sign-off
+
+Phase C is complete iff:
+
+- [ ] All Wave 2C PRs (C1–C6) merged.
+- [ ] No `ctx.<pragma>` reference exists in `src/` outside
+  `pragmas/<pragma>.py` for any pragma name.
+- [ ] `test_pragmas_empty_after_materialization` passes on the full
+  fixture set.
+- [ ] `test_pragma_registry_completeness` (R5) passes — every DSL
+  pragma name has an `@pragma` handler.
+- [ ] Two new sub-dialects (`parallel.block_group`,
+  `parallel.atomic_ws`) registered; their op vocabulary documented in
+  `ir_derivation_topology.md` §3.3.3.
+- [ ] Byte-equivalence preserved across the entire fixture set (or
+  documented divergences with owner sign-off).
+
+After Phase C sign-off, the `if ctx.<pragma>:` branch class of code
+is structurally extinct.

--- a/docs/phase_d_hir_passes.md
+++ b/docs/phase_d_hir_passes.md
@@ -1,0 +1,178 @@
+---
+orphan: true
+---
+
+# Phase D — HIR passes onto `ProgramPass`
+
+The HIR planning passes (stratify, semi-naive, plan, index, ...) are
+currently invoked imperatively from `compile_to_hir`. Phase D wraps
+each as a `ProgramPass` instance and inserts them into
+`DEFAULT_PIPELINE` so they're first-class members of the data-driven
+compile.
+
+Companion to [`compiler_redesign.md`](compiler_redesign.md) §4 (Pass
+kinds; `ProgramPass` justification) and
+[`ir_derivation_topology.md`](ir_derivation_topology.md) §3.1 (HIR
+pass table).
+
+## 1. Goal
+
+After Phase D:
+
+- Each HIR pass is a `ProgramPass` instance, in its own file under
+  `dialects/hir/passes/<pass>.py`.
+- `compile_to_hir` no longer hardcodes the pass sequence; `Compiler.run`
+  drives them via the pipeline data.
+- HIR types stay as planning records (mutable, not Op-subclassed) —
+  the Stage 3B "wrong abstraction" call from earlier still stands.
+  ProgramPass is the framework escape hatch for whole-program
+  transformations.
+- External plugins can ship new HIR passes (e.g., a custom
+  optimization or a debugging dump) by registering a `ProgramPass`
+  and inserting it into the pipeline at a specified position.
+
+Phase D does NOT:
+
+- Convert HIR types to `Op` subclasses (out of scope; per the
+  redesign, HIR stays as records).
+- Break HIR's existing API (planning records are still mutable;
+  passes still mutate them in-place, just inside `apply()`).
+
+## 2. `ProgramPass` contract
+
+```python
+class ProgramPass(Pass):
+    """Whole-program transformation. Used for HIR planning passes
+    that operate on HirProgram as a unit.
+
+    Unlike LoweringPass / RewritePass, ProgramPass does NOT walk an
+    Op tree. It calls `self.fn(prog, compiler)` and returns the
+    result. The function may mutate `prog` in place (HIR's
+    convention) or return a new HirProgram.
+
+    Usage:
+        @program_pass(name="stratify",
+                      consumes=("hir",),
+                      produces=("hir",))
+        def stratify_pass(prog, compiler):
+            ...   # imperative HIR transformation
+            return prog
+    """
+    name: str
+    consumes: tuple[str, ...]
+    produces: tuple[str, ...]
+    fn: Callable[[Any, Compiler], Any]
+
+    def apply(self, prog, compiler):
+        return self.fn(prog, compiler)
+```
+
+The `@program_pass` decorator wraps a function as a `ProgramPass`
+instance and registers it with the running Compiler.
+
+## 3. Per-HIR-pass migration table (Wave 2B)
+
+| Wave 2B PR | Branch | HIR pass | Existing function (in `hir/`) | Notes |
+|---|---|---|---|---|
+| **D-Stratify** | `feat/hir-stratify-pass` | `StratifyPass` | `stratify.py:stratify(prog)` | SCC analysis on the rule dep graph |
+| **D-Split** | `feat/hir-split-pass` | `SplitPass` | `split.py:split_multihead(prog)` | Splits multi-head rules |
+| **D-SemiNaive** | `feat/hir-semi-naive-pass` | `SemiNaivePass` | `semi_naive.py:gen_variants(prog)` | Delta variants for recursive rules |
+| **D-Plan** | `feat/hir-plan-pass` | `PlanPass` | `plan.py:plan(prog)` | var_order / clause_order per variant |
+| **D-Index** | `feat/hir-index-pass` | `IndexSelectionPass` | `index.py:select_indices(prog)` | Required indices per relation |
+| **D-TempRel** | `feat/hir-temprel-synthesis-pass` | `TempRelSynthesisPass` | `temprel.py:synthesize(prog)` | Temp relations (semi-join helpers) |
+| **D-TempIndex** | `feat/hir-temp-index-pass` | `TempIndexRegistrationPass` | `temp_index.py:register(prog)` | Temp relation indices |
+
+Each PR is small (~50–100 LOC): wrap an existing imperative function
+as a `ProgramPass`, move it to `dialects/hir/passes/<pass>.py`,
+register it.
+
+### 3.1 Per-PR template
+
+```python
+# File: src/srdatalog/dialects/hir/passes/stratify.py
+
+from srdatalog.core import program_pass
+
+@program_pass(name="stratify", consumes=("hir",), produces=("hir",))
+def stratify_pass(prog, compiler):
+    """SCC analysis on the rule dependency graph; populates
+    prog.strata with the topo-sorted strata.
+
+    Migrated from hir/stratify.py:stratify (Phase D-Stratify).
+    Behavior unchanged; this is purely a wrapping move so the pass
+    becomes part of DEFAULT_PIPELINE.
+    """
+    from srdatalog.ir.hir.stratify import stratify as _legacy_stratify
+    _legacy_stratify(prog)  # mutates prog in place
+    return prog
+```
+
+### 3.2 Per-PR acceptance gate
+
+- The migrated pass produces the same `HirProgram` as the legacy
+  invocation on every fixture.
+- A new test `test_hir_<pass>_pass_via_pipeline` runs the pass via
+  `Compiler.run` (with a pipeline containing only this pass) and
+  asserts the output matches the legacy direct call.
+- The legacy function is **not deleted** in this PR — it stays in
+  place as the pass's implementation. Deletion happens in the cleanup
+  PR after all 7 passes have been migrated.
+
+## 4. `compile_to_hir` becomes data-driven
+
+### 4.1 Before
+
+```python
+def compile_to_hir(program, verbose=False):
+    return default_pipeline(verbose=verbose).compile_to_hir(program)
+
+def default_pipeline(verbose=False):
+    p = HirCompilerPipeline(verbose=verbose)
+    p.add_hir_transform(StratifyPass())
+    p.add_hir_transform(SplitPass())
+    p.add_hir_transform(SemiNaivePass())
+    p.add_hir_transform(PlanPass())
+    p.add_hir_transform(TempRelSynthesisPass())
+    p.add_hir_transform(IndexSelectionPass())
+    p.add_hir_transform(TempIndexRegistrationPass())
+    return p
+```
+
+### 4.2 After
+
+```python
+def compile_to_hir(program, *, compiler=None):
+    """Run the HIR sub-pipeline only. Returns HirProgram.
+
+    Convenience for callers that want HIR but not MIR/IIR/codegen.
+    For full compile, use Compiler.run(program, pipeline=DEFAULT_PIPELINE).
+    """
+    compiler = compiler or Compiler.with_default_plugins()
+    hir_pipeline = [p for p in DEFAULT_PIPELINE
+                    if isinstance(p, ProgramPass)
+                    and p.consumes == ("hir",)]
+    hir_prog = HirProgram.from_user_program(program)
+    return compiler.run(hir_prog, pipeline=hir_pipeline)
+```
+
+`DEFAULT_PIPELINE` (in `pipeline.py`) lists all 7 HIR passes by
+instance, in order. Inserting a custom pass between two HIR passes
+is a one-line change to a user-supplied pipeline list.
+
+## 5. Sign-off
+
+Phase D is complete iff:
+
+- [ ] All 7 Wave 2B PRs merged.
+- [ ] `compile_to_hir` no longer constructs a hardcoded
+  `HirCompilerPipeline`; it pulls the HIR sub-pipeline from
+  `DEFAULT_PIPELINE`.
+- [ ] `dialects/hir/passes/` contains exactly 7 modules, each with
+  exactly one `@program_pass`-decorated function.
+- [ ] Byte-equivalence preserved (HIR / MIR goldens unchanged).
+- [ ] A new test asserts inserting a custom user `ProgramPass`
+  between two built-in passes works end-to-end (validates the
+  extension model from the user side).
+
+After Phase D, every IR layer (HIR / MIR / IIR) is driven by passes
+in `DEFAULT_PIPELINE`. No layer has imperative dispatch.

--- a/docs/phase_e_plugin_extensibility.md
+++ b/docs/phase_e_plugin_extensibility.md
@@ -1,0 +1,233 @@
+---
+orphan: true
+---
+
+# Phase E — Plugin extensibility (entry-point discovery + worked examples)
+
+The phase that proves the redesign delivers on its central promise:
+**every language feature is a plugin, including built-ins, and an
+external package can add new pragmas / dialects / targets without
+touching core**.
+
+Companion to [`compiler_redesign.md`](compiler_redesign.md) §3 (the
+language is a configuration of the compiler).
+
+## 1. Goal
+
+After Phase E:
+
+- `pip install some-srdatalog-extension` automatically extends the
+  compiler. No core changes. No DSL surface changes. No editing
+  `DEFAULT_PIPELINE`.
+- A worked example external plugin lives in
+  `examples/plugin_aggregation_jaccard/` (or as a separately-shipped
+  PyPI package) and demonstrates: new pragma, new MIR wrap op, new
+  sub-dialect, new IIR ops, new lowerings, new render registrations.
+- Built-in pragmas (`pragmas/dedup_hash.py` etc.) are discovered the
+  same way as external pragmas — no special-casing.
+- Discipline test asserts: removing all pragma modules from
+  `pragmas/` reduces the compiler to a no-op (the core knows nothing
+  about pragmas; everything is plugin-supplied).
+
+## 2. Plugin discovery — entry points
+
+`pyproject.toml` (in any extension package, including this repo's
+own built-ins):
+
+```toml
+[project.entry-points."srdatalog.plugins"]
+default_lang = "srdatalog.plugins.default_lang:register"
+cuda_target = "srdatalog.plugins.cuda_target:register"
+
+# An external package would add:
+# my_optimization = "my_pkg.srdatalog_plugin:register"
+```
+
+Each entry point points to a `register(compiler)` function:
+
+```python
+# srdatalog/plugins/default_lang/__init__.py
+def register(compiler):
+    """Register all built-in HIR/MIR/IIR dialects, MIR pragma_ops,
+    and pragma rewrite rules with the given Compiler."""
+    from srdatalog.dialects.hir import DIALECT as HIR_DIALECT
+    from srdatalog.dialects.mir import DIALECT as MIR_DIALECT
+    # ... all built-in dialects
+    for d in (HIR_DIALECT, MIR_DIALECT, ...):
+        compiler.register_dialect(d)
+    # Pragma modules self-register on import (their @pragma decorators
+    # populate the registry on the running compiler instance).
+    from srdatalog.pragmas import (dedup_hash, block_group,
+                                   work_stealing, tiled_cartesian,
+                                   count, fanout)  # noqa: F401
+```
+
+`Compiler.with_default_plugins()`:
+
+```python
+@classmethod
+def with_default_plugins(cls) -> 'Compiler':
+    """Construct a Compiler with all entry-point plugins loaded.
+
+    Walks importlib.metadata.entry_points(group='srdatalog.plugins'),
+    calls each register(self).
+
+    For tests / custom configs, use Compiler() and call
+    register_plugin manually.
+    """
+    compiler = cls()
+    for ep in importlib.metadata.entry_points(group='srdatalog.plugins'):
+        register_fn = ep.load()
+        register_fn(compiler)
+    return compiler
+```
+
+## 3. Explicit registration (for tests / custom configs)
+
+```python
+compiler = Compiler()
+compiler.register_plugin('default_lang')          # by entry-point name
+compiler.register_plugin(my_module.register)      # by callable
+compiler.register_dialect(my_dialect)             # by Dialect instance
+```
+
+All three are the same call shape internally — `register_plugin`
+resolves the argument to a `register(compiler)` callable.
+
+## 4. Worked example: ship a custom pragma as an external package
+
+Project layout (notional `my-srdatalog-jaccard` package on PyPI):
+
+```
+my-srdatalog-jaccard/
+  pyproject.toml
+  src/my_srdatalog_jaccard/
+    __init__.py
+    register.py                  # entry-point target
+    pragma.py                    # @pragma(name="jaccard")
+    dialect_jaccard/             # new IIR sub-dialect
+      ops.py                     # JaccardSimilarity, JaccardThreshold
+      print.py
+      __init__.py                # DIALECT
+    mir_ops/
+      jaccard_gate.py            # MIR wrap op
+    lowerings/
+      lower_mir_jaccard_gate.py  # @lowering for the wrap op
+    render/
+      cuda.py                    # @register_render(target='cuda') for IIR ops
+```
+
+`pyproject.toml`:
+
+```toml
+[project]
+name = "my-srdatalog-jaccard"
+dependencies = ["srdatalog>=2.0"]
+
+[project.entry-points."srdatalog.plugins"]
+jaccard = "my_srdatalog_jaccard.register:register"
+```
+
+`src/my_srdatalog_jaccard/register.py`:
+
+```python
+def register(compiler):
+    from . import pragma            # noqa — @pragma decorator fires
+    from .dialect_jaccard import DIALECT as JACCARD_DIALECT
+    from .mir_ops import jaccard_gate  # noqa — Op class loaded
+    from .lowerings import lower_mir_jaccard_gate  # noqa — @lowering fires
+    from .render import cuda  # noqa — @register_render fires
+
+    compiler.register_dialect(JACCARD_DIALECT)
+```
+
+End-user code (no changes to core, no changes to `srdatalog`'s DSL):
+
+```python
+from srdatalog import Compiler, Program, Rule, Var
+
+# Plugin auto-loaded via entry point.
+compiler = Compiler.with_default_plugins()
+
+X, Y = Var('x'), Var('y')
+similar_pairs = (
+    Rule(...)
+        .with_pragma('jaccard', {'threshold': 0.7})
+)
+
+prog = Program(rules=[similar_pairs])
+result = compiler.run(prog)  # uses DEFAULT_PIPELINE; jaccard pragma fires
+```
+
+What happens internally:
+
+1. `Compiler.with_default_plugins()` loads `default_lang`,
+   `cuda_target`, AND `jaccard` (from the user's installed
+   `my-srdatalog-jaccard` package) — all three call `register(compiler)`.
+2. The DSL accepts `with_pragma('jaccard', {'threshold': 0.7})`
+   because the `@pragma(name='jaccard', value_type=dict)` registered.
+3. HIR carries the pragma to MIR.
+4. `MirPragmaPass` calls `materialize_jaccard(...)`, which inserts a
+   `JaccardGate` MIR wrap op.
+5. `MirToIirLowering` finds `@lowering(target=JACCARD_DIALECT,
+   source=JaccardGate)` and lowers to IIR using the plugin's IIR ops.
+6. `IirCanonicalizePass` decomposes any COMPOUND ops the plugin
+   supplied.
+7. `verify_renderability` checks that every op type has a CUDA
+   renderer; plugin's `register/cuda.py` provided them.
+8. `CudaRenderPass` emits the C++.
+
+**Core never knew about jaccard.** The DSL never knew about jaccard.
+The default plugin set never knew about jaccard. The plugin itself
+provided every step from pragma trigger to rendered text.
+
+## 5. Validation: built-ins ARE plugins (Wave 2D)
+
+To prove the redesign actually delivers extensibility (not just claims
+to), Wave 2D PRs re-ship one or two existing built-in features as
+plugin packages — i.e., move them out of `srdatalog/` proper into
+their own plugin module loaded via entry point.
+
+| PR | Branch | Re-ships | Validates |
+|---|---|---|---|
+| **E1** | `feat/plugin-aggregation-as-extension` | One aggregation kind (e.g. AggCount) as a plugin | Aggregation framework is plugin-extensible |
+| **E2** | `feat/plugin-semiring-as-extension` | One semiring (e.g. BooleanSR) as a plugin | Semiring framework is plugin-extensible |
+
+These PRs are validation; their goal is to confirm the redesign's
+extension story works end-to-end. If either fails, the failure is
+diagnostic — the redesign needs revision before declaring Phase E
+complete.
+
+## 6. Discipline tests added in Phase E
+
+| Test | Enforces | PR |
+|---|---|---|
+| `test_compiler_with_default_plugins_loads_built_ins` | `Compiler.with_default_plugins()` loads at least the default_lang, cuda_target plugins | E (foundation) |
+| `test_external_plugin_can_add_pragma` | A test fixture shipping a fake plugin module + entry point can compile a program using its pragma | E (foundation) |
+| `test_core_module_set_pinned` (D11) | The set of files under `core/` is exactly the pinned list — no domain knowledge leaks into core | F1 (foundation), reaffirmed in Phase E |
+| `test_default_lang_is_a_plugin` | `srdatalog/plugins/default_lang/__init__.py` exists; built-in pragmas are discoverable through the same entry-point mechanism as external | E (foundation) |
+| `test_no_pragma_hardcoded_in_core` (D8) | `core/` has zero string literals matching known pragma names | F1 (foundation), reaffirmed in Phase E |
+
+## 7. Sign-off
+
+Phase E is complete iff:
+
+- [ ] `Compiler.with_default_plugins()` exists and loads via entry
+  points.
+- [ ] Built-in pragmas live in `pragmas/` and are discovered through
+  the same entry-point mechanism as external plugins.
+- [ ] At least one external-plugin worked example exists (in
+  `examples/`) demonstrating new pragma + new sub-dialect + new
+  lowering + new render — all in a separate package, no edits to
+  `srdatalog/` proper.
+- [ ] Wave 2D validation PRs (E1, E2) merged: at least one
+  aggregation and one semiring re-shipped as plugin packages, proving
+  the extension story works.
+- [ ] Discipline tests in §6 all pass.
+- [ ] Documentation in `phase_e_plugin_extensibility.md` (this doc)
+  has a step-by-step "How to ship an external plugin" section that a
+  user can follow without reading any other doc.
+
+After Phase E sign-off, the compiler is genuinely framework-driven
+and genuinely extensible. The redesign delivers what
+`compiler_redesign.md` §3 promised.


### PR DESCRIPTION
## Summary

The architectural rescope discussed in the redesign session. **Docs only — no code changes.** Approval gate: review all 8 docs together; sign off (or red-line) before any Layer 1 code work begins.

## What's in this PR

8 design docs under \`docs/\`:

| Doc | Purpose |
|---|---|
| \`compiler_redesign.md\` | Architectural spine. Pass kinds, LowerCtx contract, plugin/extensibility model, partial-eval framing, sub-dialect criteria, migration policy, anti-patterns, phase order. |
| \`ir_derivation_topology.md\` | The IR layer + dialect graph every contributor shares. Per-dialect tables, extension points, sub-dialect criteria, discipline boundaries. |
| \`code_discipline.md\` | Forbidden / required code shapes, CI-enforced discipline tests (D1–D12), per-PR Definition of Done, three-layer enforcement (CI + template + design-doc reference). |
| \`phase_a_mir_onto_op.md\` | MIR onto Op. 60-type migration, mutation-site inventory, pragmas-field-only ExecutePipeline. |
| \`phase_b_lowering_dispatcher.md\` | LoweringPass algorithm, LowerCtx 5-field design, per-MIR-op work-unit table for Wave 2A (10 parallel PRs), USE_DECLARATIVE migration ratchet. |
| \`phase_c_pragma_materialization.md\` | @pragma decorator contract, MirPragmaPass algorithm, per-built-in-pragma design, two new sub-dialects (parallel.block_group, parallel.atomic_ws). |
| \`phase_d_hir_passes.md\` | ProgramPass contract, per-HIR-pass migration table for Wave 2B (7 parallel PRs). |
| \`phase_e_plugin_extensibility.md\` | Entry-point discovery, register_plugin API, worked external-pragma example, validation PRs. |

## Architectural commitments locked in

- **100% dialect-pass-driven compiler.** Every transformation is a registered Pass. No imperative if/isinstance dispatch in user code.
- **The language is a configuration of the compiler.** Every language feature (pragmas, dialects, targets, DSL) is a plugin registration. Core knows nothing about specific features.
- **Pragmas are partial evaluation.** Materialized as typed op insertions; pragma flags vanish after MirPragmaPass.
- **LowerCtx is small** (5 fields, frozen). No flag-keyed dispatch in lowerings.
- **Sub-dialect criteria are explicit.** Only two new sub-dialects for built-in pragmas (parallel.block_group, parallel.atomic_ws).
- **Per-MIR-op migration** with monotonic USE_DECLARATIVE flag. Byte-equivalence preserved per PR.
- **Discipline tests are hard CI blocks.** Per-PR Definition of Done has 10 checklist items. PR template enforces.

## Why now

The current compiler has framework infrastructure on the renderer (P1) and plugin (P2) axes, and an imperative monolith on the lowering axis (\`lower_scan_pipeline\`, 2500 LOC). Pragmas are \`if ctx.X:\` branches scattered through the lowering. The half-frameworked state is worse than either pure pole — extra abstraction surface without additive extensibility benefit.

The redesign commits to the framework approach end-to-end. The 8 docs together are the contract that prevents the half-state from re-emerging.

## Phase plan summary

| Layer | Scope | Agents | PRs |
|---|---|---|---|
| **0: Design docs** | This PR | 1 | 1 |
| **1: Foundation (sequential)** | Pass kinds, MIR onto Op, LowerCtx, plugin discovery, declarative pipeline shim | 1 | 5 |
| **2A: Per-MIR-op lowering** | Each PR migrates one MIR op type | up to 5 in parallel | ~10 |
| **2B: Per-HIR-pass migration** | Each PR converts one HIR pass to ProgramPass | up to 3 in parallel | 7 |
| **2C: Per-pragma materialization** | Each PR adds one pragma + (if criteria met) sub-dialect | up to 4 in parallel | 4–6 |
| **2D: Plugin extensibility validation** | Re-ship one or two built-ins as plugin packages | 2 | 2 |
| **3: Cleanup (sequential)** | Delete monolith, legacy LoweringCtx, all if ctx.X branches | 1 | 1 |

**Approval gate at every phase boundary.** User signs off before the next phase starts.

## Sign-off needed

Each doc has a § "Sign-off" section. Reviewer initials + date below each.

If any doc is red-lined: discussion happens in this PR's review; the doc is amended; the rescope is locked in only when all 8 are approved.

## What this PR does NOT promise

- No code changes (purely docs).
- No commitment to merge until owner signs off all 8 docs.
- No PRs in flight (PRs #25 and #26 stay foundation, decoupled from this redesign branch).
- No production behavior change anywhere.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

## Merge target — INTEGRATION BRANCH

This PR targets `refactor/compiler-redesign` (long-lived integration branch), NOT `main`. Per discussion: the entire 3-month refactor lands on the integration branch; main stays clean; one big merge `refactor/compiler-redesign` → `main` at the end of Layer 3.

All subsequent Layer 1/2/3 PRs target the integration branch (directly or via stacking).