### PR TITLE
C5: migrate tiled_cartesian to typed Pragma + TiledCartesian wrap op

### DIFF
--- a/src/srdatalog/ir/codegen/cuda/envelope.py
+++ b/src/srdatalog/ir/codegen/cuda/envelope.py
@@ -103,6 +103,14 @@ def _assign_handle_positions_rec(node: m.MirNode, offset_box: list[int]) -> m.Mi
   if isinstance(node, m.PositionedExtract):
     new_sources = [_assign_handle_positions_rec(src, offset_box) for src in node.sources]
     return replace(node, sources=new_sources)
+  # C5: `mir.TiledCartesian` wraps an eligible `CartesianJoin` (the
+  # `TiledCartesian` pragma's materialized form). The wrap is opaque
+  # to the handle walk; recurse into `inner` so the wrapped Cart's
+  # handles get assigned identically to the unwrapped flow.
+  if isinstance(node, m.TiledCartesian):
+    new_inner = _assign_handle_positions_rec(node.inner, offset_box)
+    assert isinstance(new_inner, m.CartesianJoin)
+    return replace(node, inner=new_inner)
   return node
 
 
@@ -147,12 +155,16 @@ def count_handles(ops: list[m.MirNode]) -> int:
   '''Number of `views[]` slots needed by the kernel — `max(handle_start) + 1`.'''
   result = 0
   for op in ops:
-    if isinstance(op, m.ColumnJoin | m.CartesianJoin):
-      for src in op.sources:
+    # C5: `TiledCartesian` wraps a CartesianJoin; unwrap before
+    # accounting so the wrapped Cart's sources count toward the
+    # handle slot total identically to the unwrapped flow.
+    actual = op.inner if isinstance(op, m.TiledCartesian) else op
+    if isinstance(actual, m.ColumnJoin | m.CartesianJoin):
+      for src in actual.sources:
         h = getattr(src, 'handle_start', -1)
         result = max(result, h + 1)
-    elif isinstance(op, m.Scan | m.Negation | m.Aggregate):
-      result = max(result, getattr(op, 'handle_start', -1) + 1)
+    elif isinstance(actual, m.Scan | m.Negation | m.Aggregate):
+      result = max(result, getattr(actual, 'handle_start', -1) + 1)
   return result
 
 
@@ -207,10 +219,17 @@ def collect_unique_view_specs(ops: list[m.MirNode]) -> list[ViewSpec]:
   '''Walk the pipeline and collect a deduplicated list of `ViewSpec`s in
   first-occurrence order. Covers every op that references a view
   (ColumnJoin, CartesianJoin, Scan, Negation, Aggregate, BalancedScan,
-  PositionedExtract).'''
+  PositionedExtract).
+
+  C5: `mir.TiledCartesian` wraps a `CartesianJoin`; the wrap is
+  opaque to this walk so we unwrap before dispatching to the same
+  source-collection logic used for the unwrapped Cart.
+  '''
   specs: list[ViewSpec] = []
   seen: set[str] = set()
   for op in ops:
+    if isinstance(op, m.TiledCartesian):
+      op = op.inner
     if isinstance(op, m.ColumnJoin | m.CartesianJoin):
       for src in op.sources:
         if isinstance(src, m.ColumnSource):
@@ -331,6 +350,11 @@ def emit_view_declarations(
     view_vars[key] = view_var
 
   for op in pipeline:
+    # C5: `TiledCartesian` wraps a `CartesianJoin` — unwrap so the
+    # handle-index map ('1' -> 'view_R_0_FULL_VER', etc.) gets
+    # populated identically to the unwrapped flow.
+    if isinstance(op, m.TiledCartesian):
+      op = op.inner
     if isinstance(op, m.ColumnJoin | m.CartesianJoin):
       for src in op.sources:
         k = _spec_key(src.rel_name, list(src.index), src.version.code)

--- a/src/srdatalog/ir/codegen/cuda/pipeline_utils.py
+++ b/src/srdatalog/ir/codegen/cuda/pipeline_utils.py
@@ -168,13 +168,22 @@ def count_handles_in_pipeline(ops: list[m.MirNode]) -> int:
   slots the kernel's `views[]` array needs. Zero when no op carries a
   handle_start (caller should still allocate 1 slot in that case; this
   function faithfully returns 0 to match Nim).
+
+  C5: `mir.TiledCartesian` wraps a `CartesianJoin`; the wrap is
+  opaque to this walk so we unwrap before accounting for the
+  underlying Cart's source handles.
   '''
   result = 0
   for op in ops:
-    if isinstance(op, m.ColumnJoin) or isinstance(op, m.CartesianJoin):
-      for src in op.sources:
+    actual = op.inner if isinstance(op, m.TiledCartesian) else op
+    if isinstance(actual, m.ColumnJoin) or isinstance(actual, m.CartesianJoin):
+      for src in actual.sources:
         h = getattr(src, "handle_start", -1)
         result = max(result, h + 1)
-    elif isinstance(op, m.Scan) or isinstance(op, m.Negation) or isinstance(op, m.Aggregate):
-      result = max(result, getattr(op, "handle_start", -1) + 1)
+    elif (
+      isinstance(actual, m.Scan)
+      or isinstance(actual, m.Negation)
+      or isinstance(actual, m.Aggregate)
+    ):
+      result = max(result, getattr(actual, "handle_start", -1) + 1)
   return result

--- a/src/srdatalog/ir/dialects/relation/sorted_array/__init__.py
+++ b/src/srdatalog/ir/dialects/relation/sorted_array/__init__.py
@@ -141,6 +141,27 @@ def _register_passes() -> None:
   def lower_mir_fan_out(op: Any, ctx: Any) -> Any:
     return lower_fan_out(op, ctx)
 
+  # C5 (per docs/phase_c_pragma_materialization.md §4.3): the
+  # `TiledCartesian` pragma's MIR wrap op `mir.TiledCartesian` lowers
+  # via the rule registered here. The dispatch entry point asserts
+  # because the actual emission needs the trailing chain from
+  # `_lower_inner_chain` — see the pragma module's
+  # `lower_tiled_cartesian_in_chain` docstring for the split rationale.
+  # This rule pins the dialect's ownership of `TiledCartesian` for
+  # the registry-completeness discipline test.
+  from srdatalog.ir.dialects.relation.sorted_array.pragmas.tiled_cartesian import (
+    lower_tiled_cartesian,
+  )
+
+  @lowering(
+    DIALECT,
+    mir.TiledCartesian,
+    consumes=('mir',),
+    produces=('iir.cf', 'relation.sorted_array'),
+  )
+  def lower_mir_tiled_cartesian(op: Any, ctx: Any) -> Any:
+    return lower_tiled_cartesian(op, ctx)
+
   # Verifier scaffolding — per-op invariants (D9: SaHint inside
   # IterURV scope, etc.) land incrementally as we encode them.
   @verifier(DIALECT)

