### PR TITLE
C1: MirPragmaPass framework (no-op shell, unblocks C2-C6 parallel)

### DIFF
--- a/src/srdatalog/ir/mir/pragma_pass.py
+++ b/src/srdatalog/ir/mir/pragma_pass.py
@@ -1,0 +1,286 @@
+'''`MirPragmaPass` — typed pragma materialization for MIR.
+
+Walks every `ExecutePipeline` in an MIR program and, for each, applies
+the registered `@pragma_handler` callbacks in Kahn-topo-sorted order
+to consume each present `Pragma` instance into a wrap-op insertion.
+After the pass, every EP's `pragmas` field MUST be empty —
+`UnconsumedPragmaError` fires otherwise.
+
+Spec: docs/phase_c_pragma_materialization.md §3 (algorithm) and
+docs/pragma_as_typed_object.md §5 (type-based dispatch).
+
+Phase C1 ships this pass with **zero registered handlers**, so the
+walk is a structural identity for every EP currently produced by
+`HirToMirLowering`. C2-C6 each migrate one of the named bool fields
+(`dedup_hash`, `block_group`, `work_stealing`, `tiled_cartesian`,
+`count`, `fanout`) into a typed `Pragma` subclass + a registered
+handler; the discipline test
+`test_pragmas_empty_after_materialization` (this file's test
+companion) gates the migration.
+
+Why a separate module from `mir/passes.py`: `mir/passes.py` is the
+home for *optimization* passes over MIR (clause reorder, prefix
+reorder, concurrent-write marking). Pragma materialization is a
+structurally different transformation (it consumes typed
+declarations and inserts wrap ops); per the spec it deserves its own
+file so future readers can find it under the obvious name.
+
+Per discipline D10 / parallel rule for `LowerCtx`, the per-pass
+context object (`PragmaCtx`) is minimal — it carries only the active
+`Compiler`. Handlers that need richer state get amendments to
+`PragmaCtx`, not free-form mutable state.
+'''
+
+from __future__ import annotations
+
+from collections.abc import Iterable
+from dataclasses import dataclass
+from typing import Any
+
+from srdatalog.ir.core.ops import Op
+from srdatalog.ir.core.passes import RewritePass
+from srdatalog.ir.core.pragma import (
+  Pragma,
+  PragmaCtx,
+  PragmaOrderingError,
+  PragmaRegistration,
+  UnconsumedPragmaError,
+  UnregisteredPragmaError,
+  get_pragma_registrations,
+)
+from srdatalog.ir.core.strategy import bottom_up
+from srdatalog.ir.mir.types import ExecutePipeline
+
+# -----------------------------------------------------------------------------
+# Topological sort over Pragma classes
+# -----------------------------------------------------------------------------
+
+
+def _topo_sort_pragma_classes(
+  present: list[type[Pragma]],
+  registry: dict[type[Pragma], PragmaRegistration],
+) -> list[type[Pragma]]:
+  '''Kahn-topo-sort the given pragma classes by registered `before` /
+  `after` constraints.
+
+  `present` is the (deduplicated, registration-order) list of pragma
+  classes actually present on the EP being processed. `registry`
+  maps each present class to its registration. Edges:
+
+    - A `before=(B,)` declaration on A's registration adds A -> B
+      (A must run before B).
+    - An `after=(A,)` declaration on B's registration adds A -> B
+      (A must run before B), symmetric encoding.
+
+  Edges that reference a class not in `present` are dropped (the
+  ordering only matters between classes that are actually firing on
+  this EP). Cycles raise `PragmaOrderingError` naming the cycle.
+
+  Tie-break is deterministic registration order from `present` so
+  the output is stable across Python hash-seed changes (Kahn's
+  algorithm with a stable priority on the ready set).
+  '''
+  present_set = set(present)
+  # Adjacency: edges[u] = set of v such that u must run before v.
+  edges: dict[type[Pragma], set[type[Pragma]]] = {cls: set() for cls in present}
+  in_degree: dict[type[Pragma], int] = {cls: 0 for cls in present}
+
+  for cls in present:
+    reg = registry[cls]
+    for nxt in reg.before:
+      if nxt in present_set and nxt not in edges[cls]:
+        edges[cls].add(nxt)
+        in_degree[nxt] += 1
+    for prv in reg.after:
+      if prv in present_set and cls not in edges[prv]:
+        edges[prv].add(cls)
+        in_degree[cls] += 1
+
+  # Kahn: pick zero-in-degree nodes in registration order.
+  order: list[type[Pragma]] = []
+  remaining = list(present)
+  while remaining:
+    ready = [cls for cls in remaining if in_degree[cls] == 0]
+    if not ready:
+      raise PragmaOrderingError(
+        f'cycle in @pragma_handler before/after constraints among {[c.__name__ for c in remaining]}'
+      )
+    pick = ready[0]
+    order.append(pick)
+    remaining.remove(pick)
+    for v in edges[pick]:
+      in_degree[v] -= 1
+
+  return order
+
+
+# -----------------------------------------------------------------------------
+# MirPragmaPass
+# -----------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class MirPragmaPass(RewritePass):
+  '''One-shot RewritePass: materialize every typed `Pragma` instance.
+
+  Walks the MIR program; for every `ExecutePipeline`, runs the
+  registered `@pragma_handler` callbacks (Kahn-topo-sorted by
+  `before` / `after`) in turn until `ep.pragmas == ()`.
+
+  C1 no-op behavior: with zero registered handlers, the walk visits
+  every EP, the per-EP topo-sort is empty, and the post-flight
+  invariant (`ep.pragmas == ()`) holds trivially since every EP
+  currently produced by `HirToMirLowering` has an empty `pragmas`
+  tuple. The pass is structurally identity until C2 lands.
+
+  Algorithm (per spec §3):
+
+    1. Snapshot the global `@pragma_handler` registry.
+    2. Walk the program bottom-up; for each `ExecutePipeline`:
+       a. Identify the present pragma classes (deduplicated).
+       b. Pre-flight: every present class must have a registration,
+          else `UnregisteredPragmaError` (with did-you-mean hint).
+       c. Topo-sort the present classes.
+       d. For each class in order: invoke the handler. The handler
+          returns a transformed EP (with the consumed pragma stripped
+          from `pragmas`).
+       e. Post-flight: `ep.pragmas == ()`, else `UnconsumedPragmaError`.
+
+  Spec: docs/phase_c_pragma_materialization.md §3,
+  docs/pragma_as_typed_object.md §5.
+  '''
+
+  name: str = 'mir_pragma_materialization'
+  consumes: tuple[str, ...] = ('mir',)
+  produces: tuple[str, ...] = ('mir',)
+  dialect_name: str = 'mir'
+  until_fixpoint: bool = False
+
+  def apply(self, prog: Any, compiler: Any) -> Any:
+    registrations = get_pragma_registrations()
+    # Restrict the registry to handlers targeting `ExecutePipeline`.
+    # Other ops in MIR don't carry pragmas today; if a future op
+    # gains a `pragmas` field, the handler's `on=` will pick it up
+    # and this filter expands accordingly.
+    registry: dict[type[Pragma], PragmaRegistration] = {}
+    for reg in registrations:
+      if reg.on is not ExecutePipeline:
+        continue
+      # Last writer wins for duplicate registrations on the same
+      # Pragma class — symmetric with how the rest of the codebase
+      # handles multi-decoration; in practice C2-C6 each register
+      # exactly one handler per Pragma type.
+      registry[reg.pragma_cls] = reg
+
+    ctx = PragmaCtx(compiler=compiler)
+
+    def _materialize(op: Op) -> Op | None:
+      if not isinstance(op, ExecutePipeline):
+        return None
+      if not op.pragmas:
+        return None
+      return _materialize_one_ep(op, registry, ctx)
+
+    return bottom_up(_materialize)(prog)
+
+
+def _materialize_one_ep(
+  ep: ExecutePipeline,
+  registry: dict[type[Pragma], PragmaRegistration],
+  ctx: PragmaCtx,
+) -> ExecutePipeline:
+  '''Materialize all pragmas on a single ExecutePipeline.
+
+  Per-EP algorithm: identify present pragma classes, validate every
+  present class has a handler (`UnregisteredPragmaError` otherwise),
+  topo-sort by `before` / `after`, invoke each handler in order,
+  assert post-flight `ep.pragmas == ()`
+  (`UnconsumedPragmaError` otherwise).
+
+  Returns the transformed EP. The handler for each pragma is
+  responsible for stripping its own `Pragma` instance from
+  `ep.pragmas` (otherwise the post-flight assertion fires; the
+  handler is buggy).
+  '''
+  present = _present_pragma_classes(ep.pragmas)
+
+  # Pre-flight: every present pragma must be registered.
+  for cls in present:
+    if cls not in registry:
+      known = sorted(c.__name__ for c in registry)
+      raise UnregisteredPragmaError(
+        f'{cls.__name__} appears on ExecutePipeline {ep.rule_name!r} '
+        f'but no @pragma_handler claims its type. '
+        f'Did you mean one of: {known}? '
+        f'(import the module that registers the handler, or add '
+        f'`@pragma_handler({cls.__name__}, on=ExecutePipeline)` to '
+        f'a loaded module.)'
+      )
+
+  ordered = _topo_sort_pragma_classes(present, registry)
+
+  current = ep
+  for cls in ordered:
+    reg = registry[cls]
+    instance = _first_instance(current.pragmas, cls)
+    if instance is None:
+      # A previous handler in this EP already consumed it (or it
+      # never appeared on this op). Skip.
+      continue
+    result = reg.fn(current, instance, ctx)
+    if result is None:
+      # Spec §2: handler may return None to skip. The pragma stays
+      # on the EP; the post-flight check below will then fire as
+      # `UnconsumedPragmaError`.
+      continue
+    current = result
+
+  # Post-flight: every pragma must have been consumed.
+  if current.pragmas:
+    surviving = current.pragmas[0]
+    handler_names = sorted(c.__name__ for c in registry)
+    raise UnconsumedPragmaError(
+      f'pragma {surviving!r} on ExecutePipeline {current.rule_name!r} '
+      f'survived MirPragmaPass; the registered handler for '
+      f'{type(surviving).__name__} returned an op without removing '
+      f'this instance from `pragmas`. Registered handlers: '
+      f'{handler_names}.'
+    )
+
+  return current
+
+
+def _present_pragma_classes(pragmas: Iterable[Any]) -> list[type[Pragma]]:
+  '''Distinct pragma TYPES present on `pragmas`, in first-seen order.
+
+  Filters to actual `Pragma` instances; non-Pragma entries (the
+  legacy name-keyed `(str, Any)` shape that still types
+  `ExecutePipeline.pragmas` until A3) are skipped. C1 behavior: the
+  field is empty in practice, so this returns `[]`.
+  '''
+  seen: dict[type[Pragma], None] = {}
+  for p in pragmas:
+    if isinstance(p, Pragma) and type(p) not in seen:
+      seen[type(p)] = None
+  return list(seen)
+
+
+def _first_instance(
+  pragmas: Iterable[Any],
+  cls: type[Pragma],
+) -> Pragma | None:
+  '''First `cls` instance in `pragmas`, or None.
+
+  Mirrors `core.pragma.get_pragma` but operates on the iterable
+  directly (no Op wrapper required) so we can call it on the
+  in-progress `current.pragmas` after each handler.
+  '''
+  for p in pragmas:
+    if isinstance(p, cls):
+      return p
+  return None
+
+
+__all__ = [
+  'MirPragmaPass',
+]

