### PR TITLE
F5.2: cut compile_to_mir to Compiler.run + DEFAULT_PROGRAM_PIPELINE

### DIFF
--- a/src/srdatalog/ir/default_pipelines.py
+++ b/src/srdatalog/ir/default_pipelines.py
@@ -47,12 +47,19 @@ if TYPE_CHECKING:
 @dataclass(frozen=True, slots=True)
 class InitialProg:
   '''Program-pipeline through-state. Threaded by the four
-  `DEFAULT_PROGRAM_PIPELINE` shims; each fills one field.'''
+  `DEFAULT_PROGRAM_PIPELINE` shims; each fills one field.
+
+  `verbose` mirrors the legacy `compile_to_mir(verbose=...)` kwarg.
+  Read by `HirPlanningShim` when computing HIR from scratch; ignored
+  if `hir` is pre-populated by the caller. Added in F5.2 so the
+  declarative pipeline can preserve the imperative entry point's
+  verbosity knob byte-equivalently.'''
 
   program: Program
   hir: HirProgram | None = None
   steps: list[tuple[mir.MirNode, bool]] | None = None
   mir_program: mir.Program | None = None
+  verbose: bool = False
 
 
 @dataclass(frozen=True, slots=True)
@@ -101,7 +108,7 @@ class HirPlanningShim(ProgramPass):
       return state
     from srdatalog.ir.hir import compile_to_hir
 
-    return dataclasses.replace(state, hir=compile_to_hir(state.program))
+    return dataclasses.replace(state, hir=compile_to_hir(state.program, verbose=state.verbose))
 
 
 class HirToMirShim(ProgramPass):

--- a/src/srdatalog/ir/hir/__init__.py
+++ b/src/srdatalog/ir/hir/__init__.py
@@ -110,15 +110,26 @@ def compile_to_mir(
   (`hir=None`) runs `compile_to_hir(program, verbose=verbose)` internally.
   Callers that already have HIR (e.g. `ir.pipeline.compile_program`)
   should pass it to avoid the redundant pass.
+
+  F5.2: implemented as a `Compiler.run` over `DEFAULT_PROGRAM_PIPELINE`.
+  The `apply_mir_passes=False` knob is preserved by filtering out
+  `MirOptShim` from the pipeline. The `verbose` + `hir` knobs flow into
+  `HirPlanningShim` via `InitialProg`. Spec: docs/phase_f5_declarative_pipeline.md
+  section 3.1.
   '''
-  import srdatalog.ir.mir.types as mir
-  from srdatalog.ir.hir.lower import lower_hir_to_mir_steps
+  from srdatalog.ir.core.dialect import Compiler
+  from srdatalog.ir.default_pipelines import (
+    DEFAULT_PROGRAM_PIPELINE,
+    InitialProg,
+    MirOptShim,
+  )
 
-  if hir is None:
-    hir = compile_to_hir(program, verbose=verbose)
-  steps = lower_hir_to_mir_steps(hir)
-  if apply_mir_passes:
-    from srdatalog.ir.mir.passes import apply_all_mir_passes
+  pipeline = DEFAULT_PROGRAM_PIPELINE
+  if not apply_mir_passes:
+    pipeline = [p for p in pipeline if not isinstance(p, MirOptShim)]
 
-    steps = apply_all_mir_passes(steps)
-  return mir.Program(steps=[(node, is_rec) for node, is_rec in steps])
+  state = Compiler().run(
+    InitialProg(program=program, hir=hir, verbose=verbose),
+    pipeline=pipeline,
+  )
+  return state.mir_program

--- a/tests/test_default_pipelines_shims.py
+++ b/tests/test_default_pipelines_shims.py
@@ -278,6 +278,82 @@ def test_kernel_pipeline_count_phase_runs():
   assert len(out.body_text) > 0
 
 
