### PR TITLE
Phase A2.1: thread handle_start via dataclasses.replace (D18 ratchet 17 → 11)

### DIFF
--- a/src/srdatalog/ir/codegen/cuda/api.py
+++ b/src/srdatalog/ir/codegen/cuda/api.py
@@ -49,12 +49,15 @@ def compile_pipeline(ep: m.ExecutePipeline, *, target: Target = 'cuda') -> str:
     raise ValueError(f'compile_pipeline: unsupported target {target!r}')
 
   from srdatalog.ir.codegen.cuda.envelope import (
-    assign_handle_positions,
+    assign_handle_positions_in_ep,
     emit_full_file,
   )
 
-  pipeline = list(ep.pipeline)
-  pipeline = assign_handle_positions(pipeline)
+  # Rebuild EP with handle_start filled in on both pipeline ops AND the
+  # parallel source_specs references. `emit_full_file` reads handles
+  # off `ep.pipeline` via `count_handles`; `compile_kernel_body` walks
+  # `ep.pipeline` to assign view slots. Both must see the same handles.
+  ep = assign_handle_positions_in_ep(ep)
 
   # Standalone jit_batch shape uses handle_idx-based view slots; runner
   # contexts (compile_runner / compile_kernel_body) default to positional.

--- a/src/srdatalog/ir/codegen/cuda/complete_runner.py
+++ b/src/srdatalog/ir/codegen/cuda/complete_runner.py
@@ -38,7 +38,7 @@ import srdatalog.ir.dialects.relation.d2l  # noqa: F401
 import srdatalog.ir.mir.types as m
 from srdatalog.ir.codegen.cuda.materialized import is_materialized_pipeline
 from srdatalog.ir.codegen.cuda.pipeline_utils import (
-  assign_handle_positions,
+  assign_handle_positions_in_ep,
   has_balanced_scan,
   has_tiled_cartesian_eligible,
 )