--- a/tests/test_mir_pragma_pass.py
+++ b/tests/test_mir_pragma_pass.py
@@ -1,0 +1,509 @@
+'''Tests for `srdatalog.ir.mir.pragma_pass.MirPragmaPass` (Phase C1).
+
+Covers:
+  - No-op behavior on EPs without pragmas (the C1 default state).
+  - Hand-built pragma round-trip: register a handler, attach the
+    pragma to an EP, run the pass, observe the wrap-op insertion +
+    the cleared `pragmas` field.
+  - Topo-sort ordering via `before` / `after` declarations.
+  - Cycle detection -> `PragmaOrderingError`.
+  - Unregistered pragma -> `UnregisteredPragmaError` (with a
+    did-you-mean hint).
+  - Buggy handler that doesn't strip its pragma ->
+    `UnconsumedPragmaError`.
+  - Driving via `Compiler.run` end-to-end (pre-flight ordering,
+    `consumes='mir'` -> `produces='mir'`).
+  - Discipline test scaffold: every EP has empty `pragmas` after
+    `MirPragmaPass` (trivially satisfied today; first real gate
+    when C2 lands).
+
+Spec: docs/phase_c_pragma_materialization.md §3 + §7.
+'''
+
+from __future__ import annotations
+
+import dataclasses
+from dataclasses import dataclass
+from typing import final
+
+import pytest
+
+from srdatalog.ir.core import Compiler, Dialect
+from srdatalog.ir.core.pragma import (
+  Pragma,
+  PragmaOrderingError,
+  PragmaRegistration,
+  UnconsumedPragmaError,
+  UnregisteredPragmaError,
+  pragma_handler,
+)
+from srdatalog.ir.hir.types import Version
+from srdatalog.ir.mir.pragma_pass import MirPragmaPass
+from srdatalog.ir.mir.types import (
+  Block,
+  ExecutePipeline,
+  FixpointPlan,
+  InsertInto,
+  Program,
+)
+
+# -----------------------------------------------------------------------------
+# Fixtures
+# -----------------------------------------------------------------------------
+
+
+@pytest.fixture
+def isolated_registry(monkeypatch):
+  '''Snapshot + restore the module-global pragma registry.
+
+  Mirrors the fixture in tests/test_core_pragma.py so this test
+  module can register handlers without leaking into others (and
+  vice versa).
+  '''
+  fresh: list[PragmaRegistration] = []
+  monkeypatch.setattr('srdatalog.ir.core.pragma._PRAGMA_REGISTRY', fresh)
+  return fresh
+
+
+@pytest.fixture
+def mir_compiler():
+  '''Compiler with the MIR dialect registered (no others).
+
+  Sufficient for C1's `MirPragmaPass` driver tests; future phases
+  will add the parallel.* sub-dialects via plugin discovery.
+  '''
+  from srdatalog.ir.mir import DIALECT as MIR_DIALECT
+
+  c = Compiler()
+  c.register_dialect(MIR_DIALECT)
+  return c
+
+
+# -----------------------------------------------------------------------------
+# Helpers
+# -----------------------------------------------------------------------------
+
+
+def _ep(*, rule_name: str = 'r', pragmas: tuple[Pragma, ...] = ()) -> ExecutePipeline:
+  '''Build a minimal ExecutePipeline with the given pragmas.
+
+  C1 attaches typed `Pragma` instances directly onto the
+  `pragmas` tuple; the field's static annotation still says
+  `tuple[tuple[str, Any], ...]` (until A3 retypes it), but Python
+  accepts the typed shape at runtime — that is the whole point of
+  the migration.
+  '''
+  return ExecutePipeline(
+    pipeline=[],
+    source_specs=[],
+    dest_specs=[],
+    rule_name=rule_name,
+    pragmas=pragmas,  # type: ignore[arg-type]
+  )
+
+
+def _strip_pragma(ep: ExecutePipeline, instance: Pragma) -> ExecutePipeline:
+  '''Return `ep` with `instance` removed from `ep.pragmas`.'''
+  return dataclasses.replace(
+    ep,
+    pragmas=tuple(p for p in ep.pragmas if p is not instance),
+  )
+
+
+# -----------------------------------------------------------------------------
+# 1. No-op smoke
+# -----------------------------------------------------------------------------
+
+
+def test_noop_on_empty_pragmas_returns_identity_ep(isolated_registry, mir_compiler):
+  '''An EP with `pragmas=()` is returned by-identity (the bottom_up
+  walker only replaces nodes whose `_materialize` returns non-None).
+  '''
+  ep = _ep()
+  pas = MirPragmaPass()
+  out = pas.apply(ep, mir_compiler)
+  assert out is ep
+
+
+def test_noop_on_program_with_many_eps(isolated_registry, mir_compiler):
+  '''A nested Program containing several EPs (all `pragmas=()`)
+  walks cleanly and returns by-identity.'''
+  prog = Program(
+    steps=[
+      (
+        FixpointPlan(
+          instructions=[_ep(rule_name='a'), _ep(rule_name='b')],
+        ),
+        True,
+      ),
+      (Block(instructions=[_ep(rule_name='c')]), False),
+    ]
+  )
+  out = MirPragmaPass().apply(prog, mir_compiler)
+  assert out is prog
+
+
+# -----------------------------------------------------------------------------
+# 2. Hand-built pragma round-trip
+# -----------------------------------------------------------------------------
+
+
+@final
+@dataclass(frozen=True, slots=True)
+class _TagPragma(Pragma):
+  '''Test-local pragma: handler appends `tag` to the EP's rule_name
+  and strips the instance.'''
+
+  tag: str = 'X'
+
+
+def test_handler_consumes_pragma_and_clears_field(isolated_registry, mir_compiler):
+  '''A registered handler fires, returns a transformed EP, and the
+  `pragmas` field is empty afterwards.'''
+
+  @pragma_handler(_TagPragma, on=ExecutePipeline)
+  def _handle(op, pragma, ctx):
+    return dataclasses.replace(
+      _strip_pragma(op, pragma),
+      rule_name=f'{op.rule_name}+{pragma.tag}',
+    )
+
+  ep = _ep(rule_name='r', pragmas=(_TagPragma(tag='hello'),))
+  out = MirPragmaPass().apply(ep, mir_compiler)
+  assert out.rule_name == 'r+hello'
+  assert out.pragmas == ()
+
+
+def test_handler_fires_inside_nested_program(isolated_registry, mir_compiler):
+  '''Handler discovery walks nested EPs (FixpointPlan -> EP, Block ->
+  EP). Both the inner EPs get materialized; the outer Program is
+  rebuilt with the transformed children.'''
+
+  @pragma_handler(_TagPragma, on=ExecutePipeline)
+  def _handle(op, pragma, ctx):
+    return dataclasses.replace(
+      _strip_pragma(op, pragma),
+      rule_name=f'{op.rule_name}!',
+    )
+
+  inner_a = _ep(rule_name='a', pragmas=(_TagPragma(),))
+  inner_b = _ep(rule_name='b')  # no pragma, untouched
+  prog = Program(
+    steps=[(FixpointPlan(instructions=[inner_a, inner_b]), True)],
+  )
+
+  out = MirPragmaPass().apply(prog, mir_compiler)
+  fp_out = out.steps[0][0]
+  assert fp_out.instructions[0].rule_name == 'a!'
+  assert fp_out.instructions[0].pragmas == ()
+  assert fp_out.instructions[1] is inner_b
+
+
+# -----------------------------------------------------------------------------
+# 3. Topo-sort ordering
+# -----------------------------------------------------------------------------
+
+
+@final
+@dataclass(frozen=True, slots=True)
+class _PragmaA(Pragma):
+  pass
+
+
+@final
+@dataclass(frozen=True, slots=True)
+class _PragmaB(Pragma):
+  pass
+
+
+def test_before_constraint_orders_handlers(isolated_registry, mir_compiler):
+  '''`@pragma_handler(A, before=(B,))` => A's handler runs before
+  B's. We tag the rule_name in fire-order; the final string
+  encodes the sequence.'''
+
+  @pragma_handler(_PragmaA, on=ExecutePipeline, before=(_PragmaB,))
+  def _ha(op, pragma, ctx):
+    return dataclasses.replace(
+      _strip_pragma(op, pragma),
+      rule_name=op.rule_name + 'A',
+    )
+
+  @pragma_handler(_PragmaB, on=ExecutePipeline)
+  def _hb(op, pragma, ctx):
+    return dataclasses.replace(
+      _strip_pragma(op, pragma),
+      rule_name=op.rule_name + 'B',
+    )
+
+  # Attach both pragmas in the OPPOSITE order to the desired fire
+  # order — proves the topo-sort, not the iteration order, drives
+  # the dispatch.
+  ep = _ep(rule_name='', pragmas=(_PragmaB(), _PragmaA()))
+  out = MirPragmaPass().apply(ep, mir_compiler)
+  assert out.rule_name == 'AB'
+  assert out.pragmas == ()
+
+
+def test_after_constraint_orders_handlers(isolated_registry, mir_compiler):
+  '''`@pragma_handler(B, after=(A,))` => B's handler runs after A's.
+  Symmetric to `before`; same expected order.'''
+
+  @pragma_handler(_PragmaA, on=ExecutePipeline)
+  def _ha(op, pragma, ctx):
+    return dataclasses.replace(
+      _strip_pragma(op, pragma),
+      rule_name=op.rule_name + 'A',
+    )
+
+  @pragma_handler(_PragmaB, on=ExecutePipeline, after=(_PragmaA,))
+  def _hb(op, pragma, ctx):
+    return dataclasses.replace(
+      _strip_pragma(op, pragma),
+      rule_name=op.rule_name + 'B',
+    )
+
+  ep = _ep(rule_name='', pragmas=(_PragmaA(), _PragmaB()))
+  out = MirPragmaPass().apply(ep, mir_compiler)
+  assert out.rule_name == 'AB'
+
+
+def test_cycle_in_before_after_raises_pragma_ordering_error(isolated_registry, mir_compiler):
+  '''A.before=(B,) AND B.before=(A,) => topo-sort cycle => raise
+  PragmaOrderingError naming both classes.'''
+
+  @pragma_handler(_PragmaA, on=ExecutePipeline, before=(_PragmaB,))
+  def _ha(op, pragma, ctx):
+    return _strip_pragma(op, pragma)
+
+  @pragma_handler(_PragmaB, on=ExecutePipeline, before=(_PragmaA,))
+  def _hb(op, pragma, ctx):
+    return _strip_pragma(op, pragma)
+
+  ep = _ep(pragmas=(_PragmaA(), _PragmaB()))
+  with pytest.raises(PragmaOrderingError, match=r'cycle'):
+    MirPragmaPass().apply(ep, mir_compiler)
+
+
+# -----------------------------------------------------------------------------
+# 4. Unregistered pragma
+# -----------------------------------------------------------------------------
+
+
+@final
+@dataclass(frozen=True, slots=True)
+class _NotRegistered(Pragma):
+  pass
+
+
+def test_unregistered_pragma_raises_with_did_you_mean(isolated_registry, mir_compiler):
+  '''A pragma instance whose type has no registered handler triggers
+  `UnregisteredPragmaError` at pre-flight; the error message lists
+  registered handler names so the user can spot a typo / missing
+  import.'''
+
+  @pragma_handler(_PragmaA, on=ExecutePipeline)
+  def _ha(op, pragma, ctx):
+    return _strip_pragma(op, pragma)
+
+  ep = _ep(pragmas=(_NotRegistered(),))
+  with pytest.raises(UnregisteredPragmaError) as ei:
+    MirPragmaPass().apply(ep, mir_compiler)
+  msg = str(ei.value)
+  assert '_NotRegistered' in msg
+  assert '_PragmaA' in msg  # did-you-mean hint lists known handlers
+  assert 'Did you mean' in msg
+
+
+def test_unregistered_pragma_error_is_typeerror(isolated_registry, mir_compiler):
+  '''Per `core.pragma` docstring: UnregisteredPragmaError IS a
+  TypeError, so existing `except TypeError` catches it.'''
+  ep = _ep(pragmas=(_NotRegistered(),))
+  with pytest.raises(TypeError):
+    MirPragmaPass().apply(ep, mir_compiler)
+
+
+# -----------------------------------------------------------------------------
+# 5. Buggy (non-stripping) handler -> UnconsumedPragmaError
+# -----------------------------------------------------------------------------
+
+
+def test_handler_that_doesnt_strip_raises_unconsumed(isolated_registry, mir_compiler):
+  '''A handler that returns the EP unchanged (or mutates other
+  fields but forgets to drop its own Pragma instance) leaves
+  `pragmas` non-empty after dispatch -> UnconsumedPragmaError.'''
+
+  @pragma_handler(_PragmaA, on=ExecutePipeline)
+  def _bad_handler(op, pragma, ctx):
+    # Bug: returns the EP with the pragma still attached.
+    return dataclasses.replace(op, rule_name=op.rule_name + '?')
+
+  ep = _ep(pragmas=(_PragmaA(),))
+  with pytest.raises(UnconsumedPragmaError, match=r'survived MirPragmaPass'):
+    MirPragmaPass().apply(ep, mir_compiler)
+
+
+def test_handler_returning_none_also_triggers_unconsumed(isolated_registry, mir_compiler):
+  '''Per spec §2 the handler may return None to skip; that leaves the
+  pragma on the EP, which the post-flight check then reports as an
+  UnconsumedPragmaError. The two paths converge on the same error so
+  no path silently survives.'''
+
+  @pragma_handler(_PragmaA, on=ExecutePipeline)
+  def _skip_handler(op, pragma, ctx):
+    return None
+
+  ep = _ep(pragmas=(_PragmaA(),))
+  with pytest.raises(UnconsumedPragmaError):
+    MirPragmaPass().apply(ep, mir_compiler)
+
+
+# -----------------------------------------------------------------------------
+# 6. Driven via Compiler.run
+# -----------------------------------------------------------------------------
+
+
+def test_pass_runs_via_compiler_run_pipeline(isolated_registry, mir_compiler):
+  '''MirPragmaPass declares consumes=('mir',) and produces=('mir',).
+  With the MIR dialect registered, `Compiler.run(prog,
+  pipeline=[MirPragmaPass()])` passes pre-flight ordering and
+  threads the prog through.'''
+
+  @pragma_handler(_PragmaA, on=ExecutePipeline)
+  def _ha(op, pragma, ctx):
+    return dataclasses.replace(
+      _strip_pragma(op, pragma),
+      rule_name=op.rule_name + '!',
+    )
+
+  ep = _ep(rule_name='r', pragmas=(_PragmaA(),))
+  out = mir_compiler.run(ep, pipeline=[MirPragmaPass()])
+  assert out.rule_name == 'r!'
+  assert out.pragmas == ()
+
+
+def test_pass_default_metadata_advertises_mir_dialect():
+  '''The Pass declares the right `name`, `consumes`, `produces`,
+  `dialect_name` so test_pass_kinds-style introspection picks it up.
+  '''
+  p = MirPragmaPass()
+  assert p.name == 'mir_pragma_materialization'
+  assert p.consumes == ('mir',)
+  assert p.produces == ('mir',)
+  assert p.dialect_name == 'mir'
+  assert p.until_fixpoint is False
+
+
+# -----------------------------------------------------------------------------
+# 7. Discipline scaffold (Spec §7)
+# -----------------------------------------------------------------------------
+
+
+def test_pragmas_empty_after_materialization(isolated_registry, mir_compiler):
+  '''Discipline test (Spec §7): every EP has `pragmas == ()` after
+  `MirPragmaPass`. C1 satisfies this trivially because every EP
+  starts with `pragmas == ()`; the test is the gate for C2's first
+  migration -> any EP that arrives at `MirPragmaPass` carrying a
+  typed Pragma whose handler is missing or buggy fails this gate.
+
+  We use a representative MIR program: a Program with a
+  FixpointPlan + Block, several EPs, and a non-EP wrap (InsertInto
+  has no `pragmas`, must walk past it cleanly).
+  '''
+  prog = Program(
+    steps=[
+      (
+        FixpointPlan(
+          instructions=[
+            _ep(rule_name='a'),
+            _ep(rule_name='b'),
+          ],
+        ),
+        True,
+      ),
+      (
+        Block(
+          instructions=[
+            _ep(rule_name='c'),
+            InsertInto(
+              rel_name='R',
+              version=Version.FULL,
+              vars=[],
+              index=[],
+            ),
+          ],
+        ),
+        False,
+      ),
+    ]
+  )
+
+  out = MirPragmaPass().apply(prog, mir_compiler)
+
+  # Walk every EP in the output and assert pragmas == ().
+  def _walk_eps(node, found):
+    if isinstance(node, ExecutePipeline):
+      found.append(node)
+    elif isinstance(node, Program):
+      for step, _ in node.steps:
+        _walk_eps(step, found)
+    elif isinstance(node, FixpointPlan) or isinstance(node, Block):
+      for instr in node.instructions:
+        _walk_eps(instr, found)
+
+  found: list[ExecutePipeline] = []
+  _walk_eps(out, found)
+  assert len(found) == 3
+  for ep in found:
+    assert ep.pragmas == ()
+
+
+# -----------------------------------------------------------------------------
+# 8. Misc / surface checks
+# -----------------------------------------------------------------------------
+
+
+def test_pass_skips_handlers_for_other_op_types(isolated_registry, mir_compiler):
+  '''A `@pragma_handler` registered with `on=SomeOtherOp` is ignored
+  by MirPragmaPass — the pass only dispatches handlers whose `on`
+  is `ExecutePipeline`. Otherwise an unrelated registration could
+  fire on every EP and corrupt the dispatch.'''
+
+  class _OtherOp:
+    pass
+
+  @pragma_handler(_PragmaA, on=_OtherOp)
+  def _ha(op, pragma, ctx):  # pragma: no cover — must not fire
+    raise AssertionError('handler should not fire for non-ExecutePipeline')
+
+  # An EP with the same Pragma type, but the handler is for a
+  # different op kind. The pre-flight then sees no registered
+  # handler for ExecutePipeline + _PragmaA and raises.
+  ep = _ep(pragmas=(_PragmaA(),))
+  with pytest.raises(UnregisteredPragmaError):
+    MirPragmaPass().apply(ep, mir_compiler)
+
+
+def test_dialect_registration_is_used_by_compiler_run(mir_compiler):
+  '''Smoke: the mir_compiler fixture has the mir dialect registered
+  (so `Compiler.run` pre-flight on `consumes=('mir',)` succeeds).
+  '''
+  names = [d.name for d in mir_compiler.dialects]
+  assert 'mir' in names
+
+
+def test_dialect_unregistered_run_raises_pass_ordering_error(isolated_registry):
+  '''Without the MIR dialect registered, `Compiler.run` pre-flight
+  rejects MirPragmaPass on `consumes=('mir',)` — the same gate the
+  rest of the F1 framework enforces.'''
+  from srdatalog.ir.core.passes import PassOrderingError
+
+  empty = Compiler()
+  with pytest.raises(PassOrderingError):
+    empty.run(_ep(), pipeline=[MirPragmaPass()])
+
+
+def test_external_dialect_test_helper_used():
+  '''Sanity that the Dialect import path used elsewhere works (the
+  C2 PR will register its handler from a dialect's __init__).'''
+  d = Dialect(name='test.dummy')
+  assert d.name == 'test.dummy'