+# -----------------------------------------------------------------------------
+# F5.2: compile_to_mir uses DEFAULT_PROGRAM_PIPELINE under the hood
+# -----------------------------------------------------------------------------
+
+
+def test_compile_to_mir_uses_default_pipeline():
+  '''F5.2 cut-over: `compile_to_mir(program)` is now a thin wrapper
+  over `Compiler().run(InitialProg(...), pipeline=DEFAULT_PROGRAM_PIPELINE)`.
+  The output must match the direct `Compiler.run` invocation byte-for-byte.'''
+  from srdatalog.ir.hir import compile_to_mir
+
+  prog = _tc_program()
+
+  # Compare imperative entry point against the declarative pipeline
+  # invoked directly (the pipeline IS the source of truth post-F5.2).
+  via_entry = compile_to_mir(prog)
+  via_pipeline = (
+    Compiler()
+    .run(
+      InitialProg(program=prog),
+      pipeline=DEFAULT_PROGRAM_PIPELINE,
+    )
+    .mir_program
+  )
+
+  assert via_entry == via_pipeline
+
+
+def test_compile_to_mir_apply_mir_passes_false_filters_mir_opt():
+  '''F5.2: `apply_mir_passes=False` drops `MirOptShim` from the pipeline.
+  The output must match a direct `Compiler.run` over the filtered
+  pipeline (i.e. raw HIR -> MIR steps, no optimization).'''
+  from srdatalog.ir.hir import compile_to_mir
+
+  prog = _tc_program()
+  via_entry = compile_to_mir(prog, apply_mir_passes=False)
+
+  filtered = [p for p in DEFAULT_PROGRAM_PIPELINE if not isinstance(p, MirOptShim)]
+  via_pipeline = (
+    Compiler()
+    .run(
+      InitialProg(program=prog),
+      pipeline=filtered,
+    )
+    .mir_program
+  )
+
+  assert via_entry == via_pipeline
+
+
+def test_compile_to_mir_with_precomputed_hir_skips_planning():
+  '''F5.2: passing `hir=...` short-circuits `HirPlanningShim` (which is
+  idempotent on `state.hir is not None`). Output must match the
+  default path.'''
+  from srdatalog.ir.hir import compile_to_hir, compile_to_mir
+
+  prog = _tc_program()
+  hir = compile_to_hir(prog)
+  via_hir = compile_to_mir(prog, hir=hir)
+  default = compile_to_mir(prog)
+  assert via_hir == default
+
+
+def test_compile_to_mir_verbose_does_not_break():
+  '''F5.2: `verbose=True` is threaded through `InitialProg.verbose`
+  into `HirPlanningShim`, which forwards to `compile_to_hir`. Smoke
+  test: it doesn't crash and the output is byte-equivalent to the
+  non-verbose default (verbose only affects logging side effects).'''
+  from srdatalog.ir.hir import compile_to_mir
+
+  prog = _tc_program()
+  loud = compile_to_mir(prog, verbose=True)
+  quiet = compile_to_mir(prog)
+  assert loud == quiet
+
+
 if __name__ == '__main__':
   test_every_program_pipeline_entry_is_a_pass()
   test_every_kernel_pipeline_entry_is_a_pass()
@@ -297,4 +373,8 @@ if __name__ == '__main__':
   test_default_program_pipeline_end_to_end()
   test_default_kernel_pipeline_end_to_end()
   test_kernel_pipeline_count_phase_runs()
+  test_compile_to_mir_uses_default_pipeline()
+  test_compile_to_mir_apply_mir_passes_false_filters_mir_opt()
+  test_compile_to_mir_with_precomputed_hir_skips_planning()
+  test_compile_to_mir_verbose_does_not_break()
   print('OK')


### PR DESCRIPTION
## Summary
- Replaces `compile_to_mir` body (15 LOC imperative) with a `Compiler().run(InitialProg(...), pipeline=DEFAULT_PROGRAM_PIPELINE)` call
- Preserves all 3 knobs: `hir=`, `verbose=`, `apply_mir_passes=` (the last via pipeline filter `[p for p in pipeline if not isinstance(p, MirOptShim)]`)
- Minor F5.1 extension: adds `verbose: bool = False` to `InitialProg` and threads it through `HirPlanningShim` (one field + one arg change)

## Notes for reviewer
- Bare `Compiler()` works because the shim pipeline uses through-state tags (`"hir"`, `"mir_steps"`, `"mir_program"`), not registered dialect names. Pre-flight check satisfied: first shim has `consumes=()`, each downstream shim's `consumes` is satisfied by an earlier shim's `produces`.
- Filter for `apply_mir_passes=False` removes `MirOptShim`; the remaining chain (`HirPlanningShim` → `HirToMirShim` → `MirProgramAssembly`) still satisfies pre-flight.

## Test plan
- [x] Full suite `pytest`: 1262 passed, 5 skipped (no regressions)
- [x] Byte-equivalence: 279 + 2 skipped passed (preserved)
- [x] mypy: 0 new errors
- [x] ruff check + format (CI v0.9.10): clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)