### PR TITLE
F-D18: transitional state ratchet test (17 shims tracked)

### DIFF
--- a/tests/test_discipline_transitional_state_ratchet.py
+++ b/tests/test_discipline_transitional_state_ratchet.py
@@ -1,0 +1,110 @@
+'''D18 — transitional mutable state ratchet test.
+
+Per `docs/code_discipline.md` §2 D18 + `docs/phase_zero_prerequisites.md`
+§2.1: any `object.__setattr__(...)` call on a frozen `Op` subclass is
+transitional tech-debt that MUST be removed in a named follow-up
+phase. The cap below pins the current count; CI fails if the count
+goes UP.
+
+This is the V1 scaffold — covers sub-category (a) only:
+
+  (a) `object.__setattr__` shims on frozen Op subclasses (THIS TEST)
+  (b) `# DEPRECATED:` fields on dataclasses pending removal (FUTURE)
+  (c) module-global mutable registries with per-Compiler target (FUTURE)
+
+(b) and (c) extend this test file when those patterns are established.
+
+Same ratchet shape as D5 (`test_iir_no_raw_string_growth`, whole-tree
+scan) and D12 (`USE_DECLARATIVE` monotonic-add). The cap stays at or
+below the current count; A2/A3 reduces it; Layer 3 cleanup hits zero.
+
+A1's inventory baseline (from `docs/phase_a_mir_onto_op.md` §8):
+  - `ir/codegen/cuda/envelope.py` — `_assign_handle_positions_rec`
+  - `ir/codegen/cuda/pipeline_utils.py` — `_assign_handle_positions_rec` twin
+  - `ir/codegen/cuda/orchestrator.py` — `_gen_parallel_group` concurrent_write
+  - `ir/mir/passes.py` — reorder / source-spec / balanced-scan passes
+'''
+
+from __future__ import annotations
+
+from pathlib import Path
+
+# Whole IR + codegen tree. The shim pattern is only relevant inside
+# `src/srdatalog/ir/` (frozen-Op land); other packages don't have a
+# frozen-Op contract, so they don't need to be ratcheted here.
+_SRC_ROOTS = (Path(__file__).resolve().parent.parent / 'src' / 'srdatalog' / 'ir',)
+
+# Files explicitly excluded from the ratchet. Anything listed here is
+# permanent framework infra (NOT a transition shim) and must carry an
+# inline rationale in the source file plus an entry in D18 of
+# `docs/code_discipline.md`.
+#
+# Currently empty: every `object.__setattr__(` call site under
+# `src/srdatalog/ir/` at the time this test ships is an A1-era
+# transition shim. `core/pragma.py` does not use the shim pattern
+# (the typed-Pragma registry is built by class-body decorators, not
+# instance mutation).
+_EXCLUDED: frozenset[Path] = frozenset()
+
+
+def _all_shim_sites() -> dict[Path, int]:
+  '''Return ``{path: count}`` for every src file under `_SRC_ROOTS`
+  that contains `object.__setattr__(` calls (excluding `_EXCLUDED`).
+  '''
+  out: dict[Path, int] = {}
+  for root in _SRC_ROOTS:
+    for p in root.rglob('*.py'):
+      if p in _EXCLUDED:
+        continue
+      text = p.read_text()
+      n = text.count('object.__setattr__(')
+      if n > 0:
+        out[p] = n
+  return out
+
+
+# RATCHET: only DECREASE this. Increases require explicit owner
+# sign-off + amendment of D18 in `docs/code_discipline.md`.
+#
+# Snapshot taken at `feat/discipline-d18-ratchet` (post-A1, pre-A2):
+#   ir/mir/passes.py                      10
+#   ir/codegen/cuda/envelope.py            3
+#   ir/codegen/cuda/pipeline_utils.py      3
+#   ir/codegen/cuda/orchestrator.py        1
+#                                       ----
+#                              total      17
+_MAX_TRANSITIONAL_SHIMS = 17
+
+
+def test_no_transitional_shim_growth() -> None:
+  sites = _all_shim_sites()
+  total = sum(sites.values())
+  if total > _MAX_TRANSITIONAL_SHIMS:
+    repo_root = _SRC_ROOTS[0].parent.parent.parent
+    breakdown = '\n'.join(f'  {p.relative_to(repo_root)}: {n}' for p, n in sorted(sites.items()))
+    raise AssertionError(
+      f'object.__setattr__(...) shim count: {total}, cap is '
+      f'{_MAX_TRANSITIONAL_SHIMS}.\n'
+      f'Breakdown:\n{breakdown}\n\n'
+      'Per D18 (`docs/code_discipline.md` §2), any new '
+      '`object.__setattr__`\n'
+      'on a frozen Op subclass is transitional tech-debt. Either:\n'
+      '  (a) Remove an existing shim (preferred) and update the cap.\n'
+      '  (b) Add a `# TODO(phase-X): <action>` comment and motivate\n'
+      '      the new shim in the PR description.\n'
+      '  (c) If the new use is genuinely permanent (framework infra,\n'
+      '      not a transition), exclude the file in `_EXCLUDED` + amend\n'
+      '      D18 in `docs/code_discipline.md`.\n'
+      'See `docs/phase_zero_prerequisites.md` §2.1 for the contract.'
+    )
+
+
+def test_shim_count_pinned_exact() -> None:
+  '''If shim count drops below the cap, update `_MAX_TRANSITIONAL_SHIMS`
+  in the same commit. Strict ratchet — no silent slack.'''
+  total = sum(_all_shim_sites().values())
+  assert total == _MAX_TRANSITIONAL_SHIMS, (
+    f'object.__setattr__ shim count is {total}; cap is '
+    f'{_MAX_TRANSITIONAL_SHIMS}. If you removed a shim, update the '
+    f'cap to {total} in the same commit.'
+  )