### PR DESCRIPTION
## Summary
- Adds `src/srdatalog/ir/mir/pragma_pass.py`: `MirPragmaPass` (RewritePass) that walks MIR, gathers each `ExecutePipeline.pragmas` tuple, Kahn-topo-sorts by registered handler `before` / `after` declarations, invokes each handler, and asserts every EP has `pragmas == ()` afterwards
- **No-op for now** (zero pragmas registered as Pragma subclasses; the named bool fields stay through C2-C6)
- Unblocks C2-C6 to land in parallel per `docs/phase_c_pragma_materialization.md` § 5

## Notes for reviewer
- **No `core/pragma.py` changes** — Agent A's PR #29 already exposed `_PRAGMA_REGISTRY`, `get_pragma_registrations()`, and `PragmaRegistration`. The pass consumes those directly.
- **Topo-sort:** Kahn with explicit adjacency + in-degree dicts keyed by `type[Pragma]`. Restricted to classes actually present on the EP (off-EP `before`/`after` references dropped). Tie-break is stable registration order. Cycle → `PragmaOrderingError`.
- **Walking strategy:** reuses `core.strategy.bottom_up` combinator (F1's strategy library). Per-op closure short-circuits unless op is an `ExecutePipeline` with non-empty `pragmas` — no-op path is cheap.
- **Handler `on=` filter scoped to ExecutePipeline:** restricts the registry snapshot to `on is ExecutePipeline`. C1's MIR only carries `pragmas` on EPs; future ops gain coverage by adding more matches. `test_pass_skips_handlers_for_other_op_types` pins it.
- **Last-writer-wins on duplicate registrations:** dict-overwrite semantics with inline doc. C2-C6 each register exactly one handler per class so this is theoretical for plugin collisions.
- **`return None` from a handler triggers UnconsumedPragmaError:** spec § 2 says handlers may return `None` to skip; we leave the pragma on the EP and the post-flight assertion fires. Covered by `test_handler_returning_none_also_triggers_unconsumed`.
- **`MirPragmaPass()` works with no boilerplate:** subclass sets `name = 'mir_pragma_materialization'`, `consumes = ('mir',)`, `produces = ('mir',)` as defaults. Pipelines write `MirPragmaPass()`. Tested in `test_pass_default_metadata_advertises_mir_dialect`.
- **No plugin auto-registration** — F4 entry-point wiring deferred. Pipelines opt in via `Compiler.run(prog, pipeline=[MirPragmaPass()])`. F5 wires it once `default_pipelines.py` lands (PR #37).

## Spec
`docs/phase_c_pragma_materialization.md` § 2 (decorator contract), § 3 (algorithm), § 7 (discipline tests), § 5 (PR breakdown — this is C1).

## Test plan
- [x] `pytest tests/test_mir_pragma_pass.py` — 18 passed (no-op smoke + hand-built pragma flow + topo-sort orderings + cycle detection + UnregisteredPragmaError + UnconsumedPragmaError + `Compiler.run` integration + handler `on=` filter scoping)
- [x] full suite `pytest` — 1258 passed, 5 skipped (no regressions)
- [x] `mypy src/srdatalog/ir/mir/pragma_pass.py src/srdatalog/ir/core/pragma.py` — clean
- [x] `ruff check` + `ruff format --check` (CI v0.9.10) — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)