### PR TITLE
F5.3: cut compile_kernel_body to Compiler.run + DEFAULT_KERNEL_PIPELINE

### DIFF
--- a/src/srdatalog/ir/codegen/cuda/api.py
+++ b/src/srdatalog/ir/codegen/cuda/api.py
@@ -136,53 +136,35 @@ def compile_kernel_body(
       `relation.d2l` (and any future index dialect) so positional
       slots advance by 2 per FULL_VER D2L source — matching legacy
       `compute_view_slot_offsets`. Pass {} or None for plain DSAI.
+
+  Implementation: F5.3 routes this entry point through
+  `Compiler.run(KernelCtx(...), pipeline=DEFAULT_KERNEL_PIPELINE)` —
+  the imperative block that previously lived here is now five
+  `ProgramPass` shims in `srdatalog.ir.default_pipelines`. Output is
+  byte-equivalent (the shim composition mirrors the old block 1-to-1;
+  `AssignHandlesShim` is idempotent so re-running it over an EP whose
+  handles are already assigned — the `compile_pipeline` path — leaves
+  the pipeline byte-identical).
   '''
-  from srdatalog.ir.codegen.cuda.emit import EmitCtx, emit
-  from srdatalog.ir.codegen.cuda.envelope import (
-    assign_handle_positions,
-    collect_unique_view_specs,
-    emit_view_declarations,
-  )
-  from srdatalog.ir.dialects.relation.d2l import view_counts_for_specs
-  from srdatalog.ir.dialects.relation.sorted_array.lowerings import (
-    LoweringCtx,
-    lower_scan_pipeline,
-  )
+  from srdatalog.ir.core.dialect import Compiler
+  from srdatalog.ir.default_pipelines import DEFAULT_KERNEL_PIPELINE, KernelCtx
 
-  pipeline = list(ep.pipeline)
-  pipeline = assign_handle_positions(pipeline)
-
-  view_specs = collect_unique_view_specs(pipeline)
-  view_counts = view_counts_for_specs(view_specs, rel_index_types or {})
-  view_decls, view_vars = emit_view_declarations(
-    view_specs,
-    pipeline,
-    slot_mode=slot_mode,
-    view_counts=view_counts,
+  state: KernelCtx = Compiler().run(
+    KernelCtx(
+      ep=ep,
+      is_counting=is_counting,
+      output_var_name=output_var_name,
+      output_vars=output_vars,
+      slot_mode=slot_mode,
+      rel_index_types=rel_index_types,
+      tiled_cartesian=tiled_cartesian,
+      bg_enabled=bg_enabled,
+    ),
+    pipeline=DEFAULT_KERNEL_PIPELINE,
   )
-
-  # Split the combined view_vars dict into name-only (handle_idx ->
-  # view_var) and base-slot (handle_idx -> slot) maps. The envelope
-  # emits both into the same dict via a `__base__<idx>` sentinel.
-  name_map = {k: v for k, v in view_vars.items() if k.isdigit()}
-  base_map = {
-    k.removeprefix('__base__'): int(v) for k, v in view_vars.items() if k.startswith('__base__')
-  }
-
-  lower_ctx = LoweringCtx(
-    view_var_names=name_map,
-    is_counting=is_counting,
-    output_var=output_var_name,
-    output_var_overrides=dict(output_vars) if output_vars else {},
-    rel_index_types=dict(rel_index_types) if rel_index_types else {},
-    view_slot_bases=base_map,
-    dedup_hash=ep.dedup_hash,
-    tiled_cartesian=tiled_cartesian,
-    bg_enabled=bg_enabled,
-  )
-  iir = lower_scan_pipeline(pipeline, lower_ctx)
-  emit_ctx = EmitCtx(indent_level=4)
-  return view_decls + emit(iir, emit_ctx)
+  body_text = state.body_text
+  assert body_text is not None, 'compile_kernel_body: CudaRenderShim left body_text unset'
+  return body_text
 
 
 __all__ = ['Target', 'compile_kernel_body', 'compile_pipeline', 'compile_runner']

--- a/tests/test_default_pipelines_shims.py
+++ b/tests/test_default_pipelines_shims.py
@@ -354,6 +354,86 @@ def test_compile_to_mir_verbose_does_not_break():
   assert loud == quiet
 
 
+# -----------------------------------------------------------------------------
+# F5.3: compile_kernel_body cut-over
+# -----------------------------------------------------------------------------
+
+
+def test_compile_kernel_body_routes_through_default_pipeline():
+  '''F5.3: `compile_kernel_body` is now a thin `Compiler.run` over
+  `DEFAULT_KERNEL_PIPELINE`. The returned string must equal the
+  direct shim composition for both phases.'''
+  from srdatalog.ir.codegen.cuda.api import compile_kernel_body
+
+  compiler = Compiler.with_default_plugins()
+  prog_state = compiler.run(InitialProg(program=_tc_program()), pipeline=DEFAULT_PROGRAM_PIPELINE)
+  assert prog_state.mir_program is not None
+  ep = _first_ep(prog_state.mir_program)
+
+  # Materialize phase.
+  via_api = compile_kernel_body(ep, is_counting=False)
+  via_pipeline = compiler.run(
+    KernelCtx(ep=ep, is_counting=False), pipeline=DEFAULT_KERNEL_PIPELINE
+  ).body_text
+  assert via_api == via_pipeline
+
+  # Count phase with overridden output var (mirrors runner emit).
+  via_api_ct = compile_kernel_body(ep, is_counting=True, output_var_name='output_ctx')
+  via_pipeline_ct = compiler.run(
+    KernelCtx(ep=ep, is_counting=True, output_var_name='output_ctx'),
+    pipeline=DEFAULT_KERNEL_PIPELINE,
+  ).body_text
+  assert via_api_ct == via_pipeline_ct
+
+
+def test_compile_kernel_body_threads_all_kwargs():
+  '''Sanity check: every kwarg on `compile_kernel_body` survives the
+  cut-over. Build a KernelCtx with non-default values for each knob
+  the shims read and confirm `compile_kernel_body` reaches the same
+  shim output.'''
+  from srdatalog.ir.codegen.cuda.api import compile_kernel_body
+
+  compiler = Compiler.with_default_plugins()
+  prog_state = compiler.run(InitialProg(program=_tc_program()), pipeline=DEFAULT_PROGRAM_PIPELINE)
+  assert prog_state.mir_program is not None
+  ep = _first_ep(prog_state.mir_program)
+
+  kwargs = dict(
+    is_counting=False,
+    output_var_name='output_ctx_0',
+    output_vars={'Path': 'output_ctx_0'},
+    slot_mode='positional',
+    rel_index_types={},
+    tiled_cartesian=False,
+    bg_enabled=False,
+  )
+  via_api = compile_kernel_body(ep, **kwargs)
+  via_pipeline = compiler.run(
+    KernelCtx(ep=ep, **kwargs), pipeline=DEFAULT_KERNEL_PIPELINE
+  ).body_text
+  assert via_api == via_pipeline
+
+
+def test_assign_handles_shim_is_idempotent():
+  '''Compile_pipeline rebuilds the EP with `assign_handle_positions_in_ep`
+  before calling `compile_kernel_body`, which then re-runs the
+  AssignHandlesShim. The shim must produce a byte-identical pipeline
+  on the second pass, otherwise `compile_pipeline` would shift handle
+  indices and break the jit_batch goldens.'''
+  from srdatalog.ir.codegen.cuda.envelope import assign_handle_positions_in_ep
+
+  compiler = Compiler.with_default_plugins()
+  prog_state = compiler.run(InitialProg(program=_tc_program()), pipeline=DEFAULT_PROGRAM_PIPELINE)
+  assert prog_state.mir_program is not None
+  ep = _first_ep(prog_state.mir_program)
+
+  ep_once = assign_handle_positions_in_ep(ep)
+  state_twice = AssignHandlesShim().apply(KernelCtx(ep=ep_once, is_counting=False), None)
+  # Each MIR op's handle_start must be unchanged after re-assignment.
+  for before, after in zip(ep_once.pipeline, state_twice.ep.pipeline, strict=True):
+    assert getattr(before, 'handle_start', None) == getattr(after, 'handle_start', None)
+
+
 if __name__ == '__main__':
   test_every_program_pipeline_entry_is_a_pass()
   test_every_kernel_pipeline_entry_is_a_pass()
@@ -377,4 +457,7 @@ if __name__ == '__main__':
   test_compile_to_mir_apply_mir_passes_false_filters_mir_opt()
   test_compile_to_mir_with_precomputed_hir_skips_planning()
   test_compile_to_mir_verbose_does_not_break()
+  test_compile_kernel_body_routes_through_default_pipeline()
+  test_compile_kernel_body_threads_all_kwargs()
+  test_assign_handles_shim_is_idempotent()
   print('OK')


### PR DESCRIPTION
## Summary
- Replaces `compile_kernel_body` body (46 LOC imperative) with a `Compiler().run(KernelCtx(...), pipeline=DEFAULT_KERNEL_PIPELINE)` call
- All 8 kwargs (`is_counting`, `output_var_name`, `output_vars`, `slot_mode`, `rel_index_types`, `tiled_cartesian`, `bg_enabled`) preserved verbatim
- No `KernelCtx` / shim extensions needed; F5.1 already declared every field

## Notes for reviewer
- **`compile_pipeline` double-assign-handles resolution: no fix needed.** `AssignHandlesShim` is idempotent (pure deterministic walk with fresh `offset_box=[0]` + `dataclasses.replace`; no mutation). Re-running on an already-assigned pipeline produces byte-identical `handle_start` values. Pinned by new `test_assign_handles_shim_is_idempotent`.
- LOC delta on the function body: 46 → 19. Full function (sig + docstring + body): 88 → 70.

## Test plan
- [x] Full suite `pytest`: 1279 passed, 5 skipped (no regressions)
- [x] Byte-equivalence (`test_byte_equivalence_jit.py` + `test_runner_byte_equivalence.py` + `test_cuda_complete_runner.py` + `test_dedup_hash_byte_equivalence.py`): 553 baseline goldens pass; new tests bring `test_default_pipelines_shims.py` to 21 (was 18)
- [x] mypy: 0 issues on the touched files
- [x] ruff check + format (CI v0.9.10): clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)