### PR DESCRIPTION
## Summary

Implementation of D18 from \`docs/code_discipline.md\` — the transitional mutable state ratchet. Inventories all \`object.__setattr__(...)\` shims on frozen \`Op\` subclasses; cap pinned at 17; CI fails if count goes UP.

**Implemented by parallel subagent** (Agent D), reviewed. Single commit (\`63ca54b\`). No source changes — test file only.

## Inventory

| File | Shim count |
|---|---|
| \`src/srdatalog/ir/mir/passes.py\` | 10 |
| \`src/srdatalog/ir/codegen/cuda/envelope.py\` | 3 |
| \`src/srdatalog/ir/codegen/cuda/pipeline_utils.py\` | 3 |
| \`src/srdatalog/ir/codegen/cuda/orchestrator.py\` | 1 |
| **Total** | **17** |

Note: A1's docs cited "~6 sites" in \`mir/passes.py\`; **actual count is 10** (multi-statement reorder helpers expand to more shim calls than the doc summary suggested). Phase A docs will reconcile in a follow-up commit.

## What lands

\`tests/test_discipline_transitional_state_ratchet.py\` (NEW) — modeled exactly on the existing \`test_iir_no_raw_string_growth.py\` (D5 ratchet).

Two test functions:
- \`test_no_transitional_shim_growth\` — soft cap (≤ 17). Failure prints per-file breakdown + remediation menu.
- \`test_shim_count_pinned_exact\` — strict (== 17). If a shim is removed, the cap MUST be updated atomically in the same commit.

\`_EXCLUDED\` is empty. Verified \`core/pragma.py\` has zero \`object.__setattr__\` calls (typed-Pragma registry uses class-body decorators). \`mir/types.py\` also zero. No ambiguous cases.

## Step 3 dry-run validation (per the agent prompt)

Setting \`_MAX_TRANSITIONAL_SHIMS = 16\` (cap−1) failed both tests with descriptive messages — the per-file breakdown + a/b/c remediation menu fired correctly. Cap was restored to 17 before commit.

## V1 scope only — sub-categories (b) and (c) deferred

D18 has three sub-categories:
- **(a)** \`object.__setattr__\` shims on frozen Op — **THIS TEST**
- **(b)** \`# DEPRECATED:\` fields on dataclasses pending removal — FUTURE (extends this test)
- **(c)** module-global mutable registries with documented per-Compiler migration target — FUTURE

The test module docstring explicitly scopes (b) and (c) as future extensions.

## Test plan

- [x] \`pytest -q\` — **1192 passed, 6 skipped** (no regressions; +2 new tests).
- [x] \`ruff check\` + \`ruff format --check\` — clean.
- [x] No source files changed.
- [x] No markdown-link cross-refs in docstrings (sphinx-myst safe).

## Reviewer checklist (per code_discipline.md §4)

- [x] Discipline CI: tests pass.
- [x] No new \`if\`-branch in existing lowerings.
- [x] No new \`@lowering\` / \`@rewrite\` / \`@pragma_handler\` registrations.
- [x] Byte-equivalence preserved (no source change).
- [x] No new file in \`core/\`.
- [x] No new pragma name in \`core/\`.
- [x] Diff size: 1 new test file.
- [x] \`LowerCtx\` not extended.
- [x] PR description references \`code_discipline.md\` D18.
- [ ] **Reviewer comment "Verified no shortcut" required before merge.**

🤖 Implementation by parallel subagent. Reviewed by Claude Opus 4.7.