--- a/src/srdatalog/ir/dialects/relation/sorted_array/lowerings.py
+++ b/src/srdatalog/ir/dialects/relation/sorted_array/lowerings.py
@@ -228,6 +228,11 @@ def _supported_pipeline(ops: list[mir.MirNode]) -> bool:
     # dispatches to `_lower_nested_cart` via `_lower_inner_chain`,
     # which already handles 1+ source forms (with prefix narrowing).
     # Hit by ddisasm StackLiveVarBlockEnd1_D0_splitB.
+    #
+    # C5: `mir.TiledCartesian` (the wrap op the `TiledCartesian`
+    # pragma materializes around an eligible Cartesian) is accepted
+    # in the same slot — `_lower_inner_chain` dispatches it through
+    # `lower_tiled_cartesian_in_chain`.
     for op in middle:
       if isinstance(op, (mir.Filter, mir.ConstantBind)):
         continue
@@ -235,18 +240,23 @@ def _supported_pipeline(ops: list[mir.MirNode]) -> bool:
         continue
       if isinstance(op, mir.CartesianJoin):
         continue
+      if isinstance(op, mir.TiledCartesian):
+        continue
       return False
     return True
 
   if isinstance(head, mir.ColumnJoin) and len(head.sources) >= 2:
     # M3+M5+M7+M5.x shape: multi-source root CJ; middle can hold
     # nested CJs / Filter / ConstantBind / Negation / Cartesian.
+    # C5: same `mir.TiledCartesian` allowance as the Scan-rooted case.
     for op in middle:
       if isinstance(op, (mir.Filter, mir.ConstantBind)):
         continue
       if isinstance(op, mir.ColumnJoin) and len(op.sources) >= 2:
         continue
       if isinstance(op, mir.CartesianJoin):
+        continue
+      if isinstance(op, mir.TiledCartesian):
         continue
       if isinstance(op, mir.Negation):
         continue
