### PR TITLE
F1: Pass kinds framework (LoweringPass / RewritePass / ProgramPass) + Compiler.run

### DIFF
--- a/src/srdatalog/ir/core/__init__.py
+++ b/src/srdatalog/ir/core/__init__.py
@@ -17,6 +17,9 @@ Public API:
   Strategy combinators — top_down, bottom_up, seq, choice, repeat,
                          try_, all_, one, some, id_, fail.
   assert_never        — exhaustiveness check for match defaults.
+  Pragma + @pragma_handler — typed compile-time pragma objects (F-pragma).
+  Pass kinds (LoweringPass, RewritePass, ProgramPass) + program_pass
+                       — F1 declarative-pipeline framework.
 
 Design invariants:
 
@@ -37,7 +40,19 @@ from typing import NoReturn
 
 from srdatalog.ir.core.dialect import Compiler, Dialect
 from srdatalog.ir.core.ops import Op, Type
-from srdatalog.ir.core.passes import Lowering, PassDriver, Rewrite
+from srdatalog.ir.core.passes import (
+  AmbiguousLowering,
+  Lowering,
+  LoweringMissingError,
+  LoweringPass,
+  Pass,
+  PassDriver,
+  PassOrderingError,
+  ProgramPass,
+  Rewrite,
+  RewritePass,
+  program_pass,
+)
 from srdatalog.ir.core.pragma import (
   Pragma,
   PragmaConfigError,
@@ -78,16 +93,23 @@ def assert_never(value: object) -> NoReturn:
 
 
 __all__ = [
+  'AmbiguousLowering',
   'Compiler',
   'Dialect',
   'Lowering',
+  'LoweringMissingError',
+  'LoweringPass',
   'Op',
+  'Pass',
   'PassDriver',
+  'PassOrderingError',
   'Pragma',
   'PragmaConfigError',
   'PragmaCtx',
   'PragmaOrderingError',
+  'ProgramPass',
   'Rewrite',
+  'RewritePass',
   'Strategy',
   'Type',
   'UnconsumedPragmaError',
@@ -103,6 +125,7 @@ __all__ = [
   'id_',
   'one',
   'pragma_handler',
+  'program_pass',
   'repeat',
   'seq',
   'some',

--- a/src/srdatalog/ir/core/dialect.py
+++ b/src/srdatalog/ir/core/dialect.py
@@ -65,3 +65,31 @@ class Compiler:
   def dialects(self) -> list[Dialect]:
     '''All registered dialects, in registration order.'''
     return list(self._dialects.values())
+
+  def run(self, prog: Any, *, pipeline: list[Any]) -> Any:
+    '''Drive a list of `Pass` instances over `prog`. Returns the
+    (possibly transformed) prog.
+
+    Pre-flight: validate pipeline ordering. For each `Pass`, check
+    that all `consumes` dialects are either registered with this
+    Compiler OR produced by an earlier Pass in the list. Raises
+    `PassOrderingError` on mismatch — at construction time, before
+    any pass executes.
+
+    Per `docs/compiler_redesign.md` §4 and the R4 research report:
+    pipelines are data; ordering errors are caught up-front.
+    '''
+    # Local import to avoid a circular at module-load time
+    # (passes.py imports Compiler from this module).
+    from srdatalog.ir.core.passes import PassOrderingError
+
+    available: set[str] = {d.name for d in self.dialects}
+    for i, p in enumerate(pipeline):
+      for needed in p.consumes:
+        if needed not in available:
+          raise PassOrderingError(p.name, needed, i)
+      available |= set(p.produces)
+
+    for p in pipeline:
+      prog = p.apply(prog, self)
+    return prog

--- a/src/srdatalog/ir/core/passes.py
+++ b/src/srdatalog/ir/core/passes.py
@@ -48,11 +48,13 @@ See docs/ir_lowering_semantics.md, section 21.
 
 from __future__ import annotations
 
+from abc import ABC, abstractmethod
 from collections.abc import Callable
 from dataclasses import dataclass, field
 from typing import Any
 
 from srdatalog.ir.core.dialect import Compiler, Dialect
+from srdatalog.ir.core.strategy import bottom_up, repeat
 
 
 @dataclass
@@ -279,12 +281,339 @@ class PassDriver:
     return prog
 
 
+# -----------------------------------------------------------------------------
+# Pass kinds (Layer 1 / F1)
+#
+# Per docs/compiler_redesign.md §4 (the three Pass kinds) and
+# docs/phase_b_lowering_dispatcher.md §2 (LoweringPass algorithm), the
+# framework recognizes exactly three kinds of `Pass`:
+#
+#   LoweringPass  — cross-dialect, source-driven, per-op dispatch
+#                    (HIR → MIR, MIR → IIR).
+#   RewritePass   — intra-dialect, op-driven, per-op dispatch
+#                    (pragma materialization, MIR opts, IIR canonicalization).
+#   ProgramPass   — whole-program transformation (HIR planning).
+#
+# `Pass.apply(prog, compiler)` returns the (possibly transformed) prog.
+# `Compiler.run(prog, pipeline=[...])` drives a list of `Pass` instances.
+#
+# This is Layer 1 foundation. The full LowerCtx (5-field per
+# compiler_redesign.md §5) lands in F3; F1 ships only the minimum
+# dispatcher needed to wire up the three Pass kinds and prove the
+# pipeline shape.
+# -----------------------------------------------------------------------------
+
+
+class PassOrderingError(Exception):
+  '''A Pass's `consumes` references a dialect that no earlier pass
+  in the pipeline has produced (and that isn't a Compiler-registered
+  dialect at run start).
+
+  Raised at construction-time validation in `Compiler.run`, before any
+  pass executes. Mirrors `PassDependencyError` but operates on a
+  pipeline list rather than the registered dialect set.
+  '''
+
+  def __init__(self, pass_name: str, missing: str, position: int) -> None:
+    self.pass_name = pass_name
+    self.missing = missing
+    self.position = position
+    super().__init__(
+      f'pass {pass_name!r} at pipeline position {position} '
+      f'requires dialect {missing!r} which no earlier pass produces '
+      f"and which isn't registered with the Compiler. Either register "
+      f'the dialect or insert a pass that produces it earlier.'
+    )
+
+
+class AmbiguousLowering(Exception):
+  '''Two `@lowering` registrations target the same source op type
+  for the same target dialect.
+
+  Raised by `LoweringPass._build_table` at `apply()` time, before
+  any op is dispatched.
+  '''
+
+  def __init__(self, source_op_type: type, target_dialect_name: str) -> None:
+    self.source_op_type = source_op_type
+    self.target_dialect_name = target_dialect_name
+    super().__init__(
+      f'multiple @lowering registrations match source op type '
+      f'{source_op_type.__name__!r} for target dialect '
+      f'{target_dialect_name!r}; expected exactly one.'
+    )
+
+
+class LoweringMissingError(Exception):
+  '''No `@lowering` registered for `type(op)` targeting this
+  LoweringPass's `target_dialect_name`.
+
+  Raised by the dispatcher at `ctx.lower(op)` time. Per
+  `phase_b_lowering_dispatcher.md` §2, this is the runtime safety
+  net; discipline test R4 catches it earlier at registration time
+  for built-in ops.
+  '''
+
+  def __init__(self, op_type: type, target_dialect_name: str) -> None:
+    self.op_type = op_type
+    self.target_dialect_name = target_dialect_name
+    super().__init__(
+      f'no @lowering registered for source op type {op_type.__name__!r} '
+      f'targeting dialect {target_dialect_name!r}.'
+    )
+
+
+@dataclass(frozen=True)
+class Pass(ABC):
+  '''Abstract base for every compile-pipeline step.
+
+  Three concrete kinds: `LoweringPass`, `RewritePass`, `ProgramPass`.
+  `Pass.apply(prog, compiler)` returns the (possibly transformed) prog.
+
+  Per `docs/compiler_redesign.md` §4: every step in every
+  `Compiler.run` pipeline is one of these three kinds; nothing else.
+
+  `consumes` / `produces` declare dialect dependencies for the
+  ordering validation done by `Compiler.run` at construction time
+  (per the R4 research report and `phase_b_lowering_dispatcher.md`
+  §5). They are advisory data, not enforced inside `apply`.
+  '''
+
+  name: str
+  consumes: tuple[str, ...] = ()
+  produces: tuple[str, ...] = ()
+
+  @abstractmethod
+  def apply(self, prog: Any, compiler: Any) -> Any:
+    '''Run this pass against `prog`. Returns the (possibly
+    transformed) prog. Implementations are pure functions: no
+    Compiler mutation, no global state.'''
+    ...
+
+
+@dataclass
+class _LoweringDispatcher:
+  '''Internal: bridges between a frozen `LoweringPass` and its
+  per-call dispatch table.
+
+  F3 promotes this to the public `LowerCtx` with 5 fields per
+  `compiler_redesign.md` §5. F1 ships only the minimum to dispatch
+  (just `compiler` + the table + `lower(op)`); production lowerings
+  that need `name_gen`, `view_layout`, `plugin_registry`, `target`
+  are not yet wired up here — those land in F3.
+  '''
+
+  compiler: Any
+  table: dict[type, Lowering]
+  target_dialect_name: str = ''
+
+  def lower(self, op: Any) -> Any:
+    '''Dispatch entry; looks up the registered Lowering for
+    `type(op)` and applies it. Raises `LoweringMissingError` if no
+    registration exists. Lowerings call this back into the
+    dispatcher for child ops they want to recurse into (per R1's
+    explicit-recursion rule).'''
+    low = self.table.get(type(op))
+    if low is None:
+      raise LoweringMissingError(type(op), self.target_dialect_name)
+    return low.apply(op, self)
+
+
+@dataclass(frozen=True)
+class LoweringPass(Pass):
+  '''Cross-dialect, source-driven, per-op dispatch.
+
+  Walks the input tree via the dispatcher; for each op, looks up the
+  registered `@lowering(target=self.target_dialect_name,
+  source=type(op))` and applies it.
+
+  Per the R1 design report:
+
+    - **Source-driven dispatch.** The dispatch table is built at
+      `apply()` time, keyed on op type. One `LoweringPass` instance
+      = one source-to-target direction.
+    - **Explicit `ctx.lower(child)` recursion.** No auto-walk.
+      Lowerings call `ctx.lower(child)` themselves when they want
+      to recurse into children. This mirrors MLIR's
+      `ConversionPattern` and explicitly rejects the `bottom_up`-
+      style auto-walk; lowerings that want auto-walk implement it
+      themselves.
+
+  This PR implements the Pass class shape but NOT the full 5-field
+  `LowerCtx`. The dispatcher passes a placeholder `ctx` (with
+  `compiler` + `lower()` only) sufficient to dispatch; F3 lands the
+  full `LowerCtx` and threads it through registered lowerings.
+  '''
+
+  target_dialect_name: str = ''
+
+  def apply(self, prog: Any, compiler: Any) -> Any:
+    table = self._build_table(compiler)
+    ctx = _LoweringDispatcher(
+      compiler=compiler,
+      table=table,
+      target_dialect_name=self.target_dialect_name,
+    )
+    return ctx.lower(prog)
+
+  def _build_table(self, compiler: Any) -> dict[type, Lowering]:
+    '''Build the per-pass dispatch table mapping source op type to
+    registered Lowering for `self.target_dialect_name`.
+
+    Raises `AmbiguousLowering` if two registrations claim the same
+    source op type for this target.
+
+    A Lowering registered on dialect D targets D — i.e., it appears
+    in `D.lowerings` and produces ops in D's vocabulary. So we walk
+    all dialects and select Lowerings that belong to the target
+    dialect (registered on it).
+    '''
+    table: dict[type, Lowering] = {}
+    for d in compiler.dialects:
+      if d.name != self.target_dialect_name:
+        continue
+      for low in d.lowerings:
+        if low.matches in table:
+          raise AmbiguousLowering(low.matches, self.target_dialect_name)
+        table[low.matches] = low
+    return table
+
+
+@dataclass(frozen=True)
+class RewritePass(Pass):
+  '''Intra-dialect, op-driven, per-op dispatch (fixpoint optional).
+
+  Walks the input tree; for each op, looks up registered
+  `@rewrite(self.dialect_name, type(op))` and applies it. The
+  result must be in the same dialect (or in declared
+  `consumes`/`produces` dialects).
+
+  Implemented on top of `strategy.bottom_up` + `strategy.repeat`:
+  one bottom-up sweep applies every applicable rewrite at every op;
+  with `until_fixpoint=True` (default), `repeat` re-runs until the
+  tree stops changing.
+
+  Per `compiler_redesign.md` §4: used for MIR pragma materialization
+  (one-shot), MIR opts (R1–R5, fixpoint), IIR canonicalization
+  (fixpoint).
+  '''
+
+  dialect_name: str = ''
+  until_fixpoint: bool = True
+
+  def apply(self, prog: Any, compiler: Any) -> Any:
+    rewrites_by_type = self._build_table(compiler)
+    if not rewrites_by_type:
+      return prog
+
+    def _rewrite_one(op: Any) -> Any | None:
+      rs = rewrites_by_type.get(type(op))
+      if not rs:
+        return None
+      changed_any = False
+      for r in rs:
+        new = r.apply(op, compiler)
+        if new is not None and new is not op:
+          op = new
+          changed_any = True
+      return op if changed_any else None
+
+    sweep = bottom_up(_rewrite_one)
+    if self.until_fixpoint:
+      driver = repeat(sweep)
+      return driver(prog)
+    return sweep(prog)
+
+  def _build_table(self, compiler: Any) -> dict[type, list[Rewrite]]:
+    '''Build a dispatch table mapping op type to the list of
+    Rewrites registered on the named dialect that match it.
+
+    A dialect may register multiple rewrites for the same op type
+    (unlike Lowerings). They are tried in registration order in one
+    bottom-up sweep.
+    '''
+    table: dict[type, list[Rewrite]] = {}
+    for d in compiler.dialects:
+      if d.name != self.dialect_name:
+        continue
+      for r in d.rewrites:
+        table.setdefault(r.matches, []).append(r)
+    return table
+
+
+@dataclass(frozen=True)
+class ProgramPass(Pass):
+  '''Whole-program transformation. Per `docs/phase_d_hir_passes.md`
+  §2 (ProgramPass contract).
+
+  Used for HIR planning passes that operate on `HirProgram` as a
+  unit (stratify, semi-naive variant generation, plan, index
+  selection, ...).
+
+  HIR types are mutable planning records (not Op-subclassed), so
+  they can't be walked by `LoweringPass` / `RewritePass` per-op
+  dispatch. `ProgramPass` is the explicit escape hatch for
+  whole-program transformations.
+
+  The function is called as `fn(prog, compiler)` and may mutate or
+  replace the program. Per the redesign §4: used ONLY for HIR
+  planning; MIR / IIR transformations must be `LoweringPass` or
+  `RewritePass`.
+  '''
+
+  fn: Callable[[Any, Any], Any] = field(default=lambda prog, _c: prog)
+
+  def apply(self, prog: Any, compiler: Any) -> Any:
+    return self.fn(prog, compiler)
+
+
+def program_pass(
+  *,
+  name: str,
+  consumes: tuple[str, ...] = (),
+  produces: tuple[str, ...] = (),
+) -> Callable[[Callable[[Any, Any], Any]], ProgramPass]:
+  '''Decorator: wrap a function as a `ProgramPass` instance.
+
+  Usage:
+
+      @program_pass(name="stratify",
+                    consumes=("hir",),
+                    produces=("hir",))
+      def stratify_pass(prog, compiler):
+          ...   # imperative HIR transformation
+          return prog
+
+  The decorated name is replaced by the `ProgramPass` instance, so
+  it can be inserted directly into a pipeline list. Per
+  `phase_d_hir_passes.md` §3.1.
+  '''
+
+  def _wrap(fn: Callable[[Any, Any], Any]) -> ProgramPass:
+    return ProgramPass(
+      name=name,
+      consumes=tuple(consumes),
+      produces=tuple(produces),
+      fn=fn,
+    )
+
+  return _wrap
+
+
 __all__ = [
+  'AmbiguousLowering',
   'Lowering',
+  'LoweringMissingError',
+  'LoweringPass',
+  'Pass',
   'PassDependencyError',
   'PassDriver',
+  'PassOrderingError',
+  'ProgramPass',
   'Rewrite',
+  'RewritePass',
   'lowering',
+  'program_pass',
   'rewrite',
   'verifier',
 ]

--- a/tests/test_core_pass_kinds.py
+++ b/tests/test_core_pass_kinds.py
@@ -1,0 +1,424 @@
+'''F1 / Layer 1 foundation tests — `Pass` kinds + `Compiler.run`.
+
+Covers the contract from `docs/compiler_redesign.md` §4 (the three
+Pass kinds) and `docs/phase_b_lowering_dispatcher.md` §2 (LoweringPass
+algorithm) and `docs/phase_d_hir_passes.md` §2 (ProgramPass contract).
+
+This file is self-contained: synthetic `Op` + `Dialect` fixtures, no
+import of any production dialect. F1 ships only the dispatcher
+shape; the full 5-field LowerCtx (compiler_redesign.md §5) lands in F3.
+'''
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+
+import pytest
+
+from srdatalog.ir.core import (
+  AmbiguousLowering,
+  Compiler,
+  Dialect,
+  LoweringMissingError,
+  LoweringPass,
+  Op,
+  Pass,
+  PassOrderingError,
+  ProgramPass,
+  RewritePass,
+  program_pass,
+)
+from srdatalog.ir.core.passes import lowering, rewrite
+
+# -----------------------------------------------------------------------------
+# Synthetic op fixtures (no production dialect imports)
+# -----------------------------------------------------------------------------
+
+
+@dataclass(frozen=True, slots=True)
+class _SrcLeaf(Op):
+  '''Source-dialect leaf op carrying an integer payload.'''
+
+  value: int
+
+
+@dataclass(frozen=True, slots=True)
+class _SrcWrap(Op):
+  '''Source-dialect wrapper holding one inner source op (used to
+  exercise explicit ctx.lower(child) recursion).'''
+
+  inner: Any
+
+
+@dataclass(frozen=True, slots=True)
+class _TgtLeaf(Op):
+  '''Target-dialect leaf op carrying the lowered payload.'''
+
+  value: int
+
+
+@dataclass(frozen=True, slots=True)
+class _TgtWrap(Op):
+  '''Target-dialect wrapper holding one lowered inner op.'''
+
+  inner: Any
+
+
+@dataclass(frozen=True, slots=True)
+class _SameDialectOp(Op):
+  '''Op used to exercise RewritePass intra-dialect rewriting. The
+  rewrite halves `n` until 0; fixpoint when n=0.'''
+
+  n: int
+
+
+# -----------------------------------------------------------------------------
+# Pass abstractness (T1)
+# -----------------------------------------------------------------------------
+
+
+def test_pass_is_abstract():
+  '''Instantiating `Pass(...)` directly fails (abstract base).'''
+  with pytest.raises(TypeError, match="abstract"):
+    Pass(name='bad')  # type: ignore[abstract]
+
+
+# -----------------------------------------------------------------------------
+# LoweringPass dispatch (T2 - T5)
+# -----------------------------------------------------------------------------
+
+
+def _src_dialect() -> Dialect:
+  d = Dialect(name='test.src')
+  d.ops = [_SrcLeaf, _SrcWrap]
+  return d
+
+
+def _tgt_dialect() -> Dialect:
+  d = Dialect(name='test.tgt')
+  d.ops = [_TgtLeaf, _TgtWrap]
+  return d
+
+
+def test_lowering_pass_dispatches_registered_lowering():
+  '''A registered @lowering for the source op type is found and
+  applied by LoweringPass.apply.'''
+  src = _src_dialect()
+  tgt = _tgt_dialect()
+
+  @lowering(tgt, _SrcLeaf, consumes=('test.src',), produces=('test.tgt',))
+  def _l_leaf(op, ctx):
+    return _TgtLeaf(value=op.value * 10)
+
+  c = Compiler()
+  c.register_dialect(src)
+  c.register_dialect(tgt)
+
+  p = LoweringPass(
+    name='src_to_tgt',
+    consumes=('test.src',),
+    produces=('test.tgt',),
+    target_dialect_name='test.tgt',
+  )
+  out = p.apply(_SrcLeaf(value=3), c)
+  assert out == _TgtLeaf(value=30)
+
+
+def test_lowering_pass_missing_handler_raises():
+  '''An op whose type has no registered @lowering raises
+  LoweringMissingError at dispatch time.'''
+  src = _src_dialect()
+  tgt = _tgt_dialect()
+
+  c = Compiler()
+  c.register_dialect(src)
+  c.register_dialect(tgt)
+
+  p = LoweringPass(
+    name='src_to_tgt_empty',
+    consumes=('test.src',),
+    produces=('test.tgt',),
+    target_dialect_name='test.tgt',
+  )
+  with pytest.raises(LoweringMissingError) as ei:
+    p.apply(_SrcLeaf(value=1), c)
+  assert ei.value.op_type is _SrcLeaf
+  assert ei.value.target_dialect_name == 'test.tgt'
+
+
+def test_lowering_pass_ambiguous_registration_raises():
+  '''Two @lowering for the same source op type on the same target
+  dialect raises AmbiguousLowering at apply-time table build.'''
+  src = _src_dialect()
+  tgt = _tgt_dialect()
+
+  @lowering(tgt, _SrcLeaf)
+  def _l1(op, ctx):
+    return _TgtLeaf(value=op.value)
+
+  @lowering(tgt, _SrcLeaf)
+  def _l2(op, ctx):
+    return _TgtLeaf(value=op.value + 1)
+
+  c = Compiler()
+  c.register_dialect(src)
+  c.register_dialect(tgt)
+
+  p = LoweringPass(
+    name='src_to_tgt_amb',
+    consumes=('test.src',),
+    produces=('test.tgt',),
+    target_dialect_name='test.tgt',
+  )
+  with pytest.raises(AmbiguousLowering) as ei:
+    p.apply(_SrcLeaf(value=1), c)
+  assert ei.value.source_op_type is _SrcLeaf
+  assert ei.value.target_dialect_name == 'test.tgt'
+
+
+def test_lowering_pass_explicit_recursion():
+  '''A lowering that calls ctx.lower(child) recursively works on a
+  synthetic op tree (per R1: explicit recursion, not auto-walk).'''
+  src = _src_dialect()
+  tgt = _tgt_dialect()
+
+  @lowering(tgt, _SrcLeaf)
+  def _l_leaf(op, ctx):
+    return _TgtLeaf(value=op.value + 100)
+
+  @lowering(tgt, _SrcWrap)
+  def _l_wrap(op, ctx):
+    # Explicit recursion into the child — no auto-walk.
+    return _TgtWrap(inner=ctx.lower(op.inner))
+
+  c = Compiler()
+  c.register_dialect(src)
+  c.register_dialect(tgt)
+
+  p = LoweringPass(
+    name='src_to_tgt_rec',
+    consumes=('test.src',),
+    produces=('test.tgt',),
+    target_dialect_name='test.tgt',
+  )
+  tree = _SrcWrap(inner=_SrcWrap(inner=_SrcLeaf(value=7)))
+  out = p.apply(tree, c)
+  assert out == _TgtWrap(inner=_TgtWrap(inner=_TgtLeaf(value=107)))
+
+
+# -----------------------------------------------------------------------------
+# RewritePass (T6)
+# -----------------------------------------------------------------------------
+
+
+def test_rewrite_pass_runs_to_fixpoint():
+  '''A registered @rewrite is applied to fixpoint by RewritePass.
+
+  We register a rule that halves `n` (rounding toward zero) on
+  _SameDialectOp; starting from n=8, fixpoint is n=0.
+  '''
+  d = Dialect(name='test.rw')
+  d.ops = [_SameDialectOp]
+
+  @rewrite(d, _SameDialectOp)
+  def _halve(op, ctx):
+    if op.n == 0:
+      return None
+    return _SameDialectOp(n=op.n // 2)
+
+  c = Compiler()
+  c.register_dialect(d)
+
+  p = RewritePass(
+    name='halve_to_zero',
+    consumes=('test.rw',),
+    produces=('test.rw',),
+    dialect_name='test.rw',
+    until_fixpoint=True,
+  )
+  out = p.apply(_SameDialectOp(n=8), c)
+  assert out == _SameDialectOp(n=0)
+
+
+def test_rewrite_pass_one_shot_when_no_fixpoint():
+  '''until_fixpoint=False applies one bottom-up sweep only.'''
+  d = Dialect(name='test.rw.once')
+  d.ops = [_SameDialectOp]
+
+  @rewrite(d, _SameDialectOp)
+  def _halve(op, ctx):
+    if op.n == 0:
+      return None
+    return _SameDialectOp(n=op.n // 2)
+
+  c = Compiler()
+  c.register_dialect(d)
+
+  p = RewritePass(
+    name='halve_once',
+    consumes=('test.rw.once',),
+    produces=('test.rw.once',),
+    dialect_name='test.rw.once',
+    until_fixpoint=False,
+  )
+  out = p.apply(_SameDialectOp(n=8), c)
+  assert out == _SameDialectOp(n=4)
+
+
+# -----------------------------------------------------------------------------
+# ProgramPass + program_pass decorator (T7, T8)
+# -----------------------------------------------------------------------------
+
+
+def test_program_pass_invokes_fn_once_with_prog_and_compiler():
+  '''A ProgramPass with a closure verifies the fn is called once
+  with (prog, compiler) and its return is threaded out.'''
+  call_log: list[tuple[Any, Any]] = []
+
+  def _fn(prog, compiler):
+    call_log.append((prog, compiler))
+    return ('transformed', prog)
+
+  c = Compiler()
+  p = ProgramPass(name='hello', consumes=(), produces=(), fn=_fn)
+  out = p.apply('input', c)
+
+  assert call_log == [('input', c)]
+  assert out == ('transformed', 'input')
+
+
+def test_program_pass_decorator_returns_program_pass_instance():
+  '''@program_pass(...) wraps a function as a ProgramPass instance
+  with the declared name/consumes/produces.'''
+
+  @program_pass(name='stratify', consumes=('hir',), produces=('hir',))
+  def stratify_pass(prog, compiler):
+    return prog
+
+  assert isinstance(stratify_pass, ProgramPass)
+  assert stratify_pass.name == 'stratify'
+  assert stratify_pass.consumes == ('hir',)
+  assert stratify_pass.produces == ('hir',)
+  # Smoke: invoking it threads the prog through.
+  c = Compiler()
+  assert stratify_pass.apply('hir-prog', c) == 'hir-prog'
+
+
+# -----------------------------------------------------------------------------
+# Compiler.run pipeline composition (T9)
+# -----------------------------------------------------------------------------
+
+
+def test_compiler_run_pipeline_threads_prog_through_passes():
+  '''A pipeline of [LoweringPass, RewritePass, ProgramPass] runs in
+  order, threading prog through each.'''
+  src = _src_dialect()
+  tgt = _tgt_dialect()
+
+  # Tag tgt as also a "rewriting" dialect.
+  @lowering(tgt, _SrcLeaf)
+  def _l_leaf(op, ctx):
+    return _TgtLeaf(value=op.value + 1)
+
+  @rewrite(tgt, _TgtLeaf)
+  def _bump_until_5(op, ctx):
+    if op.value >= 5:
+      return None
+    return _TgtLeaf(value=op.value + 1)
+
+  c = Compiler()
+  c.register_dialect(src)
+  c.register_dialect(tgt)
+
+  trace: list[str] = []
+
+  lp = LoweringPass(
+    name='lp',
+    consumes=('test.src',),
+    produces=('test.tgt',),
+    target_dialect_name='test.tgt',
+  )
+  rp = RewritePass(
+    name='rp',
+    consumes=('test.tgt',),
+    produces=('test.tgt',),
+    dialect_name='test.tgt',
+    until_fixpoint=True,
+  )
+
+  def _final(prog, compiler):
+    trace.append(f'final({prog!r})')
+    return ('done', prog)
+
+  pp = ProgramPass(name='pp', consumes=('test.tgt',), produces=('test.tgt',), fn=_final)
+
+  out = c.run(_SrcLeaf(value=2), pipeline=[lp, rp, pp])
+  # 2 → lower → TgtLeaf(3) → rewrite-to-fixpoint → TgtLeaf(5) → pp → ('done', TgtLeaf(5))
+  assert out == ('done', _TgtLeaf(value=5))
+  assert trace == ['final(_TgtLeaf(value=5))']
+
+
+# -----------------------------------------------------------------------------
+# Pass ordering validation (T10, T11)
+# -----------------------------------------------------------------------------
+
+
+def test_compiler_run_raises_pass_ordering_error_for_unmet_consumes():
+  '''A pipeline whose Pass requires a dialect that no earlier Pass
+  produces (and that isn't registered with the Compiler) raises
+  PassOrderingError at construction-time validation, before any
+  Pass.apply runs.'''
+  c = Compiler()  # no dialects registered
+
+  applied: list[str] = []
+
+  def _record(name):
+    def _fn(prog, compiler):
+      applied.append(name)
+      return prog
+
+    return _fn
+
+  p1 = ProgramPass(name='p1', consumes=(), produces=('a',), fn=_record('p1'))
+  # p2 requires 'b' but neither registered nor produced earlier.
+  p2 = ProgramPass(name='p2', consumes=('b',), produces=(), fn=_record('p2'))
+
+  with pytest.raises(PassOrderingError) as ei:
+    c.run('prog', pipeline=[p1, p2])
+  assert ei.value.pass_name == 'p2'
+  assert ei.value.missing == 'b'
+  assert ei.value.position == 1
+  # No pass should have been applied.
+  assert applied == []
+
+
+def test_compiler_run_ordering_satisfied_by_compiler_registration():
+  '''Pipeline Pass with consumes=('test.src',) is satisfied because
+  the dialect is registered on the Compiler at run start.'''
+  src = _src_dialect()
+  c = Compiler()
+  c.register_dialect(src)
+
+  applied: list[str] = []
+
+  def _fn(prog, compiler):
+    applied.append('p1')
+    return prog
+
+  p1 = ProgramPass(name='p1', consumes=('test.src',), produces=(), fn=_fn)
+  out = c.run('hello', pipeline=[p1])
+  assert out == 'hello'
+  assert applied == ['p1']
+
+
+def test_compiler_run_ordering_satisfied_by_earlier_pass():
+  '''A Pass whose consumes is satisfied by an earlier Pass's produces
+  (rather than a registered dialect) passes validation.'''
+  c = Compiler()  # no dialects registered
+
+  p1 = ProgramPass(name='p1', consumes=(), produces=('synthetic',), fn=lambda prog, _c: prog)
+  p2 = ProgramPass(name='p2', consumes=('synthetic',), produces=(), fn=lambda prog, _c: prog)
+  # Should not raise.
+  out = c.run('prog', pipeline=[p1, p2])
+  assert out == 'prog'


### PR DESCRIPTION
## Summary

Implementation of F1 (Pass kinds framework) per [\`docs/compiler_redesign.md\`](docs/compiler_redesign.md) §4 + R1 research findings + [\`docs/phase_zero_prerequisites.md\`](docs/phase_zero_prerequisites.md) §3.1. Stacked on the design package PR #27.

**Implemented by parallel subagent** (Agent B), reviewed + verified rebased onto latest design/redesign-package. Single commit (\`dd018ac\`).

Lands the foundation for F3 (LowerCtx), F4 (plugin discovery), F5 (declarative pipeline shim), and all of Wave 2A/2B/2C/2D.

## What lands

\`src/srdatalog/ir/core/passes.py\` — additive (existing \`Lowering\`, \`Rewrite\`, \`PassDriver\`, \`@lowering\`/\`@rewrite\`/\`@verifier\` decorators untouched):

\`\`\`python
@dataclass(frozen=True)
class Pass(ABC):
    name: str
    consumes: tuple[str, ...] = ()
    produces: tuple[str, ...] = ()
    @abstractmethod
    def apply(self, prog, compiler) -> Any: ...

@dataclass(frozen=True)
class LoweringPass(Pass):
    target_dialect_name: str = ''     # cross-dialect, source-driven dispatch

@dataclass(frozen=True)
class RewritePass(Pass):
    dialect_name: str = ''
    until_fixpoint: bool = True       # built on strategy.bottom_up + repeat

@dataclass(frozen=True)
class ProgramPass(Pass):
    fn: Callable[[Any, Any], Any] = field(default=lambda prog, _c: prog)

@program_pass(name=..., consumes=..., produces=...) def f(prog, compiler): ...
\`\`\`

Plus: \`PassOrderingError\`, \`AmbiguousLowering\`, \`LoweringMissingError\`, \`_LoweringDispatcher\` (internal — F3 promotes to public \`LowerCtx\`).

\`src/srdatalog/ir/core/dialect.py\` — added \`Compiler.run(prog, *, pipeline: list[Pass])\`:
- Pre-flight construction-time validation: walk pipeline, maintain \`available_dialects: set[str]\`, raise \`PassOrderingError\` on \`consumes\` mismatch BEFORE any pass executes.
- Then dispatches \`apply\` per pass, threading prog through.

\`src/srdatalog/ir/core/__init__.py\` — re-exported new public surface (9 new symbols).

\`tests/test_core_pass_kinds.py\` — 13 new tests, self-contained synthetic-op fixtures (no real-dialect imports).

## Spec deviation worth noting

The spec referenced \`apply_rewrites_to_fixpoint\` as "already implemented" in \`core/passes.py\`. **It doesn't exist on this branch's base** — that's downstream work in PR #25/#26 not yet on the integration branch. Agent B built \`RewritePass.apply\` directly on \`strategy.bottom_up\` + \`strategy.repeat\` (the underlying primitives). Same shape, lower level. When PR #25/#26 are eventually integrated downstream, the existing \`apply_rewrites_to_fixpoint\` becomes a candidate replacement OR the two coexist (one is the framework primitive, the other a higher-level convenience).

Other (minor):
- \`_LoweringDispatcher\` carries a \`target_dialect_name\` field (cleaner error messages than stashing in a closure).
- All Pass kinds use \`@dataclass(frozen=True)\` over \`ABC\`; subclass-specific fields all have defaults to avoid Python's "non-default field after default" inheritance error. The defaults are sometimes awkward (empty string for required-by-convention fields like \`target_dialect_name=''\`); this is a known dataclass-inheritance limitation.

## Conflict warning

This PR and **PR #29 (\`feat/core-pragma-base\`)** both modify \`src/srdatalog/ir/core/__init__.py\` with additive \`__all__\` exports. A merge conflict on that file is expected — purely mechanical (both add to the same list). Whoever merges second resolves by union.

Suggested merge order: **#29 first, then this PR rebases on post-#29 design/redesign-package**, OR vice versa. No semantic conflict.

## What this PR does NOT do

- ❌ Full \`LowerCtx\` 5-field implementation — F3.
- ❌ Plugin discovery / \`Compiler.with_default_plugins()\` — F4.
- ❌ \`MirPragmaPass\` — depends on \`core/pragma.py\` (PR #29) + Phase C.
- ❌ \`DEFAULT_PIPELINE\` in \`pipeline.py\` — F5.
- ❌ Modifications to existing dialect modules.
- ❌ Modifications to the existing \`PassDriver\` — left as-is; new Pass kinds are additive.
- ❌ MIR-level @lowering registrations — Phase B (Wave 2A).

## Test plan

- [x] \`python -m pytest -q\` — **1079 passed, 6 skipped**. (Per Agent B's worktree.)
- [x] \`ruff check\` + \`ruff format --check\` — clean.
- [x] 13 new tests cover: Pass abstract; LoweringPass dispatch + missing handler + ambiguous registration + explicit recursion; RewritePass fixpoint; ProgramPass invokes fn; \`@program_pass\` decorator; \`Compiler.run\` pipeline composition; \`PassOrderingError\` at construction; happy-path validation.

## Reviewer checklist (per code_discipline.md §4)

- [x] Discipline CI: tests pass.
- [x] No new \`if\`-branch in existing lowerings (additive only).
- [x] Every new registration has a test: \`@program_pass\` decorator, \`Compiler.run\`, all three Pass kinds tested.
- [x] Byte-equivalence preserved: full byte-equiv suite green (no production code path touched; new types not yet wired into production).
- [x] No new file in \`core/\` outside additions to \`passes.py\` and \`dialect.py\`.
- [x] No new pragma name appears in \`core/\`.
- [x] Diff size: 3 modified files in core, 1 new test file.
- [x] \`LowerCtx\` not extended (this PR doesn't touch \`LowerCtx\`; F3 lands it).
- [x] PR description references the design doc + R1 research findings.
- [ ] **Reviewer comment "Verified no shortcut" required before merge.**
- [ ] **Conflict with PR #29 on \`core/__init__.py\` resolved at merge time.**

🤖 Implementation by parallel subagent. Reviewed + verified by Claude Opus 4.7.