@@ -936,9 +936,13 @@ def gen_complete_runner(
   # tail-mode fused kernel doesn't apply.
   is_fused_eligible = not is_count and not node.dedup_hash
 
-  # MIR is frozen; assign_handle_positions returns a new pipeline with
-  # replaced nodes (handle_start filled in).
-  mutable_pipe = assign_handle_positions(list(node.pipeline))
+  # MIR is frozen. Rebuild `node` with handle_start filled in on both
+  # the pipeline ops AND the parallel `source_specs` references —
+  # downstream consumers (e.g. _gen_kernel_bg_histogram ->
+  # compute_view_slot_offsets) read handle_start off source_specs, so
+  # both views must agree.
+  node = assign_handle_positions_in_ep(node)
+  mutable_pipe = list(node.pipeline)
 
   first_src = node.source_specs[0]
   first_schema = _src_schema(first_src)

--- a/src/srdatalog/ir/codegen/cuda/envelope.py
+++ b/src/srdatalog/ir/codegen/cuda/envelope.py
@@ -26,7 +26,8 @@ the legacy copies go with them.
 
 from __future__ import annotations
 
-from dataclasses import dataclass
+from dataclasses import dataclass, replace
+from typing import overload
 
 import srdatalog.ir.mir.types as m
 
@@ -71,46 +72,77 @@ JIT_FILE_FOOTER = """
 # -----------------------------------------------------------------------------
 
 
-def _assign_handle_positions_rec(node: m.MirNode, offset_box: list[int]) -> None:
-  '''Assign `handle_start` to this node and any children, IN PLACE.
+@overload
+def _assign_handle_positions_rec(
+  node: m.ColumnSource, offset_box: list[int]
+) -> m.ColumnSource: ...
+@overload
+def _assign_handle_positions_rec(node: m.MirNode, offset_box: list[int]) -> m.MirNode: ...
+def _assign_handle_positions_rec(node: m.MirNode, offset_box: list[int]) -> m.MirNode:
+  '''Return a copy of `node` with `handle_start` filled in (and any
+  source-bearing descendants rebuilt likewise). Pure: input `node` is
+  not mutated.
 
-  MIR is frozen post-Phase-A, but `source_specs` on the parent
-  ExecutePipeline holds parallel references to the same source ops as
-  `pipeline`. A `dataclasses.replace`-based rewrite would update one
-  reference and leave the other stale, causing the runner-side
-  rendering to read the old handle_start (-1).
-
-  Until A2/A3 introduces a proper MIR pass that materializes
-  handle_start once and threads the new pipeline back into
-  source_specs, use `object.__setattr__` to mutate in place. Mirrors
-  the shim in mir/types.py `_coerce_list_fields_to_tuple` and the one
-  in codegen/cuda/orchestrator.py for `concurrent_write`.
+  `offset_box` is a one-element list used as a mutable counter
+  (Python closures can't reassign captured ints). The walk order
+  preserves the legacy left-to-right pipeline traversal so the handle
+  counter advances identically — joins claim a slot first, then
+  recurse into their children.
   '''
   if isinstance(node, m.ColumnSource | m.Scan | m.Aggregate | m.Negation):
-    object.__setattr__(node, 'handle_start', offset_box[0])
+    new_node = replace(node, handle_start=offset_box[0])
     offset_box[0] += 1
-  elif isinstance(node, m.ColumnJoin | m.CartesianJoin):
-    object.__setattr__(node, 'handle_start', offset_box[0])
-    for src in node.sources:
-      _assign_handle_positions_rec(src, offset_box)
-  elif isinstance(node, m.BalancedScan):
-    object.__setattr__(node, 'handle_start', offset_box[0])
-    _assign_handle_positions_rec(node.source1, offset_box)
-    _assign_handle_positions_rec(node.source2, offset_box)
-  elif isinstance(node, m.PositionedExtract):
-    for src in node.sources:
-      _assign_handle_positions_rec(src, offset_box)
+    return new_node
+  if isinstance(node, m.ColumnJoin | m.CartesianJoin):
+    handle = offset_box[0]
+    new_sources = [_assign_handle_positions_rec(src, offset_box) for src in node.sources]
+    return replace(node, handle_start=handle, sources=new_sources)
+  if isinstance(node, m.BalancedScan):
+    handle = offset_box[0]
+    new_source1 = _assign_handle_positions_rec(node.source1, offset_box)
+    new_source2 = _assign_handle_positions_rec(node.source2, offset_box)
+    return replace(node, handle_start=handle, source1=new_source1, source2=new_source2)
+  if isinstance(node, m.PositionedExtract):
+    new_sources = [_assign_handle_positions_rec(src, offset_box) for src in node.sources]
+    return replace(node, sources=new_sources)
+  return node
 
 
 def assign_handle_positions(ops: list[m.MirNode]) -> list[m.MirNode]:
-  '''Assign `handle_start` to every source-bearing node in pipeline
-  order starting from 0. Returns the same list (mutates in place via
-  the `object.__setattr__` shim — see `_assign_handle_positions_rec`).
+  '''Return a NEW pipeline list where every source-bearing node has its
+  `handle_start` filled in. The handle counter starts at 0 and bumps
+  in pipeline-order, left-to-right — joins claim a slot before their
+  children recurse, matching the legacy in-place walk so byte-equiv
+  is preserved.
+
+  Caller rebinds: `pipeline = assign_handle_positions(pipeline)`. For
+  ExecutePipeline contexts where `source_specs` must agree with the
+  pipeline, prefer `assign_handle_positions_in_ep` instead.
   '''
   offset_box = [0]
-  for op in ops:
-    _assign_handle_positions_rec(op, offset_box)
-  return ops
+  return [_assign_handle_positions_rec(op, offset_box) for op in ops]
+
+
+def assign_handle_positions_in_ep(ep: m.ExecutePipeline) -> m.ExecutePipeline:
+  '''Return a NEW `ExecutePipeline` with `handle_start` filled in on
+  both the pipeline ops AND the parallel `source_specs` references.
+
+  `source_specs` holds flattened references to the same source ops
+  embedded inside the pipeline (joins flatten into their leaf
+  sources). When the pipeline is rebuilt with fresh handle_start
+  values, source_specs must be regenerated from the new pipeline so
+  downstream consumers (e.g. `compute_view_slot_offsets` in
+  `codegen.cuda.view_slots`) see matching handles, not stale -1s.
+
+  Mirrors `_extract_pipeline_sources` in `srdatalog.ir.hir.lower`.
+  '''
+  from srdatalog.ir.hir.lower import _extract_pipeline_sources
+
+  new_pipeline = assign_handle_positions(list(ep.pipeline))
+  new_source_specs: list[m.ColumnSource | m.Scan | m.Negation | m.Aggregate] = []
+  for op in new_pipeline:
+    _extract_pipeline_sources(op, new_source_specs)
+  return replace(ep, pipeline=new_pipeline, source_specs=new_source_specs)
 
 
 def count_handles(ops: list[m.MirNode]) -> int:
@@ -492,6 +524,7 @@ __all__ = [
   'JIT_FILE_PRELUDE',
   'ViewSpec',
   'assign_handle_positions',
+  'assign_handle_positions_in_ep',
   'collect_unique_view_specs',
   'count_handles',
   'emit_dedup_table_struct',

--- a/src/srdatalog/ir/codegen/cuda/pipeline_utils.py
+++ b/src/srdatalog/ir/codegen/cuda/pipeline_utils.py
@@ -13,16 +13,18 @@ What remains:
     whether to emit a balanced-scan kernel variant.
   - `has_tiled_cartesian_eligible` — runner uses this to decide
     whether to enable the tiled-Cartesian materialize path.
-  - `assign_handle_positions` / `count_handles_in_pipeline` — pipeline
-    pre-pass + view-slot counting. Note: `dialects.target.cuda.
-    envelope` has its own `assign_handle_positions` for the dialect
-    path; this one stays for the runner-side prepass that mutates
-    `mutable_pipe` before kernel emission.
+  - `assign_handle_positions` / `assign_handle_positions_in_ep` /
+    `count_handles_in_pipeline` — pipeline pre-pass + view-slot
+    counting. Note: `codegen.cuda.envelope` has its own
+    `assign_handle_positions` for the dialect path; this one stays for
+    the runner-side prepass. Both are pure: they return a new pipeline
+    (or new EP) with `handle_start` filled in, never mutating input.
 '''
 
 from __future__ import annotations
 
-from dataclasses import dataclass, field
+from dataclasses import dataclass, field, replace
+from typing import overload
 
 import srdatalog.ir.mir.types as m
 
@@ -92,12 +94,22 @@ def get_balanced_scan_info(ops: list[m.MirNode]) -> BalancedScanInfo:
 # -----------------------------------------------------------------------------
 
 
-def _assign_handle_positions_rec(node: m.MirNode, offset_box: list[int]) -> None:
-  '''Assign `handle_start` to this node and any children, IN PLACE
-  (via `object.__setattr__` shim — same pattern as the envelope.py
-  twin and as the orchestrator concurrent_write shim).
+@overload
+def _assign_handle_positions_rec(
+  node: m.ColumnSource, offset_box: list[int]
+) -> m.ColumnSource: ...
+@overload
+def _assign_handle_positions_rec(node: m.MirNode, offset_box: list[int]) -> m.MirNode: ...
+def _assign_handle_positions_rec(node: m.MirNode, offset_box: list[int]) -> m.MirNode:
+  '''Return a copy of `node` with `handle_start` filled in (and any
+  source-bearing descendants rebuilt likewise). Pure: input `node` is
+  not mutated.
 
-  `offset_box` is a single-element list used as a mutable counter.
+  Twin of `envelope._assign_handle_positions_rec` — they share the
+  same walk shape (joins claim a slot before recursing into their
+  children) so the runner-side and dialect-side handle assignment
+  agree byte-for-byte. `offset_box` is a single-element list used as
+  a mutable counter.
   '''
   if (
     isinstance(node, m.ColumnSource)
@@ -105,30 +117,52 @@ def _assign_handle_positions_rec(node: m.MirNode, offset_box: list[int]) -> None
     or isinstance(node, m.Aggregate)
     or isinstance(node, m.Negation)
   ):
-    object.__setattr__(node, 'handle_start', offset_box[0])
+    new_node = replace(node, handle_start=offset_box[0])
     offset_box[0] += 1
-  elif isinstance(node, m.ColumnJoin) or isinstance(node, m.CartesianJoin):
-    object.__setattr__(node, 'handle_start', offset_box[0])
-    for src in node.sources:
-      _assign_handle_positions_rec(src, offset_box)
-  elif isinstance(node, m.BalancedScan):
-    object.__setattr__(node, 'handle_start', offset_box[0])
-    _assign_handle_positions_rec(node.source1, offset_box)
-    _assign_handle_positions_rec(node.source2, offset_box)
-  elif isinstance(node, m.PositionedExtract):
-    for src in node.sources:
-      _assign_handle_positions_rec(src, offset_box)
+    return new_node
+  if isinstance(node, m.ColumnJoin) or isinstance(node, m.CartesianJoin):
+    handle = offset_box[0]
+    new_sources = [_assign_handle_positions_rec(src, offset_box) for src in node.sources]
+    return replace(node, handle_start=handle, sources=new_sources)
+  if isinstance(node, m.BalancedScan):
+    handle = offset_box[0]
+    new_source1 = _assign_handle_positions_rec(node.source1, offset_box)
+    new_source2 = _assign_handle_positions_rec(node.source2, offset_box)
+    return replace(node, handle_start=handle, source1=new_source1, source2=new_source2)
+  if isinstance(node, m.PositionedExtract):
+    new_sources = [_assign_handle_positions_rec(src, offset_box) for src in node.sources]
+    return replace(node, sources=new_sources)
+  return node
 
 
 def assign_handle_positions(ops: list[m.MirNode]) -> list[m.MirNode]:
-  '''Assign `handle_start` to every source-bearing node in pipeline
-  order starting from 0. Mutates in place via the shim; returns
-  `ops` for chain convenience. Mirrors Nim's assignHandlePositions.
+  '''Return a NEW pipeline list where every source-bearing node has its
+  `handle_start` filled in. Mirrors Nim's `assignHandlePositions`.
+
+  Caller rebinds: `pipeline = assign_handle_positions(pipeline)`. For
+  ExecutePipeline contexts where `source_specs` must agree with the
+  pipeline, prefer `assign_handle_positions_in_ep` instead.
   '''
   offset_box = [0]
-  for op in ops:
-    _assign_handle_positions_rec(op, offset_box)
-  return ops
+  return [_assign_handle_positions_rec(op, offset_box) for op in ops]
+
+
+def assign_handle_positions_in_ep(ep: m.ExecutePipeline) -> m.ExecutePipeline:
+  '''Return a NEW `ExecutePipeline` with `handle_start` filled in on
+  both the pipeline ops AND the parallel `source_specs` references.
+
+  Twin of `envelope.assign_handle_positions_in_ep` — they delegate to
+  the same `_extract_pipeline_sources` to keep source_specs aligned
+  with the rebuilt pipeline. See that function's docstring for why
+  rebuilding source_specs is required.
+  '''
+  from srdatalog.ir.hir.lower import _extract_pipeline_sources
+
+  new_pipeline = assign_handle_positions(list(ep.pipeline))
+  new_source_specs: list[m.ColumnSource | m.Scan | m.Negation | m.Aggregate] = []
+  for op in new_pipeline:
+    _extract_pipeline_sources(op, new_source_specs)
+  return replace(ep, pipeline=new_pipeline, source_specs=new_source_specs)
 
 
 def count_handles_in_pipeline(ops: list[m.MirNode]) -> int:

--- a/tests/test_discipline_transitional_state_ratchet.py
+++ b/tests/test_discipline_transitional_state_ratchet.py
@@ -66,14 +66,19 @@ def _all_shim_sites() -> dict[Path, int]:
 # RATCHET: only DECREASE this. Increases require explicit owner
 # sign-off + amendment of D18 in `docs/code_discipline.md`.
 #
-# Snapshot taken at `feat/discipline-d18-ratchet` (post-A1, pre-A2):
+# Snapshot taken at `feat/a2-1-handle-positions-threading` (post-A2.1):
 #   ir/mir/passes.py                      10
-#   ir/codegen/cuda/envelope.py            3
-#   ir/codegen/cuda/pipeline_utils.py      3
 #   ir/codegen/cuda/orchestrator.py        1
 #                                       ----
-#                              total      17
-_MAX_TRANSITIONAL_SHIMS = 17
+#                              total      11
+#
+# A2.1 removed the envelope.py + pipeline_utils.py
+# `_assign_handle_positions_rec` shims (6 sites) by threading
+# handle_start through `dataclasses.replace` and rebuilding the EP's
+# parallel `source_specs` references via `assign_handle_positions_in_ep`.
+# A2.2 removes the orchestrator concurrent_write shim. A2.3 removes
+# the mir/passes.py reorder shims.
+_MAX_TRANSITIONAL_SHIMS = 11
 
 
 def test_no_transitional_shim_growth() -> None:


### PR DESCRIPTION
## Summary

First A2 sub-task — replaces 6 of 17 D18 mutation shims (the \`assign_handle_positions\` family in \`envelope.py\` + \`pipeline_utils.py\`) with proper threading via \`dataclasses.replace\`. Drops the D18 ratchet from **17 → 11**.

**Implemented by parallel subagent** (Agent E). Single commit (\`25f92b0\`). Byte-equivalence preserved on first try across runner / JIT / dedup-hash suites.

## Shim count change

| File | Before | After |
|---|---|---|
| \`codegen/cuda/envelope.py\` | 3 | 0 |
| \`codegen/cuda/pipeline_utils.py\` | 3 | 0 |
| \`codegen/cuda/orchestrator.py\` | 1 | 1 (A2.2) |
| \`mir/passes.py\` | 10 | 10 (A2.3) |
| **Total** | **17** | **11** |

\`_MAX_TRANSITIONAL_SHIMS\` updated **17 → 11** in the same commit (per D18's "ratchet must be atomic" rule).

## Threading approach

1. **\`_assign_handle_positions_rec\` is now pure**: returns a fresh node via \`dataclasses.replace\`, recursing into children. Walk order (joins claim a slot before recursing into children) matches the legacy in-place version exactly so byte-equivalence holds.
2. **\`assign_handle_positions(ops)\`** returns a new pipeline list — caller rebinds.
3. **\`assign_handle_positions_in_ep(ep)\`** (NEW, in both \`envelope.py\` and \`pipeline_utils.py\`) — builds a fresh pipeline, then regenerates \`source_specs\` from the new pipeline using the existing \`_extract_pipeline_sources\` helper. Returns \`dataclasses.replace(ep, pipeline=..., source_specs=...)\`.

## Call site updates

| Caller | Change | Why |
|---|---|---|
| \`api.compile_pipeline\` | switched to \`assign_handle_positions_in_ep\` | \`emit_full_file\` reads handles off \`ep.pipeline\` via \`count_handles\` |
| \`api.compile_kernel_body\` | kept as \`pipeline = assign_handle_positions(pipeline)\` | never reads \`ep.source_specs\`; local pipeline form suffices |
| \`complete_runner._gen_complete_runner\` | rebinds \`node = assign_handle_positions_in_ep(node)\` | the BG histogram delegate calls \`compute_view_slot_offsets(node.source_specs, ...)\` — source_specs MUST carry the handles. **This was the byte-equivalence land-mine** that A1's shim was concealing. |

## ⚠️ Conflict with PR #31 (D18 ratchet)

This PR modifies \`tests/test_discipline_transitional_state_ratchet.py\` — but that file does NOT exist on \`design/redesign-package\` yet (it lives only on PR #31's branch).

Agent E pragmatically brought the file into this commit and updated the cap to 11. Resolution depends on merge order:

- **If PR #31 lands first (recommended)**: rebase this branch on post-#31 \`design/redesign-package\`. The rebase will turn the duplicate "add the file" into a "modify the cap from 17 to 11". Standard \`git rebase\` should resolve cleanly.
- **If this PR lands first**: PR #31 will conflict on the file (already added). PR #31 needs to drop its add-the-file commit and just become a no-op cleanup commit (the file is already there with cap=11; #31's tests still pass).

**Suggested:** merge PR #31 first, then rebase this PR.

## Test plan

- [x] \`pytest -q\` — **1192 passed, 6 skipped**. No regressions.
- [x] \`ruff check\` + \`ruff format --check\` — clean.
- [x] Byte-equivalence: full byte-equiv suites green (runner + JIT + dedup-hash).
- [x] D18 ratchet: cap=11 matches actual count of 11.
- [x] No markdown-link cross-refs in docstrings (sphinx-myst safe).

## What this PR does NOT do

- ❌ \`orchestrator.py\` \`concurrent_write\` shim — that's A2.2.
- ❌ \`mir/passes.py\` reorder pass shims — that's A2.3.
- ❌ Any new dialect / op / lowering registration.

## Reviewer checklist (per code_discipline.md §4)

- [x] Discipline CI: tests pass.
- [x] No new \`if\`-branch in existing lowerings (the threading is structural).
- [x] No new \`@lowering\` / \`@rewrite\` / \`@pragma_handler\`.
- [x] **Byte-equivalence preserved end-to-end on first try** (the threading hypothesis from \`docs/phase_a_mir_onto_op.md\` §8 was correct).
- [x] No new file in \`core/\`.
- [x] No new pragma name in \`core/\`.
- [x] Diff: 4 source modules touched (purely refactor; signatures changed from \`-> None\` to return types) + 1 test file (D18 cap update).
- [x] \`LowerCtx\` not extended.
- [x] PR description references \`docs/phase_a_mir_onto_op.md\` §8 + \`docs/code_discipline.md\` D18.
- [ ] **Reviewer comment "Verified no shortcut" required before merge.**
- [ ] **Conflict with PR #31 resolved at merge time** (see above).

🤖 Implementation by parallel subagent. Reviewed by Claude Opus 4.7.