@@ -1073,6 +1083,21 @@ def _lower_inner_chain(
   if isinstance(head, mir.CartesianJoin):
     return _lower_nested_cart(head, tail, ctx)
 
+  # C5 (per docs/phase_c_pragma_materialization.md §4.3): the
+  # `TiledCartesian` MIR wrap op is the materialized form of the
+  # `TiledCartesian` Pragma. Dispatch here because the tiled emission
+  # helper (`_lower_nested_cart_tiled`) needs both the wrapped
+  # Cartesian AND the trailing chain (`tail`) — InsertIntos plus any
+  # Filter / ConstantBind. The standalone @lowering entry registered
+  # via the dialect package is a structural contract that asserts on
+  # direct invocation; real emission flows through this branch.
+  if isinstance(head, mir.TiledCartesian):
+    from srdatalog.ir.dialects.relation.sorted_array.pragmas.tiled_cartesian import (
+      lower_tiled_cartesian_in_chain,
+    )
+
+    return lower_tiled_cartesian_in_chain(head, tail, ctx)
+
   if isinstance(head, mir.Negation):
     return _lower_negation(head, tail, ctx)
 
@@ -1087,7 +1112,20 @@ def _tiled_cart_eligible(
   per-source / materialize phase / ctx.tiled_cartesian set. The `rest`
   shape is unconstrained (matches legacy) — Filters and other ops
   between Cart and the trailing InsertIntos pass through naturally
-  via `_lower_inner_chain` with `ctx.tiled_cartesian_valid_var` set.'''
+  via `_lower_inner_chain` with `ctx.tiled_cartesian_valid_var` set.
+
+  DEAD CODE NOTE (C5, per docs/phase_c_pragma_materialization.md §5.1):
+  the `ctx.tiled_cartesian` gate is the legacy `if ctx.tiled_cartesian:`
+  branch that the C5 PR migrates to the `TiledCartesian` Pragma +
+  `mir.TiledCartesian` wrap op. The predicate stays LIVE during the
+  C5 dual-write transition because `complete_runner.py` still
+  threads `LoweringCtx.tiled_cartesian` from
+  `has_tiled_cartesian_eligible(pipeline)` and the wrap op dispatch
+  in `_lower_inner_chain` flips the same flag for the body render.
+  Phase A3 deletes the `ctx.tiled_cartesian` field and this branch
+  collapses to the shape-only checks (which then move to
+  `pragmas/tiled_cartesian.py:_is_eligible_cart`).
+  '''
   if not ctx.tiled_cartesian or ctx.is_counting:
     return False
   if len(cart_op.sources) != 2:
@@ -1568,6 +1606,20 @@ def _lower_nested_cart(
   if num_sources < 1:
     raise ValueError('_lower_nested_cart: must have at least 1 source')
 
+  # DEAD CODE NOTE (C5, per docs/phase_c_pragma_materialization.md §5.1):
+  # this `if _tiled_cart_eligible(...)` dispatch is the legacy
+  # `if ctx.tiled_cartesian:` branch that the C5 PR migrates to the
+  # `mir.TiledCartesian` wrap op dispatched from `_lower_inner_chain`.
+  # The branch stays LIVE during the C5 dual-write transition because
+  # the legacy runner-driven path (`complete_runner.py` ->
+  # `LoweringCtx.tiled_cartesian`) still sets `ctx.tiled_cartesian=True`
+  # for shape-eligible pipelines, independent of any rule pragma. The
+  # wrap op fires only when `ep.tiled_cartesian is False` (synthesized
+  # EPs / post-A3 state); the dual-write `materialize_tiled_cartesian`
+  # handler short-circuits when the bool is set so the two paths
+  # never both fire on the same Cartesian. Phase A3 deletes the
+  # `ctx.tiled_cartesian` field, the bool short-circuit, and this
+  # dispatch — leaving the wrap-op path as the sole emission driver.
   if _tiled_cart_eligible(cart_op, ctx):
     return _lower_nested_cart_tiled(cart_op, rest, ctx)
 

--- a/src/srdatalog/ir/dialects/relation/sorted_array/pragmas/tiled_cartesian.py
+++ b/src/srdatalog/ir/dialects/relation/sorted_array/pragmas/tiled_cartesian.py
@@ -1,0 +1,287 @@
+'''Pragma: `tiled_cartesian` — atomic-free coalesced writes for 2-source
+1-var-per-source nested Cartesian joins on sorted-array sources.
+
+Trigger: `Rule(...).with_pragma(TiledCartesian())` (preferred typed form).
+   The legacy bool `ExecutePipeline.tiled_cartesian` is driven from
+   `complete_runner.py:has_tiled_cartesian_eligible(pipeline)` and
+   threaded through `compile_kernel_body(tiled_cartesian=...)` /
+   `LoweringCtx.tiled_cartesian`; that runner-side detection stays
+   intact through C5, slated for removal in A3.
+
+Materialization (this module): walk `ExecutePipeline.pipeline` and
+   replace every eligible nested `mir.CartesianJoin` with
+   `mir.TiledCartesian(inner=that_cj)` during `MirPragmaPass`, then
+   strip the `TiledCartesian` instance from the EP's `pragmas`
+   tuple. Eligibility mirrors legacy
+   `_tiled_cart_eligible`: 2 sources, 1 var per source, not counting.
+   The handler short-circuits when `ep.tiled_cartesian` is True so
+   the legacy runner-driven path remains the sole emission driver
+   (the dual-write transition; see `dedup_hash.py` for the parallel
+   pattern).
+
+Lowering (this module): a `@lowering(target=iir.cf, source=mir.
+   TiledCartesian)` rule (registered via the parent dialect's
+   `_register_passes`) delegates to the existing
+   `_lower_nested_cart_tiled` helper with `ctx.tiled_cartesian`
+   flipped True for the duration of the call, so the new lowering
+   and the legacy path emit byte-identical IIR. Because
+   `_lower_nested_cart_tiled` needs the trailing chain after the
+   Cartesian (the `rest` parameter — InsertIntos plus any
+   intervening Filter / ConstantBind), the dispatch lives inside
+   `_lower_inner_chain` rather than as a standalone lowering: that
+   site has both `head` and `tail` in scope. The
+   `@lowering`-registered rule serves as the dialect's contract that
+   `TiledCartesian` is owned here — actual emission happens via the
+   `_lower_inner_chain` branch added in `lowerings.py`.
+
+Spec: `docs/phase_c_pragma_materialization.md` §4.3 (`tiled_cartesian`
+stays in sorted_array — no new sub-dialect needed), §5 (C5 PR row),
+§5.1 (per-PR acceptance gate); `docs/pragma_as_typed_object.md` §2
+(Pragma base class), §3 (`@pragma_handler` decorator).
+'''
+
+from __future__ import annotations
+
+import dataclasses
+from dataclasses import dataclass
+from typing import Any, final
+
+from srdatalog.ir.core import Op, Pragma, pragma_handler
+from srdatalog.ir.mir.types import (
+  CartesianJoin,
+  ExecutePipeline,
+)
+from srdatalog.ir.mir.types import (
+  TiledCartesian as TiledCartesianOp,
+)
+
+
+@final
+@dataclass(frozen=True, slots=True)
+class TiledCartesian(Pragma):
+  '''Atomic-free coalesced writes for eligible nested Cartesian joins.
+
+  Triggers `MirPragmaPass` to wrap every eligible nested
+  `CartesianJoin` in `ExecutePipeline.pipeline` with a
+  `mir.TiledCartesian` wrap op; the wrap's `@lowering` rule emits
+  the same `SaTiledCartesian2D` + `TiledBallotBlock` IIR shape that
+  the legacy `if ctx.tiled_cartesian:` branch inside
+  `_lower_nested_cart` produces.
+
+  Eligibility (mirrors legacy `_tiled_cart_eligible`):
+    - exactly 2 sources,
+    - 1 var bound per source,
+    - not in the count phase (handled at lowering time via
+      `ctx.is_counting`; the wrap op is inert under counting).
+
+  No fields today — the existing legacy emitter treats
+  `tiled_cartesian` as a flat bool. Structured config (custom tile
+  sizes, smem footprint hints, etc.) is plausible later but out of
+  scope for C5; per `docs/pragma_as_typed_object.md` §2, future
+  fields land via back-compat-preserving dataclass defaults.
+  '''
+
+
+# -----------------------------------------------------------------------------
+# Materialization handler (registered at import time via @pragma_handler)
+# -----------------------------------------------------------------------------
+
+
+def _is_eligible_cart(op: Any) -> bool:
+  '''True iff `op` is a 2-source / 1-var-per-source CartesianJoin.
+
+  Pure shape predicate — does NOT consult `ctx.is_counting` (the
+  pragma pass has no count-phase notion). The wrap op's lowering
+  defers to the legacy emitter's count-phase short-circuit, so a
+  wrap that's emitted unconditionally still produces the right IIR
+  in the count phase (the legacy `_lower_nested_cart` body fires
+  instead of `_lower_nested_cart_tiled`).
+  '''
+  return (
+    isinstance(op, CartesianJoin)
+    and len(op.sources) == 2
+    and len(op.var_from_source) == 2
+    and len(op.var_from_source[0]) == 1
+    and len(op.var_from_source[1]) == 1
+  )
+
+
+def _wrap_eligible_carts(
+  pipeline: list[Any],
+) -> list[Any]:
+  '''Replace every eligible nested `CartesianJoin` in `pipeline` with
+  `TiledCartesian(inner=that_cj)`.
+
+  Walks the top-level pipeline list. The pipeline shape supported by
+  `_supported_pipeline` allows Cartesians as middle ops (after a
+  Scan or CJ root, or as the root itself). Root Cartesians are NOT
+  wrapped here — the tiled path is reserved for nested Cartesians
+  (`_lower_root_cart` doesn't dispatch to `_lower_nested_cart_tiled`,
+  per the legacy emitter shape). Per-source / per-prefix details
+  (state-key reuse, view var) are resolved later by
+  `_lower_nested_cart_tiled` from the wrapped `inner.sources`.
+
+  Non-eligible Cartesians pass through unchanged so a pipeline with
+  both 2-source and N-source Carts (rare but possible) still
+  type-checks. Non-Cartesian ops always pass through.
+  '''
+  if not pipeline:
+    return pipeline
+  wrapped: list[Any] = []
+  # The first op is the pipeline root (Scan / CJ / Cart). Root
+  # Cartesians use `_lower_root_cart` which never dispatches tiled,
+  # so we leave index 0 alone even if shape-eligible.
+  wrapped.append(pipeline[0])
+  for child in pipeline[1:]:
+    if _is_eligible_cart(child):
+      wrapped.append(TiledCartesianOp(inner=child))
+    else:
+      wrapped.append(child)
+  return wrapped
+
+
+@pragma_handler(TiledCartesian, on=ExecutePipeline)
+def materialize_tiled_cartesian(
+  op: Any,  # ExecutePipeline at runtime — typed as Any to match the registry's
+  # Callable[[Any, Pragma, PragmaCtx], Any] signature (see
+  # core/pragma.py:PragmaRegistration). Body re-narrows via the typed
+  # `op.pragmas` / `op.tiled_cartesian` accesses below.
+  pragma: Any,  # TiledCartesian at runtime; same Any reason.
+  ctx: Any,  # PragmaCtx, unused for this no-config pragma.
+) -> Any:
+  '''Materialize `TiledCartesian` into a `TiledCartesian` wrap op
+  around each eligible nested `CartesianJoin` in `op.pipeline`.
+
+  Returns a new `ExecutePipeline` with:
+    - `pipeline` rewritten so every shape-eligible nested
+      `CartesianJoin` (2 sources, 1 var per source) is replaced by
+      `mir.TiledCartesian(inner=that_cj)` — **except** in the C5
+      dual-write transition state (see below),
+    - `pragmas` filtered to drop the consumed `TiledCartesian`
+      instance (per the `MirPragmaPass` post-flight invariant; see
+      `docs/pragma_as_typed_object.md` §3).
+
+  C5 dual-write transition: the legacy runner-driven path
+  (`complete_runner.py:has_tiled_cartesian_eligible(pipeline)` ->
+  `compile_kernel_body(tiled_cartesian=True)` ->
+  `LoweringCtx.tiled_cartesian=True` ->
+  `_lower_nested_cart` dispatches to `_lower_nested_cart_tiled`)
+  unconditionally enables tiled emission on shape-eligible
+  pipelines, independent of any rule pragma. When `ep.tiled_cartesian`
+  is True we therefore SKIP the wrap step: stripping the pragma is
+  enough to satisfy `MirPragmaPass`'s post-flight invariant, and
+  the legacy ctx-driven dispatch continues to emit byte-equivalent
+  CUDA.
+
+  When `ep.tiled_cartesian` is False (the post-A3 pure-typed state,
+  or test fixtures that exercise only the typed surface), the
+  handler produces the wrap op and the dialect's
+  `_lower_inner_chain` branch (added in C5 to detect
+  `TiledCartesian` heads) delegates to `_lower_nested_cart_tiled`
+  with `ctx.tiled_cartesian` flipped True for the duration — so the
+  resulting IIR is byte-equivalent to the legacy branch by
+  construction.
+
+  Idempotency: the EP carries at most one `TiledCartesian` (the
+  DSL constructs at most one per `with_pragma(TiledCartesian())`
+  call). We filter by `isinstance(p, TiledCartesian)` to be
+  defensive — any stray duplicates get removed together. Re-running
+  the pass on already-wrapped pipelines is also safe because
+  `_is_eligible_cart` returns False for `TiledCartesianOp` (it's
+  not a `CartesianJoin`).
+  '''
+  new_pragmas = tuple(p for p in op.pragmas if not isinstance(p, TiledCartesian))
+  # Dual-write transition: skip the wrap if the legacy bool is set
+  # (the legacy lowering will handle emission). See docstring above.
+  if op.tiled_cartesian:
+    return dataclasses.replace(op, pragmas=new_pragmas)
+  new_pipeline = _wrap_eligible_carts(list(op.pipeline))
+  return dataclasses.replace(op, pipeline=new_pipeline, pragmas=new_pragmas)
+
+
+# -----------------------------------------------------------------------------
+# TiledCartesian lowering (registered by sorted_array `_register_passes`)
+# -----------------------------------------------------------------------------
+
+
+def lower_tiled_cartesian_in_chain(
+  op: TiledCartesianOp,
+  tail: list[Any],
+  ctx: Any,
+) -> Op:
+  '''Emit the IIR for `TiledCartesian(inner=CartesianJoin)` with
+  trailing chain `tail` (InsertIntos plus any intervening
+  Filter / ConstantBind from the surrounding `_lower_inner_chain`).
+
+  Called from `lowerings._lower_inner_chain` when a `TiledCartesian`
+  wrap op appears as a chain head — that site has both `head` and
+  `tail` in scope, which the legacy `_lower_nested_cart_tiled`
+  helper needs to render the inner body. We flip
+  `ctx.tiled_cartesian` True for the duration so the helper takes
+  the tiled path; the inner chain rendering also picks up
+  `ctx.tiled_cartesian_valid_var` via the helper's own save/restore.
+
+  Byte-equivalence by construction: the legacy
+  `if ctx.tiled_cartesian:` -> `_lower_nested_cart_tiled` dispatch
+  inside `_lower_nested_cart` and this wrap-op dispatch call the
+  SAME helper with the SAME args, so the produced IIR is identical
+  for the same input `(cart_op, rest)`.
+
+  `LoweringCtx` is a non-frozen dataclass (it carries `name_counter`
+  + per-pass mutable state), so attribute assignment is the
+  supported mutation surface — no `object.__setattr__` shim needed
+  and the D18 ratchet does not apply.
+  '''
+  # Deferred import: the monolith module imports nothing from this
+  # subpackage at top level, but co-located ops + pragmas + lowerings
+  # in `pragmas/tiled_cartesian.py` (this file) get loaded by the
+  # dialect's `_register_passes` AFTER the monolith. Importing at
+  # function-call time keeps the dialect import graph linear.
+  from srdatalog.ir.dialects.relation.sorted_array.lowerings import (
+    _lower_nested_cart_tiled,
+  )
+
+  prev = getattr(ctx, 'tiled_cartesian', False)
+  try:
+    ctx.tiled_cartesian = True
+    return _lower_nested_cart_tiled(op.inner, list(tail), ctx)
+  finally:
+    ctx.tiled_cartesian = prev
+
+
+def lower_tiled_cartesian(op: TiledCartesianOp, ctx: Any) -> Op:
+  '''Framework-registry stub for `@lowering(target=iir.cf,
+  source=TiledCartesian)`. The actual dispatch lives in
+  `lowerings._lower_inner_chain`, which calls
+  `lower_tiled_cartesian_in_chain` with the trailing chain in scope.
+
+  This stub exists so the dialect's `lowerings` list pins the
+  (consumes, produces) contract for `TiledCartesian` — the
+  discipline test `test_tiled_cartesian_lowering_is_registered_on_
+  sorted_array_dialect` consults the dialect to verify ownership.
+  The C2 sibling `lower_dedup_gate` doesn't need this split because
+  `DedupGate(inner=InsertInto)` is a leaf with no `tail` to thread;
+  `TiledCartesian` wraps a non-leaf and needs the surrounding
+  chain, so the chain-aware variant gets a separate entry point.
+
+  Calling this stub directly raises a structural assertion — the
+  framework path is reserved for future readers who can plumb in
+  the missing `tail` (e.g. a refactored MIR-IIR walker that no
+  longer routes through `_lower_inner_chain`).
+  '''
+  raise AssertionError(
+    'lower_tiled_cartesian: dispatch goes through '
+    '`lowerings._lower_inner_chain` -> `lower_tiled_cartesian_in_chain` '
+    'so the trailing chain is in scope. Direct invocation '
+    'indicates a refactor that bypassed the chain dispatch — '
+    'plumb the `tail` through and call `lower_tiled_cartesian_in_chain` '
+    'instead.'
+  )
+
+
+__all__ = [
+  'TiledCartesian',
+  'lower_tiled_cartesian',
+  'lower_tiled_cartesian_in_chain',
+  'materialize_tiled_cartesian',
+]

--- a/src/srdatalog/ir/hir/lower.py
+++ b/src/srdatalog/ir/hir/lower.py
@@ -588,6 +588,10 @@ def _extract_pipeline_sources(
   elif isinstance(op, mir.PositionedExtract):
     for s in op.sources:
       _extract_pipeline_sources(s, out)
+  # C5: `mir.TiledCartesian` wraps a `CartesianJoin` — recurse into
+  # `inner` so the wrapped Cart's sources appear in `source_specs`.
+  elif isinstance(op, mir.TiledCartesian):
+    _extract_pipeline_sources(op.inner, out)
 
 
 def wrap_in_execute_pipeline(

--- a/src/srdatalog/ir/mir/types.py
+++ b/src/srdatalog/ir/mir/types.py
@@ -383,6 +383,34 @@ class BlockGroupRoot(Op):
   inner: Any  # MirNode at runtime; forward-ref via Any since MirNode union is defined below.
 
 
+@final
+@dataclass(frozen=True, slots=True)
+class TiledCartesian(Op):
+  '''MIR wrap op: tiled-Cartesian dispatch around a nested CartesianJoin.
+
+  Inserted by `srdatalog.ir.dialects.relation.sorted_array.pragmas.
+  tiled_cartesian.materialize_tiled_cartesian` during `MirPragmaPass`
+  whenever an `ExecutePipeline` carries a `TiledCartesian` pragma AND
+  the legacy `ep.tiled_cartesian` dual-write bool is False. Lowered
+  by the `@lowering(target=iir.cf, source=TiledCartesian)` rule
+  registered in the same module to the same IIR shape that the
+  legacy `ctx.tiled_cartesian`-driven `_lower_nested_cart_tiled`
+  branch inside `_lower_nested_cart` produces.
+
+  The wrap op carries the inner eligible `CartesianJoin` so the
+  lowering can render the tiled smem dispatch (per-warp shared-mem
+  reads + ballot-coalesced writes) around the trailing chain.
+
+  Phase C scope (per spec §4.3): `tiled_cartesian` stays in
+  `relation.sorted_array` rather than spawning a new sub-dialect —
+  the materialized form delegates to the existing
+  `sorted_array.SaTiledCartesian2D` IIR op, which is tightly coupled
+  to sorted-array index access.
+  '''
+
+  inner: CartesianJoin
+
+
 # -----------------------------------------------------------------------------
 # Fixpoint maintenance ops (scalar — no children)
 # -----------------------------------------------------------------------------
@@ -483,6 +511,7 @@ class ExecutePipeline(Op):
   work_stealing: bool = False
   block_group: bool = False
   dedup_hash: bool = False
+  tiled_cartesian: bool = False  # C5 dual-write field; removed in A3
   count: bool = False
   concurrent_write: bool = False
 
@@ -596,6 +625,7 @@ MirNode = Union[
   CountPhase,
   FanOut,
   BlockGroupRoot,
+  TiledCartesian,
   RebuildIndex,
   ClearRelation,
   CheckSize,

--- a/tests/test_pragma_tiled_cartesian_end_to_end.py
+++ b/tests/test_pragma_tiled_cartesian_end_to_end.py
@@ -1,0 +1,533 @@
+'''End-to-end test for Phase C5: the `TiledCartesian` typed pragma.
+
+Per `docs/phase_c_pragma_materialization.md` §5.1 (per-PR acceptance
+gate), each Phase C migration ships a `test_pragma_<name>_end_to_end`
+that exercises the pragma via the production `Compiler.run`-style
+pipeline and asserts:
+
+  - The wrap op (`mir.TiledCartesian`) appears in MIR after
+    `MirPragmaPass` (or is suppressed under the dual-write
+    transition; both states are verified here).
+  - The lowered IIR is correct (matches the tiled-cartesian branch
+    of `_lower_nested_cart` -> `_lower_nested_cart_tiled`).
+  - The rendered CUDA is byte-equivalent to the legacy
+    `ctx.tiled_cartesian: bool` path (the load-bearing harness for
+    C5's backward-compat contract).
+
+Plus DSL surface checks:
+
+  - `Rule(...).with_pragma(TiledCartesian())` accepts a typed instance.
+  - `Rule(...).with_pragma(<not-a-pragma>)` raises `TypeError`.
+  - `Rule(...).with_pragma(<unregistered-Pragma>)` raises
+    `UnregisteredPragmaError` (typed sibling of `TypeError`).
+  - `tiled_cartesian` is NOT a per-rule PlanEntry bool today (the
+    runner drives eligibility from pipeline shape via
+    `has_tiled_cartesian_eligible`), so `with_pragma` only sets the
+    typed `pragmas` tuple — there is no PlanEntry bool to mirror.
+
+The framework infrastructure (the `MirPragmaPass` driver, the
+`@pragma_handler` registry, error classes) is exercised by
+`tests/test_mir_pragma_pass.py` + `tests/test_core_pragma.py`; this
+file owns the per-pragma surface.
+'''
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import final
+
+import pytest
+
+import srdatalog.ir.mir.types as m
+from srdatalog.dsl import Rule
+from srdatalog.ir.core import Compiler, Pragma, UnregisteredPragmaError
+from srdatalog.ir.dialects.relation.sorted_array import DIALECT as SA_DIALECT
+from srdatalog.ir.dialects.relation.sorted_array.pragmas.tiled_cartesian import (
+  TiledCartesian,
+  lower_tiled_cartesian,
+  lower_tiled_cartesian_in_chain,
+  materialize_tiled_cartesian,
+)
+from srdatalog.ir.hir.types import Version
+from srdatalog.ir.mir import DIALECT as MIR_DIALECT
+from srdatalog.ir.mir.passes import apply_all_mir_passes, apply_mir_pragma_pass
+from srdatalog.ir.mir.pragma_pass import MirPragmaPass
+
+# -----------------------------------------------------------------------------
+# Fixtures
+# -----------------------------------------------------------------------------
+
+
+@pytest.fixture
+def mir_compiler() -> Compiler:
+  '''Compiler with MIR + sorted_array dialects registered.
+
+  The sorted_array dialect's `_register_passes` imports the pragmas
+  submodule for side effects (registers `@pragma_handler(
+  TiledCartesian, ...)` + the `mir.TiledCartesian` lowering), so
+  this fixture is enough to drive `MirPragmaPass` end-to-end without
+  monkey-patching the registry.
+  '''
+  c = Compiler()
+  c.register_dialect(MIR_DIALECT)
+  c.register_dialect(SA_DIALECT)
+  return c
+
+
+# -----------------------------------------------------------------------------
+# Helpers — synthetic tiled-eligible EP
+# -----------------------------------------------------------------------------
+
+
+def _eligible_cart_ep(
+  *,
+  tiled_cartesian: bool = False,
+  pragmas: tuple[Pragma, ...] = (),
+) -> m.ExecutePipeline:
+  '''Build a Scan + 2-source/1-var-per-source CartesianJoin +
+  InsertInto pipeline — the canonical tiled-eligible shape per
+  `pipeline_utils.has_tiled_cartesian_eligible`.
+
+  The Scan binds `x` from `Src` then the nested Cartesian binds `y`
+  from `R` and `z` from `S`, emitting `Dst(x, y, z)`. Sources have
+  no prefix vars, so the Cartesian uses fresh roots (no state-key
+  reuse). Handles are pre-assigned to mirror the post-
+  `assign_handle_positions_in_ep` shape `compile_pipeline` produces.
+  '''
+  # Handles match the post-`assign_handle_positions` shape: Scan
+  # claims slot 0 then bumps; CartesianJoin captures `handle =
+  # offset_box[0]` (here 1) BEFORE recursing into sources, then
+  # the sources claim slots 1 and 2 in order — so Cart.handle_start
+  # aliases its first source's handle, matching the legacy
+  # convention. Re-running `assign_handle_positions` on this fixture
+  # is idempotent.
+  scan = m.Scan(
+    vars=['x'],
+    rel_name='Src',
+    version=Version.FULL,
+    index=[0],
+    handle_start=0,
+  )
+  src_r = m.ColumnSource(
+    rel_name='R',
+    version=Version.FULL,
+    index=[0],
+    prefix_vars=[],
+    handle_start=1,
+  )
+  src_s = m.ColumnSource(
+    rel_name='S',
+    version=Version.FULL,
+    index=[0],
+    prefix_vars=[],
+    handle_start=2,
+  )
+  cart = m.CartesianJoin(
+    vars=['y', 'z'],
+    sources=[src_r, src_s],
+    var_from_source=[['y'], ['z']],
+    handle_start=1,
+  )
+  insert = m.InsertInto(
+    rel_name='Dst',
+    version=Version.NEW,
+    vars=['x', 'y', 'z'],
+    index=[0, 1, 2],
+  )
+  return m.ExecutePipeline(
+    pipeline=[scan, cart, insert],
+    source_specs=[scan, src_r, src_s],
+    dest_specs=[insert],
+    rule_name='TC',
+    tiled_cartesian=tiled_cartesian,
+    pragmas=pragmas,  # type: ignore[arg-type]
+  )
+
+
+def _ineligible_cart_ep(
+  *,
+  pragmas: tuple[Pragma, ...] = (),
+) -> m.ExecutePipeline:
+  '''Build a Scan + 3-source CartesianJoin + InsertInto pipeline —
+  NOT tiled-eligible (eligibility requires exactly 2 sources). Used
+  to verify the wrap step leaves non-eligible Cartesians alone.
+  '''
+  scan = m.Scan(
+    vars=['x'],
+    rel_name='Src',
+    version=Version.FULL,
+    index=[0],
+    handle_start=0,
+  )
+  srcs = [
+    m.ColumnSource(
+      rel_name=name,
+      version=Version.FULL,
+      index=[0],
+      prefix_vars=[],
+      handle_start=1 + i,
+    )
+    for i, name in enumerate(['R', 'S', 'T'])
+  ]
+  cart = m.CartesianJoin(
+    vars=['y', 'z', 'w'],
+    sources=srcs,
+    var_from_source=[['y'], ['z'], ['w']],
+    handle_start=1,
+  )
+  insert = m.InsertInto(
+    rel_name='Dst',
+    version=Version.NEW,
+    vars=['x', 'y', 'z', 'w'],
+    index=[0, 1, 2, 3],
+  )
+  return m.ExecutePipeline(
+    pipeline=[scan, cart, insert],
+    source_specs=[scan, *srcs],
+    dest_specs=[insert],
+    rule_name='TCIneligible',
+    pragmas=pragmas,  # type: ignore[arg-type]
+  )
+
+
+# -----------------------------------------------------------------------------
+# 1. DSL surface — Rule.with_pragma
+# -----------------------------------------------------------------------------
+
+
+def _empty_rule() -> Rule:
+  '''Build a minimal Rule. The rule's structure is irrelevant for the
+  DSL-surface tests below; we only inspect `rule.plans`.'''
+  from srdatalog.dsl import Atom
+
+  head = Atom(rel='Dst', args=())
+  body_atom = Atom(rel='Src', args=())
+  return Rule(heads=(head,), body=(body_atom,))
+
+
+def test_with_pragma_attaches_typed_pragma_to_default_plan():
+  '''Calling `.with_pragma(TiledCartesian())` on a rule with no
+  plans appends a default `PlanEntry(delta=-1)` carrying the
+  pragma. There is NO matching legacy PlanEntry bool field (unlike
+  `DedupHash` -> `dedup_hash`), so the bool-shadow map returns `{}`
+  and only the typed `pragmas` tuple gets populated.'''
+  rule = _empty_rule().with_pragma(TiledCartesian())
+  assert len(rule.plans) == 1
+  plan = rule.plans[0]
+  assert plan.delta == -1
+  assert len(plan.pragmas) == 1
+  assert isinstance(plan.pragmas[0], TiledCartesian)
+
+
+def test_with_pragma_appends_to_existing_plans():
+  '''When the rule already has plans, `.with_pragma(TiledCartesian())`
+  appends the pragma to EVERY plan's `pragmas` tuple. Matches the
+  per-rule semantic intent of `with_pragma` ("this rule, every
+  variant"), symmetric with C2.'''
+  rule = (
+    _empty_rule()
+    .with_plan(delta=0)
+    .with_plan(delta=1, var_order=('a', 'b'))
+    .with_pragma(TiledCartesian())
+  )
+  assert len(rule.plans) == 2
+  for plan in rule.plans:
+    assert any(isinstance(p, TiledCartesian) for p in plan.pragmas)
+
+
+def test_with_pragma_rejects_non_pragma_arg():
+  '''Legacy string-keyed form is hard-error per
+  `docs/code_discipline.md` D15. Same for any non-`Pragma`
+  instance.'''
+  rule = _empty_rule()
+  with pytest.raises(TypeError, match=r'expected a Pragma subclass'):
+    rule.with_pragma('tiled_cartesian')  # type: ignore[arg-type]
+  with pytest.raises(TypeError):
+    rule.with_pragma(True)  # type: ignore[arg-type]
+
+
+def test_with_pragma_rejects_unregistered_pragma():
+  '''A typed `Pragma` subclass with no `@pragma_handler` registration
+  is rejected at DSL time — caught BEFORE compile, with did-you-mean
+  hints listing the registered handler class names. Per
+  `docs/pragma_as_typed_object.md` §3 and §6.
+  '''
+
+  @final
+  @dataclass(frozen=True, slots=True)
+  class _GhostPragma(Pragma):
+    pass
+
+  rule = _empty_rule()
+  with pytest.raises(UnregisteredPragmaError, match=r'_GhostPragma'):
+    rule.with_pragma(_GhostPragma())
+
+
+# -----------------------------------------------------------------------------
+# 2. MIR-level — MirPragmaPass materialization
+# -----------------------------------------------------------------------------
+
+
+def test_pragma_pass_inserts_tiled_cartesian_when_bool_is_false(mir_compiler):
+  '''Pure typed path (bool=False, only pragma set): MirPragmaPass
+  wraps every eligible nested `CartesianJoin` in `pipeline` with
+  `mir.TiledCartesian`.
+
+  This is the post-A3 target state. Synthesized EPs reach it
+  directly; the DSL `.with_pragma(TiledCartesian())` adds only the
+  typed pragma today (no PlanEntry bool exists to dual-write), but
+  whether the EP-level bool ends up True depends on HIR -> MIR
+  lowering choices outside C5's scope.
+  '''
+  ep = _eligible_cart_ep(tiled_cartesian=False, pragmas=(TiledCartesian(),))
+  out = MirPragmaPass().apply(ep, mir_compiler)
+  # Pragma instance consumed.
+  assert out.pragmas == ()
+  # Pipeline: Scan + TiledCartesian(CartesianJoin) + InsertInto.
+  assert len(out.pipeline) == 3
+  assert isinstance(out.pipeline[0], m.Scan)
+  assert isinstance(out.pipeline[1], m.TiledCartesian)
+  assert isinstance(out.pipeline[1].inner, m.CartesianJoin)
+  assert isinstance(out.pipeline[2], m.InsertInto)
+  # Legacy bool was NOT toggled; the wrap op is the sole signal.
+  assert out.tiled_cartesian is False
+
+
+def test_pragma_pass_skips_wrap_in_dual_write_mode(mir_compiler):
+  '''Dual-write transition (bool=True AND pragma set): MirPragmaPass
+  strips the pragma but leaves `pipeline` untouched. The legacy
+  runner-driven path (`complete_runner.py:has_tiled_cartesian_eligible`
+  -> `LoweringCtx.tiled_cartesian=True` -> `_lower_nested_cart` ->
+  `_lower_nested_cart_tiled`) produces the tiled emit; the wrap op
+  never appears so the monolith doesn't need to know about
+  `mir.TiledCartesian`.
+
+  This is the load-bearing test for the dual-write contract: the C5
+  PR must not break the byte-equivalence harness, and that requires
+  the legacy path to remain the sole emission driver whenever the
+  bool is set.
+  '''
+  ep = _eligible_cart_ep(tiled_cartesian=True, pragmas=(TiledCartesian(),))
+  out = MirPragmaPass().apply(ep, mir_compiler)
+  # Pragma still consumed.
+  assert out.pragmas == ()
+  # No TiledCartesian wrap inserted.
+  assert all(not isinstance(child, m.TiledCartesian) for child in out.pipeline)
+  # Bool preserved for the legacy emitter.
+  assert out.tiled_cartesian is True
+
+
+def test_pragma_pass_skips_ineligible_cartesian(mir_compiler):
+  '''A 3-source CartesianJoin (or any shape that
+  `pipeline_utils.has_tiled_cartesian_eligible` rejects) is NOT
+  wrapped. Mirrors `_is_eligible_cart` predicate; protects against
+  emitting `TiledCartesian` around a Cartesian whose body the
+  tiled smem dispatch can't accommodate.
+  '''
+  ep = _ineligible_cart_ep(pragmas=(TiledCartesian(),))
+  out = MirPragmaPass().apply(ep, mir_compiler)
+  assert out.pragmas == ()
+  # The 3-source Cartesian passes through unchanged.
+  assert all(not isinstance(child, m.TiledCartesian) for child in out.pipeline)
+  assert isinstance(out.pipeline[1], m.CartesianJoin)
+  assert len(out.pipeline[1].sources) == 3
+
+
+def test_pragma_pass_via_apply_all_mir_passes_is_noop_for_empty_pragmas(
+  mir_compiler,
+):
+  '''Sanity: the integration of `MirPragmaPass` into
+  `apply_all_mir_passes` does not change MIR shape for EPs that
+  carry no typed pragmas — the dominant case today.'''
+  ep = _eligible_cart_ep(tiled_cartesian=False, pragmas=())
+  steps_in = [(ep, False)]
+  steps_out = apply_all_mir_passes(steps_in)
+  assert len(steps_out) == 1
+  ep_out, is_rec = steps_out[0]
+  assert isinstance(ep_out, m.ExecutePipeline)
+  assert is_rec is False
+  assert ep_out.pragmas == ()
+  # Pipeline contents structurally identical (no wrap insertion).
+  assert [type(o).__name__ for o in ep_out.pipeline] == [
+    'Scan',
+    'CartesianJoin',
+    'InsertInto',
+  ]
+
+
+# -----------------------------------------------------------------------------
+# 3. Lowering — TiledCartesian -> IIR matches legacy tiled branch byte-for-byte
+# -----------------------------------------------------------------------------
+
+
+def _render_body(ep: m.ExecutePipeline, *, tiled_cartesian: bool) -> str:
+  '''Render an EP through the production `compile_kernel_body` surface,
+  which exercises the same `lower_scan_pipeline` -> dialect path the
+  byte-equivalence harnesses guard. `tiled_cartesian` controls the
+  legacy ctx flag (the runner-side signal); set independently of
+  whether the EP carries the typed pragma.'''
+  from srdatalog.compile import compile_kernel_body
+
+  return compile_kernel_body(
+    ep,
+    is_counting=False,
+    slot_mode='handle_idx',
+    tiled_cartesian=tiled_cartesian,
+  )
+
+
+def test_tiled_cartesian_lowering_matches_legacy_emission(mir_compiler):
+  '''Byte-equivalence by construction: the new wrap-op dispatch in
+  `_lower_inner_chain` delegates to `_lower_nested_cart_tiled` with
+  `ctx.tiled_cartesian=True`, so its emission is identical to the
+  legacy `if _tiled_cart_eligible(...):` branch.
+
+  We verify this end-to-end by:
+    1. Building an EP with the legacy bool (no pragma); rendering
+       via `compile_kernel_body(tiled_cartesian=True)` — the
+       "ground truth" the byte-equivalence harness anchors to.
+    2. Building the same EP with the typed pragma (bool=False);
+       running `MirPragmaPass` to insert the wrap op, then
+       rendering via `compile_kernel_body(tiled_cartesian=False)` —
+       the legacy ctx flag is off, so emission comes purely from
+       the wrap-op dispatch.
+
+  The rendered CUDA must match — same tile_total var, tc_valid_<n>
+  ballot, SaTiledCartesian2D structure.
+  '''
+  # 1. Ground truth: legacy ctx-driven path on a pragma-free EP.
+  legacy_ep = _eligible_cart_ep(tiled_cartesian=False, pragmas=())
+  legacy_out = _render_body(legacy_ep, tiled_cartesian=True)
+  assert 'tile_total' in legacy_out
+  assert 'tc_valid_' in legacy_out
+  assert 'sa_tiled_cartesian_2d' not in legacy_out  # rendered as inline C++
+
+  # 2. Typed-pragma path: pragma instance materializes the wrap op,
+  # then `_lower_inner_chain` dispatches the wrap to the same
+  # `_lower_nested_cart_tiled` helper.
+  typed_ep = _eligible_cart_ep(tiled_cartesian=False, pragmas=(TiledCartesian(),))
+  materialized = MirPragmaPass().apply(typed_ep, mir_compiler)
+  assert isinstance(materialized.pipeline[1], m.TiledCartesian)
+  typed_out = _render_body(materialized, tiled_cartesian=False)
+
+  assert typed_out == legacy_out
+
+
+def test_tiled_cartesian_lowering_restores_prior_flag(mir_compiler):
+  '''The chain-aware lowering's `ctx.tiled_cartesian` toggle is
+  save/restore — after the wrap emits, the ctx is left exactly as
+  it was. Guards against reentrancy leaks if sibling dispatches
+  depend on the flag.'''
+  from srdatalog.ir.dialects.relation.sorted_array.lowerings import LoweringCtx
+
+  ep = _eligible_cart_ep(tiled_cartesian=False, pragmas=(TiledCartesian(),))
+  materialized = MirPragmaPass().apply(ep, mir_compiler)
+  wrap = materialized.pipeline[1]
+  assert isinstance(wrap, m.TiledCartesian)
+  insert = materialized.pipeline[2]
+  assert isinstance(insert, m.InsertInto)
+
+  for original in (False, True):
+    ctx = LoweringCtx(
+      view_var_names={
+        '0': 'view_Src_0_FULL',
+        '1': 'view_R_0_FULL',
+        '2': 'view_S_0_FULL',
+      },
+      is_counting=False,
+      output_var='output',
+      tiled_cartesian=original,
+    )
+    lower_tiled_cartesian_in_chain(wrap, [insert], ctx)
+    assert ctx.tiled_cartesian is original
+
+
+# -----------------------------------------------------------------------------
+# 4. Registration completeness (R5)
+# -----------------------------------------------------------------------------
+
+
+def test_tiled_cartesian_handler_is_registered():
+  '''Importing the pragma module registers a `@pragma_handler` whose
+  `pragma_cls` is `TiledCartesian` and whose `on` is
+  `mir.ExecutePipeline`. R5
+  (`test_pragma_handler_registry_completeness`) gates this once per
+  Pragma subclass; here we pin it for the C5 surface explicitly.
+  '''
+  from srdatalog.ir.core.pragma import get_pragma_registrations
+
+  regs = [r for r in get_pragma_registrations() if r.pragma_cls is TiledCartesian]
+  assert len(regs) >= 1
+  reg = regs[0]
+  assert reg.on is m.ExecutePipeline
+  assert reg.fn is materialize_tiled_cartesian
+
+
+def test_tiled_cartesian_lowering_is_registered_on_sorted_array_dialect():
+  '''The `mir.TiledCartesian` `@lowering` is registered on the
+  `relation.sorted_array` dialect. Pins the dialect ownership choice
+  per `docs/phase_c_pragma_materialization.md` §4.3
+  (`tiled_cartesian` stays in sorted_array — no new sub-dialect
+  needed because the emission uses the existing
+  `SaTiledCartesian2D` IIR op).'''
+  matched = [low for low in SA_DIALECT.lowerings if low.matches is m.TiledCartesian]
+  assert len(matched) == 1
+  assert matched[0].consumes == ('mir',)
+  assert 'iir.cf' in matched[0].produces
+
+
+def test_tiled_cartesian_framework_entry_asserts_on_direct_call():
+  '''`lower_tiled_cartesian` is a framework-registry stub: real
+  dispatch goes through `_lower_inner_chain` ->
+  `lower_tiled_cartesian_in_chain` so the trailing chain is in
+  scope. Direct invocation of the stub raises a structural
+  assertion to surface refactors that bypass the chain dispatch.
+  '''
+  wrap = m.TiledCartesian(
+    inner=m.CartesianJoin(
+      vars=['y', 'z'],
+      sources=[
+        m.ColumnSource(rel_name='R', version=Version.FULL, index=[0]),
+        m.ColumnSource(rel_name='S', version=Version.FULL, index=[0]),
+      ],
+      var_from_source=[['y'], ['z']],
+    )
+  )
+  with pytest.raises(AssertionError, match=r'dispatch goes through'):
+    lower_tiled_cartesian(wrap, None)
+
+
+# -----------------------------------------------------------------------------
+# 5. apply_mir_pragma_pass surface
+# -----------------------------------------------------------------------------
+
+
+def test_apply_mir_pragma_pass_is_idempotent_for_empty_pragmas():
+  '''After running `apply_mir_pragma_pass`, every EP has `pragmas ==
+  ()`. Re-running it is a structural no-op. Same discipline gate
+  (R5b / `test_pragmas_empty_after_materialization`) the C2 test
+  exercises, applied through the new chain entry for C5.
+  '''
+  ep = _eligible_cart_ep(tiled_cartesian=False, pragmas=())
+  steps = [(ep, False)]
+  once = apply_mir_pragma_pass(steps)
+  twice = apply_mir_pragma_pass(once)
+  ep1 = once[0][0]
+  ep2 = twice[0][0]
+  assert isinstance(ep1, m.ExecutePipeline)
+  assert isinstance(ep2, m.ExecutePipeline)
+  assert ep1.pragmas == ()
+  assert ep2.pragmas == ()
+
+
+def test_apply_mir_pragma_pass_materializes_wrap(mir_compiler):
+  '''Sanity: piping through `apply_mir_pragma_pass` produces the
+  same wrap-op insertion the per-EP `MirPragmaPass.apply` does.
+  '''
+  ep = _eligible_cart_ep(tiled_cartesian=False, pragmas=(TiledCartesian(),))
+  steps = [(ep, False)]
+  out = apply_mir_pragma_pass(steps)
+  ep_out = out[0][0]
+  assert isinstance(ep_out, m.ExecutePipeline)
+  assert ep_out.pragmas == ()
+  assert isinstance(ep_out.pipeline[1], m.TiledCartesian)


### PR DESCRIPTION
## Summary
- `TiledCartesian` Pragma (lives in sorted_array per spec § 4.3 — not a new sub-dialect, tightly coupled to sorted-array index access)
- `TiledCartesian(inner: CartesianJoin)` MIR wrap op
- Dual-write + short-circuit pattern from C2

## Notes for reviewer
- **New field on `ExecutePipeline`**: `tiled_cartesian: bool = False`. Didn't exist before — needed for dual-write parity with the other C-PRs (DSL today doesn't set `tiled_cartesian` since no production user-facing knob exists; this PR adds the typed pragma path + the bool shadow for symmetry).
- **No `_BUILTIN_BOOL_SHADOW_PRAGMAS` entry**: `PlanEntry` has no `tiled_cartesian` field today either, so `with_pragma(TiledCartesian())` adds only the typed pragma. Legitimate per spec (the bool is a parser-detected internal optimization marker, not a user-facing DSL knob).
- **Wider blast radius than expected** (8 files vs C2/C3/C4's smaller scope): the `TiledCartesian` wrap op needs unwrapping by the existing handle-counting + view-spec emit machinery in `codegen/cuda/envelope.py` and `pipeline_utils.py`, plus `hir/lower.py`'s `_extract_pipeline_sources` recursion. These are all read-side adapters that recognize the wrap and forward to the existing logic.
- Dispatch lives in `_lower_inner_chain` (not the standalone `@lowering`) because `_lower_nested_cart_tiled` needs the trailing chain.

## Test plan
- [x] 15 new tests (DSL surface, MIR materialization for typed-only + dual-write + ineligible Cart, lowering byte-equivalence, registration completeness)
- [x] Full suite: 1318 passed, 5 skipped (no regressions)
- [x] Byte-equivalence (`test_runner_byte_equivalence` + `test_cuda_complete_runner` + `test_byte_equivalence_jit`): 532 passed, 2 skipped
- [x] mypy: 0 new errors
- [x] ruff check + format (CI v0.9.10): clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)