### PR TITLE
F5.1: declarative pipeline shims (DEFAULT_PROGRAM/KERNEL_PIPELINE)

### DIFF
--- a/src/srdatalog/ir/default_pipelines.py
+++ b/src/srdatalog/ir/default_pipelines.py
@@ -1,0 +1,354 @@
+'''Declarative pipeline shims (F5.1).
+
+Spec: docs/phase_f5_declarative_pipeline.md.
+
+Two pipelines, each a `list[Pass]` of thin `ProgramPass` shims that
+wrap the existing imperative entry points without changing behavior:
+
+  DEFAULT_PROGRAM_PIPELINE — Program -> mir.Program
+    HirPlanningShim, HirToMirShim, MirOptShim, MirProgramAssembly
+
+  DEFAULT_KERNEL_PIPELINE  — KernelCtx(ep, ...) -> body string
+    AssignHandlesShim, CollectViewSpecsShim, EmitViewDeclsShim,
+    LowerScanPipelineShim, CudaRenderShim
+
+Each shim is a `ProgramPass` subclass mirroring one block of either
+`compile_to_mir` (src/srdatalog/ir/hir/__init__.py:96-124) or
+`compile_kernel_body` (src/srdatalog/ir/codegen/cuda/api.py:98-185).
+
+The through-state types `InitialProg` and `KernelCtx` are
+frozen+slots dataclasses; each shim returns a new instance via
+`dataclasses.replace`. F5.1 is pure addition — F5.2 + F5.3 cut the
+existing imperative entry points to call `Compiler.run` over these
+pipelines.
+'''
+
+from __future__ import annotations
+
+import dataclasses
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Any
+
+from srdatalog.ir.core import Pass, ProgramPass
+
+if TYPE_CHECKING:
+  from srdatalog.dsl import Program
+  from srdatalog.ir.codegen.cuda.envelope import ViewSpec
+  from srdatalog.ir.hir.types import HirProgram
+  from srdatalog.ir.mir import types as mir
+  from srdatalog.ir.mir.types import ExecutePipeline
+
+
+# -----------------------------------------------------------------------------
+# Through-state dataclasses
+# -----------------------------------------------------------------------------
+
+
+@dataclass(frozen=True, slots=True)
+class InitialProg:
+  '''Program-pipeline through-state. Threaded by the four
+  `DEFAULT_PROGRAM_PIPELINE` shims; each fills one field.'''
+
+  program: Program
+  hir: HirProgram | None = None
+  steps: list[tuple[mir.MirNode, bool]] | None = None
+  mir_program: mir.Program | None = None
+
+
+@dataclass(frozen=True, slots=True)
+class KernelCtx:
+  '''Kernel-pipeline through-state. Carries the original
+  `compile_kernel_body` kwargs plus the progressively populated
+  derived state (handle-assigned ep, view_specs, view_decls + var
+  maps, iir, body_text).'''
+
+  ep: ExecutePipeline
+  is_counting: bool
+  output_var_name: str = 'output'
+  output_vars: dict[str, str] | None = None
+  slot_mode: str = 'positional'
+  rel_index_types: dict[str, str] | None = None
+  tiled_cartesian: bool = False
+  bg_enabled: bool = False
+  # populated by shims:
+  view_specs: tuple[ViewSpec, ...] | None = None
+  view_decls: str | None = None
+  name_map: dict[str, str] | None = None
+  base_map: dict[str, int] | None = None
+  iir: Any = None
+  body_text: str | None = None
+
+
+# -----------------------------------------------------------------------------
+# Program-pipeline shims (mirror src/srdatalog/ir/hir/__init__.py:96-124)
+# -----------------------------------------------------------------------------
+
+
+class HirPlanningShim(ProgramPass):
+  '''Wraps `srdatalog.ir.hir.compile_to_hir`. Adds `hir` to state.'''
+
+  def __init__(self) -> None:
+    super().__init__(
+      name='hir_planning',
+      consumes=(),
+      produces=('hir',),
+      fn=self._fn,
+    )
+
+  @staticmethod
+  def _fn(state: InitialProg, _compiler: Any) -> InitialProg:
+    if state.hir is not None:
+      return state
+    from srdatalog.ir.hir import compile_to_hir
+
+    return dataclasses.replace(state, hir=compile_to_hir(state.program))
+
+
+class HirToMirShim(ProgramPass):
+  '''Wraps `srdatalog.ir.hir.lower.lower_hir_to_mir_steps`. Adds
+  `steps` to state.'''
+
+  def __init__(self) -> None:
+    super().__init__(
+      name='hir_to_mir',
+      consumes=('hir',),
+      produces=('mir_steps',),
+      fn=self._fn,
+    )
+
+  @staticmethod
+  def _fn(state: InitialProg, _compiler: Any) -> InitialProg:
+    from srdatalog.ir.hir.lower import lower_hir_to_mir_steps
+
+    assert state.hir is not None, 'HirToMirShim: hir not set'
+    return dataclasses.replace(state, steps=lower_hir_to_mir_steps(state.hir))
+
+
+class MirOptShim(ProgramPass):
+  '''Wraps `srdatalog.ir.mir.passes.apply_all_mir_passes`. Updates
+  `steps` in place.'''
+
+  def __init__(self) -> None:
+    super().__init__(
+      name='mir_opt',
+      consumes=('mir_steps',),
+      produces=('mir_steps',),
+      fn=self._fn,
+    )
+
+  @staticmethod
+  def _fn(state: InitialProg, _compiler: Any) -> InitialProg:
+    from srdatalog.ir.mir.passes import apply_all_mir_passes
+
+    assert state.steps is not None, 'MirOptShim: steps not set'
+    return dataclasses.replace(state, steps=apply_all_mir_passes(state.steps))
+
+
+class MirProgramAssembly(ProgramPass):
+  '''Wraps the final `mir.Program(steps=[...])` assembly. Adds
+  `mir_program` to state.'''
+
+  def __init__(self) -> None:
+    super().__init__(
+      name='mir_program_assembly',
+      consumes=('mir_steps',),
+      produces=('mir_program',),
+      fn=self._fn,
+    )
+
+  @staticmethod
+  def _fn(state: InitialProg, _compiler: Any) -> InitialProg:
+    from srdatalog.ir.mir import types as mir_types
+
+    assert state.steps is not None, 'MirProgramAssembly: steps not set'
+    prog = mir_types.Program(steps=[(node, is_rec) for node, is_rec in state.steps])
+    return dataclasses.replace(state, mir_program=prog)
+
+
+# -----------------------------------------------------------------------------
+# Kernel-pipeline shims (mirror src/srdatalog/ir/codegen/cuda/api.py:98-185)
+# -----------------------------------------------------------------------------
+
+
+class AssignHandlesShim(ProgramPass):
+  '''Wraps `srdatalog.ir.codegen.cuda.envelope.assign_handle_positions`.
+  Rebuilds `state.ep` with handle_starts assigned across the pipeline
+  body.'''
+
+  def __init__(self) -> None:
+    super().__init__(
+      name='assign_handles',
+      consumes=(),
+      produces=('ep_with_handles',),
+      fn=self._fn,
+    )
+
+  @staticmethod
+  def _fn(state: KernelCtx, _compiler: Any) -> KernelCtx:
+    from srdatalog.ir.codegen.cuda.envelope import assign_handle_positions
+
+    new_pipeline = assign_handle_positions(list(state.ep.pipeline))
+    new_ep = dataclasses.replace(state.ep, pipeline=new_pipeline)
+    return dataclasses.replace(state, ep=new_ep)
+
+
+class CollectViewSpecsShim(ProgramPass):
+  '''Wraps `collect_unique_view_specs` (envelope) — also exists to
+  realize that the per-spec view_count computation is consumed
+  exclusively by the next shim, so it lives there rather than on
+  the through-state.'''
+
+  def __init__(self) -> None:
+    super().__init__(
+      name='collect_view_specs',
+      consumes=('ep_with_handles',),
+      produces=('view_specs',),
+      fn=self._fn,
+    )
+
+  @staticmethod
+  def _fn(state: KernelCtx, _compiler: Any) -> KernelCtx:
+    from srdatalog.ir.codegen.cuda.envelope import collect_unique_view_specs
+
+    specs = collect_unique_view_specs(list(state.ep.pipeline))
+    return dataclasses.replace(state, view_specs=tuple(specs))
+
+
+class EmitViewDeclsShim(ProgramPass):
+  '''Wraps `emit_view_declarations` (envelope) plus `view_counts_for_specs`
+  (relation.d2l). Splits the combined `view_vars` dict into a name-only
+  map (handle_idx string -> view var) and a base-slot map (handle_idx
+  string -> int) per the `__base__` sentinel convention.'''
+
+  def __init__(self) -> None:
+    super().__init__(
+      name='emit_view_decls',
+      consumes=('view_specs',),
+      produces=('view_decls',),
+      fn=self._fn,
+    )
+
+  @staticmethod
+  def _fn(state: KernelCtx, _compiler: Any) -> KernelCtx:
+    from srdatalog.ir.codegen.cuda.envelope import emit_view_declarations
+    from srdatalog.ir.dialects.relation.d2l import view_counts_for_specs
+
+    assert state.view_specs is not None, 'EmitViewDeclsShim: view_specs not set'
+    specs = list(state.view_specs)
+    view_counts = view_counts_for_specs(specs, state.rel_index_types or {})
+    view_decls, view_vars = emit_view_declarations(
+      specs,
+      list(state.ep.pipeline),
+      slot_mode=state.slot_mode,
+      view_counts=view_counts,
+    )
+    name_map = {k: v for k, v in view_vars.items() if k.isdigit()}
+    base_map = {
+      k.removeprefix('__base__'): int(v) for k, v in view_vars.items() if k.startswith('__base__')
+    }
+    return dataclasses.replace(
+      state,
+      view_decls=view_decls,
+      name_map=name_map,
+      base_map=base_map,
+    )
+
+
+class LowerScanPipelineShim(ProgramPass):
+  '''Wraps `lower_scan_pipeline` (sorted_array dialect). Builds a
+  `LoweringCtx` from the populated state and runs the MIR -> IIR
+  walk. Adds `iir` to state.'''
+
+  def __init__(self) -> None:
+    super().__init__(
+      name='lower_scan_pipeline',
+      consumes=('view_decls',),
+      produces=('iir',),
+      fn=self._fn,
+    )
+
+  @staticmethod
+  def _fn(state: KernelCtx, _compiler: Any) -> KernelCtx:
+    from srdatalog.ir.dialects.relation.sorted_array.lowerings import (
+      LoweringCtx,
+      lower_scan_pipeline,
+    )
+
+    assert state.name_map is not None, 'LowerScanPipelineShim: name_map not set'
+    assert state.base_map is not None, 'LowerScanPipelineShim: base_map not set'
+    lower_ctx = LoweringCtx(
+      view_var_names=state.name_map,
+      is_counting=state.is_counting,
+      output_var=state.output_var_name,
+      output_var_overrides=dict(state.output_vars) if state.output_vars else {},
+      rel_index_types=dict(state.rel_index_types) if state.rel_index_types else {},
+      view_slot_bases=state.base_map,
+      dedup_hash=state.ep.dedup_hash,
+      tiled_cartesian=state.tiled_cartesian,
+      bg_enabled=state.bg_enabled,
+    )
+    iir = lower_scan_pipeline(list(state.ep.pipeline), lower_ctx)
+    return dataclasses.replace(state, iir=iir)
+
+
+class CudaRenderShim(ProgramPass):
+  '''Wraps `srdatalog.ir.codegen.cuda.emit.emit` with an
+  `EmitCtx(indent_level=4)`. Concatenates `view_decls` + emitted IIR
+  into the final `body_text`.'''
+
+  def __init__(self) -> None:
+    super().__init__(
+      name='cuda_render',
+      consumes=('iir',),
+      produces=('body_text',),
+      fn=self._fn,
+    )
+
+  @staticmethod
+  def _fn(state: KernelCtx, _compiler: Any) -> KernelCtx:
+    from srdatalog.ir.codegen.cuda.emit import EmitCtx, emit
+
+    assert state.iir is not None, 'CudaRenderShim: iir not set'
+    assert state.view_decls is not None, 'CudaRenderShim: view_decls not set'
+    emit_ctx = EmitCtx(indent_level=4)
+    body_text = state.view_decls + emit(state.iir, emit_ctx)
+    return dataclasses.replace(state, body_text=body_text)
+
+
+# -----------------------------------------------------------------------------
+# Pipeline singletons
+# -----------------------------------------------------------------------------
+
+
+DEFAULT_PROGRAM_PIPELINE: list[Pass] = [
+  HirPlanningShim(),
+  HirToMirShim(),
+  MirOptShim(),
+  MirProgramAssembly(),
+]
+
+
+DEFAULT_KERNEL_PIPELINE: list[Pass] = [
+  AssignHandlesShim(),
+  CollectViewSpecsShim(),
+  EmitViewDeclsShim(),
+  LowerScanPipelineShim(),
+  CudaRenderShim(),
+]
+
+
+__all__ = [
+  'DEFAULT_KERNEL_PIPELINE',
+  'DEFAULT_PROGRAM_PIPELINE',
+  'AssignHandlesShim',
+  'CollectViewSpecsShim',
+  'CudaRenderShim',
+  'EmitViewDeclsShim',
+  'HirPlanningShim',
+  'HirToMirShim',
+  'InitialProg',
+  'KernelCtx',
+  'LowerScanPipelineShim',
+  'MirOptShim',
+  'MirProgramAssembly',
+]

