### PR TITLE
E: ship sorted_array as first entry-point plugin

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -52,6 +52,18 @@ docs = [
 [project.scripts]
 srdatalog = "srdatalog.cli:main"
 
+# ---------------------------------------------------------------------------
+# Plugin entry points (srdatalog.plugins)
+#
+# Phase E validation: built-in dialects ship as discoverable plugins via
+# the same `srdatalog.plugins` entry-point group used by external
+# packages. `Compiler.with_default_plugins()` walks this group at
+# bootstrap. Spec: docs/phase_e_plugin_extensibility.md §2, §5.
+# ---------------------------------------------------------------------------
+
+[project.entry-points."srdatalog.plugins"]
+sorted_array = "srdatalog.ir.dialects.relation.sorted_array:register"
+
 [project.urls]
 Homepage = "https://github.com/anthropics/srdatalog-python"
 Issues = "https://github.com/anthropics/srdatalog-python/issues"

--- a/src/srdatalog/ir/dialects/relation/sorted_array/__init__.py
+++ b/src/srdatalog/ir/dialects/relation/sorted_array/__init__.py
@@ -16,6 +16,8 @@ shapes the target lowering produces.
 
 from __future__ import annotations
 
+from typing import Any
+
 from srdatalog.ir.core import Dialect
 from srdatalog.ir.dialects.relation.sorted_array.ops import (
   SaChildRange,
@@ -68,6 +70,7 @@ __all__ = [
   'SaRoot',
   'SaValid',
   'SaView',
+  'register',
 ]
 
 
@@ -170,3 +173,60 @@ def _register_passes() -> None:
 
 
 _register_passes()
+
+
+# ---------------------------------------------------------------------------
+# Phase E plugin entry point
+# ---------------------------------------------------------------------------
+#
+# `register(compiler)` is the callable invoked by F4's plugin discovery
+# (`Compiler.with_default_plugins()`) AND by explicit user-driven
+# `compiler.register_plugin(...)` calls. Wired in `pyproject.toml` under
+# `[project.entry-points."srdatalog.plugins"]`.
+#
+# Coexistence with legacy direct-import: the module-level
+# `_register_passes()` call above still runs on first import, so the
+# dialect's `lowerings` / `verifier` are populated regardless of whether
+# anyone goes through `register(compiler)`. Python's module cache makes
+# `_register_passes()` itself naturally idempotent (decorators only
+# fire on first import). What `register(compiler)` adds on top is the
+# per-Compiler `register_dialect(DIALECT)` step that F4's plugin
+# loader needs to attribute ownership of the dialect to this plugin
+# and populate the running Compiler's registry.
+#
+# Re-running `register(compiler)` on the same Compiler is safe: F4's
+# `register_plugin` (see `core/dialect.py`) short-circuits on
+# already-loaded plugin names.
+
+
+def register(compiler: Any) -> None:
+  '''Plugin entry point — register the `relation.sorted_array` dialect
+  on the given Compiler.
+
+  Lowerings / pragmas were wired by `_register_passes()` at module-
+  import time (a one-shot side effect; Python's module cache makes it
+  naturally idempotent). This callable only performs the per-Compiler
+  step: `compiler.register_dialect(DIALECT)`.
+
+  Idempotent: F4's `Compiler.register_plugin` short-circuits
+  re-registration of the same plugin name.
+  '''
+  compiler.register_dialect(DIALECT)
+
+
+# Plugin metadata read by F4's topo-sort + conflict detection
+# (see `core/plugin.py` — `_plugin_attr` reads these).
+#
+# `plugin_name` — what F4 records as the loaded-plugin identifier.
+#   Matches the entry-point name `sorted_array` declared in
+#   `pyproject.toml`.
+# `provides` — the dialect names this plugin contributes. Other
+#   plugins may `requires=('relation.sorted_array',)` to load after.
+# `requires` — dialects that must be loaded first. Empty for now: the
+#   `iir.cf` lowerings emitted by `_register_passes` are looked up by
+#   op-type during MIR→IIR; nothing here actually mutates `iir.cf`'s
+#   registry, so there is no bootstrap-time ordering requirement.
+#   (When `iir.cf` itself ships as a discoverable plugin, add it here.)
+register.plugin_name = 'sorted_array'  # type: ignore[attr-defined]
+register.provides = ('relation.sorted_array',)  # type: ignore[attr-defined]
+register.requires = ()  # type: ignore[attr-defined]

--- a/tests/test_sorted_array_as_plugin.py
+++ b/tests/test_sorted_array_as_plugin.py
@@ -1,0 +1,229 @@
+'''Phase E discipline test — `sorted_array` is shipped as a
+discoverable entry-point plugin AND remains usable via the legacy
+direct-import pathway, byte-for-byte equivalent.
+
+Spec: `docs/phase_e_plugin_extensibility.md` §2 (entry-point discovery)
+and §5 (built-ins ARE plugins). Companion to `tests/test_core_plugin.py`,
+which exercises the F4 framework with synthetic plugins; this file
+exercises the framework against the first real built-in dialect to ship
+as a plugin.
+
+Three things asserted:
+
+  1. `Compiler.with_default_plugins()` discovers `sorted_array`
+     through the `srdatalog.plugins` entry-point group and registers
+     its dialect on the resulting Compiler.
+  2. Calling `compiler.register_plugin(register)` twice is a no-op the
+     second time (F4 idempotency, exercised against the real
+     register callable).
+  3. End-to-end `compile_kernel_body(ep)` returns byte-identical text
+     whether or not the caller first went through
+     `with_default_plugins()` — the legacy direct-import pathway and
+     the plugin-discovered pathway produce the same artifact.
+
+The byte-equivalence anchor (#3) is the load-bearing assertion: if a
+future change inadvertently makes the plugin path diverge from the
+legacy path, this test catches it before it reaches the full
+`test_runner_byte_equivalence.py` suite.
+'''
+
+from __future__ import annotations
+
+import srdatalog.ir.mir.types as mir
+from srdatalog.dsl import Program, Relation, Var
+from srdatalog.ir.codegen.cuda.api import compile_kernel_body
+from srdatalog.ir.core import Compiler
+from srdatalog.ir.core.plugin import ENTRY_POINT_GROUP
+from srdatalog.ir.default_pipelines import (
+  DEFAULT_PROGRAM_PIPELINE,
+  InitialProg,
+)
+from srdatalog.ir.dialects.relation.sorted_array import (
+  DIALECT as SORTED_ARRAY_DIALECT,
+)
+from srdatalog.ir.dialects.relation.sorted_array import (
+  register as register_sorted_array,
+)
+
+# -----------------------------------------------------------------------------
+# Fixtures
+# -----------------------------------------------------------------------------
+
+
+def _tc_program() -> Program:
+  '''Tiny TC-style program — same shape as
+  `tests/test_default_pipelines_shims.py::_tc_program`. Two rules give
+  the MIR plan an actual `ExecutePipeline` to feed
+  `compile_kernel_body`.
+  '''
+  X, Y, Z = Var('x'), Var('y'), Var('z')
+  arc = Relation('ArcInput', 2)
+  edge = Relation('Edge', 2)
+  path = Relation('Path', 2)
+  return Program(
+    rules=[
+      (edge(X, Y) <= arc(X, Y)).named('EdgeLoad'),
+      (path(X, Y) <= edge(X, Y)).named('TCBase'),
+      (path(X, Z) <= path(X, Y) & edge(Y, Z)).named('TCRec'),
+    ],
+  )
+
+
+def _find_execute_pipelines(node: object) -> list[mir.ExecutePipeline]:
+  '''Walk a MIR plan and collect every ExecutePipeline. Mirrors
+  `_find_execute_pipelines` in `test_default_pipelines_shims.py`.
+  '''
+  out: list[mir.ExecutePipeline] = []
+  if isinstance(node, mir.ExecutePipeline):
+    out.append(node)
+  elif isinstance(node, mir.FixpointPlan):
+    for inst in node.instructions:
+      out.extend(_find_execute_pipelines(inst))
+  elif isinstance(node, mir.ParallelGroup):
+    for op in node.ops:
+      out.extend(_find_execute_pipelines(op))
+  return out
+
+
+def _first_ep(mir_prog: mir.Program) -> mir.ExecutePipeline:
+  for step, _is_rec in mir_prog.steps:
+    eps = _find_execute_pipelines(step)
+    if eps:
+      return eps[0]
+  raise AssertionError('no ExecutePipeline in mir_prog')
+
+
+def _build_first_ep_via(compiler: Compiler) -> mir.ExecutePipeline:
+  '''Drive the program-level pipeline on `compiler` to get a real
+  `ExecutePipeline` we can hand to `compile_kernel_body`.'''
+  state = compiler.run(InitialProg(program=_tc_program()), pipeline=DEFAULT_PROGRAM_PIPELINE)
+  assert state.mir_program is not None
+  return _first_ep(state.mir_program)
+
+
+# -----------------------------------------------------------------------------
+# 1. Plugin discovery — `with_default_plugins()` picks up sorted_array
+# -----------------------------------------------------------------------------
+
+
+def test_sorted_array_is_discovered_by_with_default_plugins() -> None:
+  '''`Compiler.with_default_plugins()` walks the
+  `srdatalog.plugins` entry-point group; the `sorted_array` entry
+  point shipped in this repo's `pyproject.toml` is loaded and
+  registers the `relation.sorted_array` dialect.
+
+  If this test fails with "no plugins loaded", the most likely cause
+  is that the editable install's `.egg-info` is stale — run
+  `pip install -e . --no-deps --force-reinstall` (or `uv sync`) to
+  refresh the entry-point metadata.
+  '''
+  compiler = Compiler.with_default_plugins()
+
+  # The plugin name comes from the entry-point name in pyproject.toml
+  # (`[project.entry-points."srdatalog.plugins"] sorted_array = "..."`)
+  # — F4's `_resolve_plugin` records that name in `_plugins_loaded`.
+  assert 'sorted_array' in compiler._plugins_loaded, (
+    f'expected sorted_array in loaded plugins; got {list(compiler._plugins_loaded)!r}. '
+    f'If empty, the editable install metadata is stale: '
+    f'`pip install -e . --no-deps --force-reinstall`.'
+  )
+
+  # The dialect itself is registered on the Compiler.
+  dialect = compiler.get_dialect('relation.sorted_array')
+  assert dialect is SORTED_ARRAY_DIALECT, (
+    'with_default_plugins registered a different Dialect instance than '
+    'the module-level singleton — the plugin path is not reusing DIALECT'
+  )
+
+  # The dialect's plugin attribution is the entry-point name.
+  assert compiler._dialects_by_plugin['relation.sorted_array'] == 'sorted_array'
+
+
+def test_entry_point_group_name_matches_f4() -> None:
+  '''The entry-point group name in `pyproject.toml` is exactly the
+  one F4's plugin discovery walks. Locked at `srdatalog.plugins` per
+  the spec (`docs/phase_e_plugin_extensibility.md` §2).
+  '''
+  assert ENTRY_POINT_GROUP == 'srdatalog.plugins'
+
+
+# -----------------------------------------------------------------------------
+# 2. Idempotency — re-registering the real callable is a no-op
+# -----------------------------------------------------------------------------
+
+
+def test_register_sorted_array_plugin_idempotent() -> None:
+  '''Calling `register_plugin(register_sorted_array)` twice on the
+  same Compiler does not double-register the dialect and does not
+  raise. F4's `register_plugin` short-circuits on the plugin name
+  (`register.plugin_name = 'sorted_array'`) — this test verifies the
+  short-circuit fires for the real register callable, not just the
+  synthetic ones in `test_core_plugin.py`.
+  '''
+  compiler = Compiler()
+  compiler.register_plugin(register_sorted_array)
+  first_loaded = dict(compiler._plugins_loaded)
+  first_dialect_count = len(compiler.dialects)
+
+  # Second call must be a no-op (not raise PluginConflictError, not
+  # double-register the dialect, not append a second lowering, etc.).
+  compiler.register_plugin(register_sorted_array)
+
+  assert compiler._plugins_loaded == first_loaded
+  assert len(compiler.dialects) == first_dialect_count
+  assert compiler.get_dialect('relation.sorted_array') is SORTED_ARRAY_DIALECT
+
+
+def test_register_sorted_array_metadata_matches_entry_point() -> None:
+  '''The `register` callable's `plugin_name` / `provides` / `requires`
+  attributes match the entry-point declaration in `pyproject.toml`.
+  These attributes are what F4 topo-sorts on (see
+  `core/plugin.py::_topo_sort_plugins`) — getting them wrong silently
+  breaks dependency ordering, so we pin them here.
+  '''
+  assert register_sorted_array.plugin_name == 'sorted_array'  # type: ignore[attr-defined]
+  assert register_sorted_array.provides == ('relation.sorted_array',)  # type: ignore[attr-defined]
+  assert register_sorted_array.requires == ()  # type: ignore[attr-defined]
+
+
+# -----------------------------------------------------------------------------
+# 3. Byte-equivalence — plugin path and legacy path produce same output
+# -----------------------------------------------------------------------------
+
+
+def test_compile_kernel_body_byte_equivalent_across_plugin_paths() -> None:
+  '''The full `compile_kernel_body(ep)` text is byte-identical whether
+  the caller obtains its `ep` via a plugin-discovered Compiler
+  (`with_default_plugins`) or via a Compiler that explicitly invokes
+  the register callable. This is the load-bearing assertion: it pins
+  that wrapping the dialect as a plugin did not perturb the codegen
+  output.
+
+  We deliberately check both phases (count + materialize) since the
+  kernel-body pipeline branches on `is_counting` and a subtle plugin
+  ordering bug could surface in only one phase.
+  '''
+  # Path A: full plugin discovery via the entry-point group.
+  compiler_via_plugin = Compiler.with_default_plugins()
+  ep_via_plugin = _build_first_ep_via(compiler_via_plugin)
+
+  # Path B: explicit plugin registration (skips entry-point walk).
+  compiler_explicit = Compiler()
+  compiler_explicit.register_plugin(register_sorted_array)
+  ep_explicit = _build_first_ep_via(compiler_explicit)
+
+  # Materialize phase.
+  text_a = compile_kernel_body(ep_via_plugin, is_counting=False)
+  text_b = compile_kernel_body(ep_explicit, is_counting=False)
+  assert text_a == text_b, (
+    'compile_kernel_body diverged between plugin-discovered and '
+    'explicit-register Compilers (materialize phase)'
+  )
+
+  # Count phase — mirrors the runner emit's per-kernel knobs.
+  text_a_ct = compile_kernel_body(ep_via_plugin, is_counting=True, output_var_name='output_ctx')
+  text_b_ct = compile_kernel_body(ep_explicit, is_counting=True, output_var_name='output_ctx')
+  assert text_a_ct == text_b_ct, (
+    'compile_kernel_body diverged between plugin-discovered and '
+    'explicit-register Compilers (count phase)'
+  )


### PR DESCRIPTION
## Summary
- Adds `register(compiler)` to `sorted_array/__init__.py` with `plugin_name` / `provides` / `requires` metadata for F4's topo-sort
- Wires `pyproject.toml` `[project.entry-points."srdatalog.plugins"]` entry: `sorted_array = "srdatalog.ir.dialects.relation.sorted_array:register"`
- First real-dialect validation of the F4 plugin pathway (until now F4's tests were synthetic)

## Notes
- **Legacy + plugin coexistence**: kept the module-level `_register_passes()` call unconditional. Python's module cache makes it idempotent (decorators only fire on first import); F4's `register_plugin` is idempotent on plugin name. Both paths work. Spec's "simpler approach" branch.
- **`requires=()`** rather than `('iir.cf',)` — the latter would be cosmetic today since `iir.cf` isn't itself a plugin yet (no entry point). TODO marker for when `iir.cf` ships as plugin in a follow-up.
- **Test 3 (byte-eq)** compares two `Compiler` pathways into the same `ep` (entry-point discovery vs explicit `register_plugin(register)`) — `compile_kernel_body` constructs its own internal `Compiler()` so "legacy vs plugin" mode converges there. The broader 553-golden byte-equivalence harness covers the legacy-text-matches-goldens angle.

## Test plan
- [x] 24 new tests pass in `test_sorted_array_as_plugin.py` + `test_core_plugin.py`
- [x] Full suite: 1403 passed, 5 skipped (no regressions)
- [x] Byte-equivalence: 532 passed, 2 skipped (unchanged)
- [x] mypy: 0 new errors
- [x] ruff check + format (CI v0.9.10): clean
- [x] Entry-point smoke check: `entry_points(group='srdatalog.plugins')` returns the new entry

🤖 Generated with [Claude Code](https://claude.com/claude-code)