--- a/tests/test_default_pipelines_shims.py
+++ b/tests/test_default_pipelines_shims.py
@@ -1,0 +1,300 @@
+'''F5.1 smoke tests — declarative pipeline shims.
+
+Spec: docs/phase_f5_declarative_pipeline.md.
+
+Each shim runs in isolation against a hand-built minimal state, and
+both `DEFAULT_PROGRAM_PIPELINE` + `DEFAULT_KERNEL_PIPELINE` run
+end-to-end against a tiny TC-style program. F5.1 is pure addition;
+byte-equivalence to the imperative path is anchored separately in
+F5.4.
+'''
+
+from __future__ import annotations
+
+import srdatalog.ir.mir.types as mir
+from srdatalog.dsl import Program, Relation, Var
+from srdatalog.ir.core import Compiler, Pass
+from srdatalog.ir.default_pipelines import (
+  DEFAULT_KERNEL_PIPELINE,
+  DEFAULT_PROGRAM_PIPELINE,
+  AssignHandlesShim,
+  CollectViewSpecsShim,
+  CudaRenderShim,
+  EmitViewDeclsShim,
+  HirPlanningShim,
+  HirToMirShim,
+  InitialProg,
+  KernelCtx,
+  LowerScanPipelineShim,
+  MirOptShim,
+  MirProgramAssembly,
+)
+
+# -----------------------------------------------------------------------------
+# Fixtures
+# -----------------------------------------------------------------------------
+
+
+def _tc_program() -> Program:
+  '''Tiny TC-style program: ArcInput -> Edge, Edge -> Path (base + rec).'''
+  X, Y, Z = Var('x'), Var('y'), Var('z')
+  arc = Relation('ArcInput', 2)
+  edge = Relation('Edge', 2)
+  path = Relation('Path', 2)
+  return Program(
+    rules=[
+      (edge(X, Y) <= arc(X, Y)).named('EdgeLoad'),
+      (path(X, Y) <= edge(X, Y)).named('TCBase'),
+      (path(X, Z) <= path(X, Y) & edge(Y, Z)).named('TCRec'),
+    ],
+  )
+
+
+def _find_execute_pipelines(node: object) -> list[mir.ExecutePipeline]:
+  '''Walk a MIR plan and collect every ExecutePipeline. Mirrors the
+  shape of `_collect_pipelines` in batchfile.py for our test needs.'''
+  out: list[mir.ExecutePipeline] = []
+  if isinstance(node, mir.ExecutePipeline):
+    out.append(node)
+  elif isinstance(node, mir.FixpointPlan):
+    for inst in node.instructions:
+      out.extend(_find_execute_pipelines(inst))
+  elif isinstance(node, mir.ParallelGroup):
+    for op in node.ops:
+      out.extend(_find_execute_pipelines(op))
+  return out
+
+
+def _first_ep(mir_prog: mir.Program) -> mir.ExecutePipeline:
+  for step, _is_rec in mir_prog.steps:
+    eps = _find_execute_pipelines(step)
+    if eps:
+      return eps[0]
+  raise AssertionError('no ExecutePipeline in mir_prog')
+
+
+# -----------------------------------------------------------------------------
+# Type-erasure check (spec §6: every list entry is a Pass)
+# -----------------------------------------------------------------------------
+
+
+def test_every_program_pipeline_entry_is_a_pass():
+  for p in DEFAULT_PROGRAM_PIPELINE:
+    assert isinstance(p, Pass), p
+
+
+def test_every_kernel_pipeline_entry_is_a_pass():
+  for p in DEFAULT_KERNEL_PIPELINE:
+    assert isinstance(p, Pass), p
+
+
+def test_program_pipeline_names_unique_and_ordered():
+  names = [p.name for p in DEFAULT_PROGRAM_PIPELINE]
+  assert names == ['hir_planning', 'hir_to_mir', 'mir_opt', 'mir_program_assembly']
+  assert len(set(names)) == len(names)
+
+
+def test_kernel_pipeline_names_unique_and_ordered():
+  names = [p.name for p in DEFAULT_KERNEL_PIPELINE]
+  assert names == [
+    'assign_handles',
+    'collect_view_specs',
+    'emit_view_decls',
+    'lower_scan_pipeline',
+    'cuda_render',
+  ]
+  assert len(set(names)) == len(names)
+
+
+def test_first_shim_in_each_pipeline_consumes_nothing():
+  '''Spec note: the FIRST shim must have consumes=() because no
+  pseudo-dialects are registered with the Compiler.'''
+  assert DEFAULT_PROGRAM_PIPELINE[0].consumes == ()
+  assert DEFAULT_KERNEL_PIPELINE[0].consumes == ()
+
+
+# -----------------------------------------------------------------------------
+# Per-shim isolation tests (program pipeline)
+# -----------------------------------------------------------------------------
+
+
+def test_hir_planning_shim_runs_in_isolation():
+  shim = HirPlanningShim()
+  state = InitialProg(program=_tc_program())
+  out = shim.apply(state, None)
+  assert out.hir is not None
+  assert out.program is state.program  # unchanged
+
+
+def test_hir_planning_shim_idempotent_when_hir_already_set():
+  '''If the caller pre-populated hir, the shim is a no-op (matches
+  `compile_to_mir(program, hir=...)` legacy semantics).'''
+  from srdatalog.ir.hir import compile_to_hir
+
+  shim = HirPlanningShim()
+  hir = compile_to_hir(_tc_program())
+  state = InitialProg(program=_tc_program(), hir=hir)
+  out = shim.apply(state, None)
+  assert out.hir is hir
+
+
+def test_hir_to_mir_shim_runs_in_isolation():
+  from srdatalog.ir.hir import compile_to_hir
+
+  hir = compile_to_hir(_tc_program())
+  state = InitialProg(program=_tc_program(), hir=hir)
+  out = HirToMirShim().apply(state, None)
+  assert out.steps is not None
+  assert len(out.steps) == 6
+  assert all(isinstance(node, mir.MirNode) for node, _ in out.steps)
+
+
+def test_mir_opt_shim_preserves_step_count():
+  from srdatalog.ir.hir import compile_to_hir
+  from srdatalog.ir.hir.lower import lower_hir_to_mir_steps
+
+  hir = compile_to_hir(_tc_program())
+  steps = lower_hir_to_mir_steps(hir)
+  state = InitialProg(program=_tc_program(), hir=hir, steps=steps)
+  out = MirOptShim().apply(state, None)
+  assert out.steps is not None
+  assert len(out.steps) == len(steps)
+
+
+def test_mir_program_assembly_shim_returns_mir_program():
+  from srdatalog.ir.hir import compile_to_hir
+  from srdatalog.ir.hir.lower import lower_hir_to_mir_steps
+  from srdatalog.ir.mir.passes import apply_all_mir_passes
+
+  hir = compile_to_hir(_tc_program())
+  steps = apply_all_mir_passes(lower_hir_to_mir_steps(hir))
+  state = InitialProg(program=_tc_program(), hir=hir, steps=steps)
+  out = MirProgramAssembly().apply(state, None)
+  assert isinstance(out.mir_program, mir.Program)
+  assert len(out.mir_program.steps) == len(steps)
+
+
+# -----------------------------------------------------------------------------
+# Per-shim isolation tests (kernel pipeline)
+# -----------------------------------------------------------------------------
+
+
+def _build_kernel_ctx() -> KernelCtx:
+  '''Build a minimal KernelCtx by running the program pipeline first.'''
+  compiler = Compiler.with_default_plugins()
+  prog_state = compiler.run(InitialProg(program=_tc_program()), pipeline=DEFAULT_PROGRAM_PIPELINE)
+  assert prog_state.mir_program is not None
+  ep = _first_ep(prog_state.mir_program)
+  return KernelCtx(ep=ep, is_counting=False)
+
+
+def test_assign_handles_shim_runs_in_isolation():
+  state = _build_kernel_ctx()
+  out = AssignHandlesShim().apply(state, None)
+  # ep is rebuilt; pipeline list length preserved.
+  assert len(out.ep.pipeline) == len(state.ep.pipeline)
+
+
+def test_collect_view_specs_shim_runs_in_isolation():
+  state = AssignHandlesShim().apply(_build_kernel_ctx(), None)
+  out = CollectViewSpecsShim().apply(state, None)
+  assert out.view_specs is not None
+  # TC has at least one Edge view spec.
+  assert len(out.view_specs) >= 1
+
+
+def test_emit_view_decls_shim_populates_maps():
+  state = _build_kernel_ctx()
+  state = AssignHandlesShim().apply(state, None)
+  state = CollectViewSpecsShim().apply(state, None)
+  out = EmitViewDeclsShim().apply(state, None)
+  assert out.view_decls is not None
+  assert isinstance(out.view_decls, str)
+  assert out.name_map is not None
+  assert out.base_map is not None
+  # Every name_map key is a digit string (per the spec's split rule).
+  assert all(k.isdigit() for k in out.name_map)
+
+
+def test_lower_scan_pipeline_shim_produces_iir():
+  state = _build_kernel_ctx()
+  state = AssignHandlesShim().apply(state, None)
+  state = CollectViewSpecsShim().apply(state, None)
+  state = EmitViewDeclsShim().apply(state, None)
+  out = LowerScanPipelineShim().apply(state, None)
+  assert out.iir is not None
+
+
+def test_cuda_render_shim_returns_string_body():
+  state = _build_kernel_ctx()
+  state = AssignHandlesShim().apply(state, None)
+  state = CollectViewSpecsShim().apply(state, None)
+  state = EmitViewDeclsShim().apply(state, None)
+  state = LowerScanPipelineShim().apply(state, None)
+  out = CudaRenderShim().apply(state, None)
+  assert isinstance(out.body_text, str)
+  assert len(out.body_text) > 0
+  # Should contain the view-decls preamble + emitted body.
+  assert 'ViewType' in out.body_text
+
+
+# -----------------------------------------------------------------------------
+# End-to-end pipeline runs via Compiler.run
+# -----------------------------------------------------------------------------
+
+
+def test_default_program_pipeline_end_to_end():
+  '''DEFAULT_PROGRAM_PIPELINE runs from a Program to a mir.Program via
+  `Compiler.run`. No imperative `compile_to_mir` involved.'''
+  compiler = Compiler.with_default_plugins()
+  state = compiler.run(InitialProg(program=_tc_program()), pipeline=DEFAULT_PROGRAM_PIPELINE)
+  assert isinstance(state.mir_program, mir.Program)
+  # tc -> 3 strata -> 6 steps (FixpointPlan + PostStratumReconstructInternCols each).
+  assert len(state.mir_program.steps) == 6
+
+
+def test_default_kernel_pipeline_end_to_end():
+  '''DEFAULT_KERNEL_PIPELINE consumes a single ExecutePipeline and
+  emits a non-empty body string via `Compiler.run`.'''
+  compiler = Compiler.with_default_plugins()
+  prog_state = compiler.run(InitialProg(program=_tc_program()), pipeline=DEFAULT_PROGRAM_PIPELINE)
+  assert prog_state.mir_program is not None
+  ep = _first_ep(prog_state.mir_program)
+
+  kernel_state = compiler.run(KernelCtx(ep=ep, is_counting=False), pipeline=DEFAULT_KERNEL_PIPELINE)
+  assert isinstance(kernel_state.body_text, str)
+  assert len(kernel_state.body_text) > 0
+
+
+def test_kernel_pipeline_count_phase_runs():
+  '''Smoke: count-phase emit through the declarative pipeline.'''
+  compiler = Compiler.with_default_plugins()
+  prog_state = compiler.run(InitialProg(program=_tc_program()), pipeline=DEFAULT_PROGRAM_PIPELINE)
+  assert prog_state.mir_program is not None
+  ep = _first_ep(prog_state.mir_program)
+  kc = KernelCtx(ep=ep, is_counting=True, output_var_name='output_ctx')
+  out = compiler.run(kc, pipeline=DEFAULT_KERNEL_PIPELINE)
+  assert isinstance(out.body_text, str)
+  assert len(out.body_text) > 0
+
+
+if __name__ == '__main__':
+  test_every_program_pipeline_entry_is_a_pass()
+  test_every_kernel_pipeline_entry_is_a_pass()
+  test_program_pipeline_names_unique_and_ordered()
+  test_kernel_pipeline_names_unique_and_ordered()
+  test_first_shim_in_each_pipeline_consumes_nothing()
+  test_hir_planning_shim_runs_in_isolation()
+  test_hir_planning_shim_idempotent_when_hir_already_set()
+  test_hir_to_mir_shim_runs_in_isolation()
+  test_mir_opt_shim_preserves_step_count()
+  test_mir_program_assembly_shim_returns_mir_program()
+  test_assign_handles_shim_runs_in_isolation()
+  test_collect_view_specs_shim_runs_in_isolation()
+  test_emit_view_decls_shim_populates_maps()
+  test_lower_scan_pipeline_shim_produces_iir()
+  test_cuda_render_shim_returns_string_body()
+  test_default_program_pipeline_end_to_end()
+  test_default_kernel_pipeline_end_to_end()
+  test_kernel_pipeline_count_phase_runs()
+  print('OK')


### PR DESCRIPTION
## Summary
- Adds `src/srdatalog/ir/default_pipelines.py`: 2 frozen+slots through-state classes (`InitialProg`, `KernelCtx`) + 9 `ProgramPass` subclasses + 2 `list[Pass]` singletons (`DEFAULT_PROGRAM_PIPELINE`, `DEFAULT_KERNEL_PIPELINE`)
- Pure addition: zero existing-file modifications. F5.2 + F5.3 (separate later PRs) cut `compile_to_mir` + `compile_kernel_body` over to call `Compiler.run`
- Each shim mirrors exactly one block of the imperative source-of-truth (`compile_to_mir` body in `ir/hir/__init__.py:96-124`, `compile_kernel_body` body in `ir/codegen/cuda/api.py:98-185`)

## Notes for reviewer
- **Per-shim subclass pattern** (not `ProgramPass(name=..., fn=lambda)` instances) so each shim carries its own `consumes` / `produces` declarations. Phase B/C/D/E will replace shims atomically by deleting the subclass + adding the native Pass next to it; the `DEFAULT_PIPELINE` list barely changes.
- **`Pass` is a frozen dataclass** so class-level `name = "..."` defaults don't work. Each shim uses `__init__(self): super().__init__(name=..., ..., fn=self._fn)` + `@staticmethod _fn`.
- **`AssignHandlesShim` rebuilds the EP** via `dataclasses.replace(state.ep, pipeline=new_pipeline)` so downstream shims see handle-assigned ops. Behavior-equivalent to `compile_kernel_body`'s `pipeline = list(ep.pipeline); pipeline = assign_handle_positions(pipeline)`. Stays within the frozen-Op contract — no `object.__setattr__`, D18 ratchet stays at 0.
- **`HirPlanningShim` idempotent on `state.hir is not None`** — preserves the `compile_to_mir(program, hir=...)` semantics so `ir/pipeline.py` (pre-computed HIR caller) keeps working when F5.2 cuts over.
- Tag names picked descriptively to avoid clashing with registered dialect names: `"hir"`, `"mir_steps"`, `"mir_program"`, `"ep_with_handles"`, `"view_specs"`, `"view_decls"`, `"iir"`, `"body_text"`.

## Spec
`docs/phase_f5_declarative_pipeline.md` (committed to design/redesign-package in `619f090` / `96367ce`).

## Test plan
- [x] `pytest tests/test_default_pipelines_shims.py` — 18 passed (per-shim isolation + end-to-end smoke for both pipelines + `isinstance(p, Pass)` check)
- [x] `pytest tests/test_runner_byte_equivalence.py tests/test_cuda_complete_runner.py` — 279 + 3 = 282 passed (no regressions; pure addition)
- [x] `mypy src/srdatalog/ir/default_pipelines.py` — clean
- [x] `ruff check` + `ruff format --check` (CI version 0.9.10) — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)