### PR TITLE
B-Scan: @lowering migration (Wave 2A order 3)

### DIFF
--- a/src/srdatalog/ir/dialects/relation/sorted_array/__init__.py
+++ b/src/srdatalog/ir/dialects/relation/sorted_array/__init__.py
@@ -60,6 +60,7 @@ USE_DECLARATIVE: frozenset[type] = frozenset(
     _mir_for_use_declarative.Filter,
     _mir_for_use_declarative.ConstantBind,
     _mir_for_use_declarative.InsertInto,
+    _mir_for_use_declarative.Scan,
   }
 )
 
@@ -253,6 +254,29 @@ def _register_passes() -> None:
   )
   def _lower_mir_insert_into_registered(op: Any, ctx: Any) -> Any:
     return lower_mir_insert_into(op, ctx)
+
+  # Wave 2A / B-Scan (per docs/phase_b_lowering_dispatcher.md §4 row
+  # B-Scan, difficulty `medium`): unlike Filter / ConstantBind which
+  # live mid-chain in `_lower_inner_chain`, `mir.Scan` is a ROOT-
+  # position op dispatched from `lower_scan_pipeline`. The split-with-
+  # stub pattern is the same — the chain-aware variant
+  # (`lower_mir_scan_in_chain`) needs the trailing pipeline `rest`
+  # from `lower_scan_pipeline`, so the `@lowering`-registered stub
+  # asserts on direct invocation. The `USE_DECLARATIVE` ratchet
+  # routes root dispatch through the new path while keeping this
+  # registration as the dialect-ownership contract.
+  from srdatalog.ir.dialects.relation.sorted_array.lowerings.lower_mir_scan import (
+    lower_mir_scan,
+  )
+
+  @lowering(
+    DIALECT,
+    mir.Scan,
+    consumes=('mir',),
+    produces=('iir.cf',),
+  )
+  def _lower_mir_scan_registered(op: Any, ctx: Any) -> Any:
+    return lower_mir_scan(op, ctx)
 
   # Verifier scaffolding — per-op invariants (D9: SaHint inside
   # IterURV scope, etc.) land incrementally as we encode them.

--- a/src/srdatalog/ir/dialects/relation/sorted_array/lowerings/__init__.py
+++ b/src/srdatalog/ir/dialects/relation/sorted_array/lowerings/__init__.py
@@ -322,6 +322,32 @@ def lower_scan_pipeline(
   head = ops[0]
   rest = ops[1:]
 
+  # Phase B / Wave 2A (per docs/phase_b_lowering_dispatcher.md §5):
+  # ROOT-position MIR op types registered in `USE_DECLARATIVE` route
+  # through their per-op `@lowering` rules instead of the legacy
+  # `if isinstance` branches below. Mirrors the `_lower_inner_chain`
+  # dispatch block for middle-of-chain ops (Filter / ConstantBind).
+  # Scan is the first root op migrated (B-Scan); future root-op
+  # migrations (B-CJ-single, B-CJ-multi, B-Cart) extend this block.
+  # Layer 3 cleanup deletes both branches AND `USE_DECLARATIVE` once
+  # every MIR op is migrated. Imports are function-local to keep the
+  # module import graph linear (the sibling per-op modules import
+  # back from this file).
+  from srdatalog.ir.dialects.relation.sorted_array import USE_DECLARATIVE
+
+  if type(head) in USE_DECLARATIVE:
+    if isinstance(head, mir.Scan):
+      from srdatalog.ir.dialects.relation.sorted_array.lowerings.lower_mir_scan import (
+        lower_mir_scan_in_chain,
+      )
+
+      return lower_mir_scan_in_chain(head, rest, ctx)
+    raise AssertionError(
+      f'lower_scan_pipeline: USE_DECLARATIVE contains {type(head).__name__!r} '
+      f'but no root-dispatch wiring exists for it. Add the '
+      f'`lower_mir_<op>_in_chain` import + call above.'
+    )
+
   if isinstance(head, mir.Scan):
     return _lower_root_scan(head, rest, ctx)
   if isinstance(head, mir.ColumnJoin):

--- a/src/srdatalog/ir/dialects/relation/sorted_array/lowerings/lower_mir_scan.py
+++ b/src/srdatalog/ir/dialects/relation/sorted_array/lowerings/lower_mir_scan.py
@@ -1,0 +1,121 @@
+'''Lowering: `mir.Scan` -> iir.cf — third Wave 2A per-op migration.
+
+Per `docs/phase_b_lowering_dispatcher.md` §4 (per-MIR-op work-unit
+table, row B-Scan, difficulty `medium`) and §4.1 (per-PR template):
+each MIR op type gets one `@lowering(target=iir.cf, source=mir.X)`
+rule in its own file under
+`dialects/relation/sorted_array/lowerings/`. The registry
+registration lives alongside the dialect's other lowerings in
+`__init__.py:_register_passes`.
+
+Byte-equivalence contract (§4.2): the migrated op produces the same
+IIR tree as the legacy `if isinstance(head, mir.Scan):` branch
+inside `lower_scan_pipeline` on every fixture that exercises it.
+
+Root-position split (Scan is the FIRST head op of the pipeline, not
+a middle chain op like B-Filter / B-ConstantBind). The legacy
+dispatch lives in `lower_scan_pipeline` (not `_lower_inner_chain`):
+
+    if isinstance(head, mir.Scan):
+      return _lower_root_scan(head, rest, ctx)
+
+`mir.Scan` never appears mid-chain — neither `_supported_pipeline`
+nor `_lower_inner_chain` accepts a Scan in any non-head position.
+We therefore expose two entry points whose names mirror the
+B-Filter / B-ConstantBind split but reflect the root nature of the
+op:
+
+  - `lower_mir_scan_in_chain(op, rest, ctx)`: the real work,
+    called from `lower_scan_pipeline` when
+    `type(head) in USE_DECLARATIVE`. `rest` is the trailing
+    pipeline (middle ops + InsertIntos), same shape that the
+    legacy `_lower_root_scan` received.
+  - `lower_mir_scan(op, ctx)`: the `@lowering`-registered stub.
+    Asserts on direct invocation — the framework dispatch path is
+    reserved for a future MIR-IIR walker that no longer routes
+    through `lower_scan_pipeline` and can plumb `rest` through.
+
+We deliberately kept the `_in_chain` suffix (rather than coining a
+new `_root` / `_pipeline` name) so all Wave 2A per-op files share
+one naming convention. The shape of the trailing argument is
+op-dependent (`tail` for middle ops, `rest` for root ops); the
+suffix only signals "there is one".
+
+The split lets the registry pin dialect ownership (`Scan` belongs
+to `relation.sorted_array`) without forcing the pipeline dispatcher
+through the registry today.
+'''
+
+from __future__ import annotations
+
+from typing import Any
+
+import srdatalog.ir.mir.types as mir
+from srdatalog.ir.core import Op
+
+
+def lower_mir_scan_in_chain(
+  op: mir.Scan,
+  rest: list[Any],
+  ctx: Any,
+) -> Op:
+  '''Emit the IIR for a root `mir.Scan` with trailing pipeline `rest`.
+
+  Mirrors the legacy `if isinstance(head, mir.Scan): return
+  _lower_root_scan(head, rest, ctx)` dispatch byte-for-byte by
+  delegating to the legacy helper. The goal of this Wave 2A PR is
+  byte-equivalence with the legacy emitter, not a from-scratch
+  rewrite of the (M1+M2) scan-root scaffolding — the helper stays
+  LIVE until Layer 3 cleanup deletes both the legacy branch AND
+  the `USE_DECLARATIVE` ratchet.
+
+  `rest` is the trailing pipeline AFTER the Scan: middle ops
+  (Filter / ConstantBind / Negation / CartesianJoin /
+  TiledCartesian) followed by one-or-more trailing InsertIntos.
+  The legacy `_lower_root_scan` walks it via `_lower_inner_chain`
+  for the body and emits the root-scan scaffold (handle bind,
+  validity check, degree bind, ParallelFor grid-stride loop).
+  '''
+  # Deferred import: the pipeline dispatcher + `_lower_root_scan`
+  # live in the package `__init__.py` (the legacy monolith), which
+  # imports this module via `_register_passes`. Import-at-call-time
+  # keeps the package import graph linear (avoids a circular import
+  # between `__init__.py` and this sibling module).
+  from srdatalog.ir.dialects.relation.sorted_array.lowerings import (
+    _lower_root_scan,
+  )
+
+  return _lower_root_scan(op, rest, ctx)
+
+
+def lower_mir_scan(op: mir.Scan, ctx: Any) -> Op:
+  '''Framework-registry stub for `@lowering(target=iir.cf,
+  source=mir.Scan)`. The actual dispatch lives in
+  `lowerings.lower_scan_pipeline` (via the `USE_DECLARATIVE`
+  ratchet), which calls `lower_mir_scan_in_chain` with the
+  trailing pipeline in scope.
+
+  This stub exists so the dialect's `lowerings` list pins the
+  (consumes, produces) contract for `mir.Scan` — the discipline
+  test consults the dialect to verify ownership.
+
+  Calling this stub directly raises a structural assertion — the
+  framework path is reserved for future readers who can plumb in
+  the missing `rest` (e.g. a refactored MIR-IIR walker that no
+  longer routes through `lower_scan_pipeline` and can construct
+  the body chain from the enclosing ExecutePipeline).
+  '''
+  raise AssertionError(
+    'lower_mir_scan: dispatch goes through '
+    '`lowerings.lower_scan_pipeline` -> `lower_mir_scan_in_chain` '
+    'so the trailing pipeline is in scope. Direct invocation '
+    'indicates a refactor that bypassed the pipeline dispatch — '
+    'plumb the `rest` through and call `lower_mir_scan_in_chain` '
+    'instead.'
+  )
+
+
+__all__ = [
+  'lower_mir_scan',
+  'lower_mir_scan_in_chain',
+]

--- a/tests/test_lower_mir_scan_byte_equivalent.py
+++ b/tests/test_lower_mir_scan_byte_equivalent.py
@@ -1,0 +1,438 @@
+'''Byte-equivalence test for Wave 2A B-Scan migration.
+
+Per `docs/phase_b_lowering_dispatcher.md` §4.2 (per-PR acceptance
+gate): each per-MIR-op migration ships a
+`test_lower_mir_<op>_byte_equivalent` test that runs the migrated
+path on every relevant fixture and asserts byte equality with the
+legacy `if isinstance(head, mir.X):` branch.
+
+For Scan the relevant fixtures are:
+  - the M1 plain Scan -> InsertInto pipeline (no middle ops),
+  - the M2 Scan -> Filter -> InsertInto chain,
+  - the M2 Scan -> ConstantBind -> InsertInto chain,
+  - multi-var scans (binding 1, 2, 3 columns) — the per-column Bind
+    statements + GridStrideLoop scaffold,
+  - count phase (`is_counting=True`) where the var-elision shortcut
+    drops unused binds,
+  - debug mode toggling the leading Comment stmts,
+  - chains driving the body through nested middle ops (Filter +
+    ConstantBind composed) — exercises the counter save/restore
+    around `_lower_inner_chain`.
+
+The test compares two compilation paths:
+  - LEGACY: `USE_DECLARATIVE` patched to NOT contain `mir.Scan`,
+    so `lower_scan_pipeline` falls into the imperative
+    `_lower_root_scan(head, rest, ctx)` branch.
+  - NEW: `USE_DECLARATIVE` left alone (Scan IS in the set), so
+    `lower_scan_pipeline` routes through
+    `lower_mir_scan_in_chain`.
+
+Byte-equivalence is asserted on the rendered IIR text (which the
+load-bearing harnesses in `tests/test_runner_byte_equivalence.py`
++ `tests/test_byte_equivalence_jit.py` anchor against the legacy
+CUDA emit). The 532-fixture harness re-running green under the new
+path is the strongest signal; this file adds direct-call coverage
+of the corner cases.
+
+Root-position note (per `docs/phase_b_lowering_dispatcher.md` §4
+guidance — "if a Scan never appears mid-chain (only as root)"):
+the dispatch site is `lower_scan_pipeline` (NOT
+`_lower_inner_chain`). The chain-aware variant
+`lower_mir_scan_in_chain` takes `rest` = the trailing pipeline
+ops (middle + InsertIntos) — same signature shape as
+`_lower_root_scan`. The `_in_chain` suffix is kept for naming
+consistency across all Wave 2A per-op files.
+'''
+
+from __future__ import annotations
+
+from contextlib import contextmanager
+from typing import Any
+
+import pytest
+
+import srdatalog.ir.mir.types as mir
+from srdatalog.ir.codegen.cuda.emit import EmitCtx, emit
+from srdatalog.ir.dialects.iir.cf import Block as IirBlock
+from srdatalog.ir.dialects.relation.sorted_array.lowerings import (
+  LoweringCtx,
+  lower_scan_pipeline,
+)
+from srdatalog.ir.dialects.relation.sorted_array.lowerings.lower_mir_scan import (
+  lower_mir_scan,
+  lower_mir_scan_in_chain,
+)
+from srdatalog.ir.hir.types import Version
+
+# -----------------------------------------------------------------------------
+# Helpers
+# -----------------------------------------------------------------------------
+
+
+def _render(op: Any) -> str:
+  '''Render an IIR op tree through the CUDA emitter — the same
+  surface the byte-equivalence harnesses exercise.'''
+  return emit(op, EmitCtx(indent_level=2))
+
+
+@contextmanager
+def _force_legacy_branch():
+  '''Temporarily strip `mir.Scan` from `USE_DECLARATIVE` so
+  `lower_scan_pipeline` falls into the legacy imperative branch
+  (`_lower_root_scan`).
+
+  Save / restore as a context manager — discipline test
+  `test_use_declarative_is_monotonic` (when it lands) ratchets the
+  set at module import time, but this test mutates the dialect's
+  re-bound name for the duration of one call only.
+  '''
+  import srdatalog.ir.dialects.relation.sorted_array as sa_dialect
+
+  saved = sa_dialect.USE_DECLARATIVE
+  sa_dialect.USE_DECLARATIVE = frozenset(saved - {mir.Scan})
+  try:
+    yield
+  finally:
+    sa_dialect.USE_DECLARATIVE = saved
+
+
+def _scan(
+  vars_: list[str] | None = None,
+  rel_name: str = 'Src',
+  handle_start: int = 0,
+) -> mir.Scan:
+  vars_ = vars_ or ['v0', 'v1']
+  return mir.Scan(
+    vars=vars_,
+    rel_name=rel_name,
+    version=Version.FULL,
+    index=list(range(len(vars_))),
+    handle_start=handle_start,
+  )
+
+
+def _insert_into(
+  arity: int = 2,
+  vars_: list[str] | None = None,
+  rel_name: str = 'Dst',
+) -> mir.InsertInto:
+  vars_ = vars_ or [f'v{i}' for i in range(arity)]
+  return mir.InsertInto(
+    rel_name=rel_name,
+    version=Version.NEW,
+    vars=vars_,
+    index=list(range(len(vars_))),
+  )
+
+
+def _new_ctx(
+  view_var_names: dict[str, str] | None = None,
+  **kwargs: Any,
+) -> LoweringCtx:
+  '''Fresh LoweringCtx — counters reset so both paths bump identically.
+
+  Scan needs `view_var_names` populated for its handle_start; default
+  wires handle 0 to `view_src` to match the simple Scan fixtures
+  below.
+  '''
+  if view_var_names is None:
+    view_var_names = {'0': 'view_src'}
+  return LoweringCtx(view_var_names=view_var_names, output_var='ctx0', **kwargs)
+
+
+# -----------------------------------------------------------------------------
+# 1. M1 plain Scan -> InsertInto
+# -----------------------------------------------------------------------------
+
+
+def test_scan_m1_plain_byte_equivalent():
+  '''Plain M1: Scan(2 vars) directly into InsertInto. Both paths
+  must produce identical rendered text — the GridStrideLoop scaffold
+  + two Bind stmts + the InsertInto write.'''
+  scan = _scan(vars_=['v0', 'v1'])
+  ins = _insert_into(2)
+
+  with _force_legacy_branch():
+    legacy_text = _render(lower_scan_pipeline([scan, ins], _new_ctx()))
+  new_text = _render(lower_scan_pipeline([scan, ins], _new_ctx()))
+
+  assert legacy_text == new_text
+  # Sanity: the rendered text contains the root-scan scaffold
+  # (HandleType bind + degree() + a per-column get_value).
+  assert 'HandleType(' in legacy_text
+  assert '.degree()' in legacy_text
+  assert 'view_src.get_value(' in legacy_text
+
+
+def test_scan_single_var_byte_equivalent():
+  '''Single-var scan: just one Bind in the body. Counter trajectory
+  matches because both paths delegate to the same `_lower_root_scan`.'''
+  scan = _scan(vars_=['x'])
+  ins = _insert_into(vars_=['x'])
+
+  with _force_legacy_branch():
+    legacy_text = _render(lower_scan_pipeline([scan, ins], _new_ctx()))
+  new_text = _render(lower_scan_pipeline([scan, ins], _new_ctx()))
+
+  assert legacy_text == new_text
+
+
+def test_scan_three_var_byte_equivalent():
+  '''Three-var scan: three Bind stmts, exercises the per-column loop
+  in `_lower_root_scan`.'''
+  scan = _scan(vars_=['a', 'b', 'c'])
+  ins = _insert_into(vars_=['a', 'b', 'c'])
+
+  with _force_legacy_branch():
+    legacy_text = _render(lower_scan_pipeline([scan, ins], _new_ctx()))
+  new_text = _render(lower_scan_pipeline([scan, ins], _new_ctx()))
+
+  assert legacy_text == new_text
+
+
+# -----------------------------------------------------------------------------
+# 2. M2 Scan + middle ops
+# -----------------------------------------------------------------------------
+
+
+def test_scan_with_filter_byte_equivalent():
+  '''M2 Scan -> Filter -> InsertInto: the Filter goes through
+  `_lower_inner_chain` (which itself may dispatch through
+  `USE_DECLARATIVE` for Filter). Both paths must agree on the full
+  rendered output.'''
+  scan = _scan(vars_=['v0', 'v1'])
+  filt = mir.Filter(vars=['v0', 'v1'], code='return v0 < v1;')
+  ins = _insert_into(2)
+
+  with _force_legacy_branch():
+    legacy_text = _render(lower_scan_pipeline([scan, filt, ins], _new_ctx()))
+  new_text = _render(lower_scan_pipeline([scan, filt, ins], _new_ctx()))
+
+  assert legacy_text == new_text
+  assert 'if (v0 < v1)' in legacy_text
+
+
+def test_scan_with_constant_bind_byte_equivalent():
+  '''M2 Scan -> ConstantBind -> InsertInto: the ConstantBind goes
+  through `_lower_inner_chain`. Both paths must agree.'''
+  scan = _scan(vars_=['x'])
+  cb = mir.ConstantBind(var_name='k', code='99', deps=[])
+  ins = _insert_into(vars_=['x', 'k'])
+
+  with _force_legacy_branch():
+    legacy_text = _render(lower_scan_pipeline([scan, cb, ins], _new_ctx()))
+  new_text = _render(lower_scan_pipeline([scan, cb, ins], _new_ctx()))
+
+  assert legacy_text == new_text
+  assert 'auto k = 99;' in legacy_text
+
+
+def test_scan_with_filter_and_constant_bind_byte_equivalent():
+  '''M2 Scan -> ConstantBind -> Filter -> InsertInto: exercises the
+  composed middle-chain through `_lower_inner_chain`. Counter
+  trajectory + body shape must match.'''
+  scan = _scan(vars_=['v0', 'v1'])
+  cb = mir.ConstantBind(var_name='lo', code='0', deps=[])
+  filt = mir.Filter(vars=['v0', 'lo'], code='return v0 > lo;')
+  ins = _insert_into(2)
+
+  with _force_legacy_branch():
+    legacy_text = _render(lower_scan_pipeline([scan, cb, filt, ins], _new_ctx()))
+  new_text = _render(lower_scan_pipeline([scan, cb, filt, ins], _new_ctx()))
+
+  assert legacy_text == new_text
+
+
+# -----------------------------------------------------------------------------
+# 3. Count phase + var-elision
+# -----------------------------------------------------------------------------
+
+
+def test_scan_count_phase_byte_equivalent():
+  '''In count phase, vars not referenced by the body are elided from
+  the Bind list (Nim's `varName notin body` substring check). Both
+  paths must implement the same elision.'''
+  scan = _scan(vars_=['v0', 'v1'])
+  # body references only v0 — v1 should be elided in count phase.
+  ins = _insert_into(vars_=['v0'])
+
+  with _force_legacy_branch():
+    legacy_text = _render(lower_scan_pipeline([scan, ins], _new_ctx(is_counting=True)))
+  new_text = _render(lower_scan_pipeline([scan, ins], _new_ctx(is_counting=True)))
+
+  assert legacy_text == new_text
+
+
+# -----------------------------------------------------------------------------
+# 4. Debug-mode Comments
+# -----------------------------------------------------------------------------
+
+
+def test_scan_debug_off_byte_equivalent():
+  '''With `debug=False`, the leading `Root Scan: ...` and `MIR: ...`
+  Comment stmts are dropped. Both paths must agree.'''
+  scan = _scan(vars_=['v0', 'v1'])
+  ins = _insert_into(2)
+
+  with _force_legacy_branch():
+    legacy_text = _render(lower_scan_pipeline([scan, ins], _new_ctx(debug=False)))
+  new_text = _render(lower_scan_pipeline([scan, ins], _new_ctx(debug=False)))
+
+  assert legacy_text == new_text
+  assert 'Root Scan:' not in legacy_text
+
+
+# -----------------------------------------------------------------------------
+# 5. Direct lowering call returns the expected IIR shape
+# -----------------------------------------------------------------------------
+
+
+def test_lower_mir_scan_in_chain_returns_block():
+  '''Pin the IIR tree shape directly (independent of byte text):
+  root-scan emission is wrapped in a `Block` of scaffold stmts +
+  ParallelFor.'''
+  scan = _scan(vars_=['v0', 'v1'])
+  ins = _insert_into(2)
+
+  out = lower_mir_scan_in_chain(scan, [ins], _new_ctx())
+  assert isinstance(out, IirBlock)
+  # The Block contains the scaffold: at minimum the handle Bind, the
+  # IfReturnIfNot validity check, the degree Bind, a BlankLine, and
+  # the ParallelFor. Without debug Comments, that's >= 5 stmts.
+  assert len(out.stmts) >= 5
+
+
+def test_lower_mir_scan_in_chain_delegates_to_legacy():
+  '''The chain-aware variant delegates to `_lower_root_scan`
+  byte-for-byte. Verify by comparing the IIR text produced both
+  ways from a freshly-reset ctx.'''
+  from srdatalog.ir.dialects.relation.sorted_array.lowerings import (
+    _lower_root_scan,
+  )
+
+  scan = _scan(vars_=['v0', 'v1'])
+  ins = _insert_into(2)
+
+  via_chain = _render(lower_mir_scan_in_chain(scan, [ins], _new_ctx()))
+  via_legacy = _render(_lower_root_scan(scan, [ins], _new_ctx()))
+
+  assert via_chain == via_legacy
+
+
+# -----------------------------------------------------------------------------
+# 6. Registry contract — stub asserts on direct call
+# -----------------------------------------------------------------------------
+
+
+def test_lower_mir_scan_registry_stub_asserts():
+  '''The `@lowering(target=iir.cf, source=mir.Scan)` registry entry
+  is a stub that asserts on direct invocation — dispatch is
+  expected to flow through `lower_scan_pipeline` -> the chain-aware
+  variant. Mirrors the B-Filter / B-ConstantBind / C5
+  `lower_tiled_cartesian` split.
+  '''
+  scan = _scan(vars_=['v0'])
+  ctx = _new_ctx()
+  with pytest.raises(AssertionError, match=r'lower_mir_scan_in_chain'):
+    lower_mir_scan(scan, ctx)
+
+
+def test_lower_mir_scan_is_registered_on_sorted_array_dialect():
+  '''The `Scan` `@lowering` is registered on the
+  `relation.sorted_array` dialect. Pins dialect ownership per
+  `docs/phase_b_lowering_dispatcher.md` §4 (one `@lowering` per MIR
+  op, on the dialect that lowers it).
+  '''
+  from srdatalog.ir.dialects.relation.sorted_array import DIALECT as SA_DIALECT
+
+  matched = [low for low in SA_DIALECT.lowerings if low.matches is mir.Scan]
+  assert len(matched) == 1
+  assert matched[0].consumes == ('mir',)
+  assert 'iir.cf' in matched[0].produces
+
+
+# -----------------------------------------------------------------------------
+# 7. Smoke test through the full compile_pipeline surface
+# -----------------------------------------------------------------------------
+
+
+def test_scan_in_full_pipeline_byte_equivalent():
+  '''Smoke test: a Scan + InsertInto pipeline rendered through
+  `compile_pipeline` (the production surface that the byte-
+  equivalence harnesses guard) must produce identical CUDA under
+  both `USE_DECLARATIVE` states.
+
+  This closes the loop between the direct-call tests above and the
+  532-fixture harness — if a divergence ever creeps in, both this
+  test and the harness will catch it.
+  '''
+  from srdatalog.ir.codegen.cuda.api import compile_pipeline
+
+  scan = mir.Scan(
+    vars=['x', 'y'],
+    rel_name='Src',
+    version=Version.FULL,
+    index=[0, 1],
+    handle_start=0,
+  )
+  ins = mir.InsertInto(rel_name='Dst', version=Version.NEW, vars=['x', 'y'], index=[0, 1])
+  ep = mir.ExecutePipeline(
+    pipeline=[scan, ins],
+    source_specs=[scan],
+    dest_specs=[ins],
+    rule_name='ScanRule',
+  )
+
+  with _force_legacy_branch():
+    legacy_out = compile_pipeline(ep)
+  new_out = compile_pipeline(ep)
+
+  assert legacy_out == new_out
+
+
+def test_scan_with_filter_in_full_pipeline_byte_equivalent():
+  '''Smoke test: a Scan + Filter + InsertInto pipeline through the
+  full `compile_pipeline` surface. Exercises both the Scan
+  migration and the Filter migration interacting.
+  '''
+  from srdatalog.ir.codegen.cuda.api import compile_pipeline
+
+  scan = mir.Scan(
+    vars=['x', 'y'],
+    rel_name='Src',
+    version=Version.FULL,
+    index=[0, 1],
+    handle_start=0,
+  )
+  filt = mir.Filter(vars=['x', 'y'], code='return x < y;')
+  ins = mir.InsertInto(rel_name='Dst', version=Version.NEW, vars=['x', 'y'], index=[0, 1])
+  ep = mir.ExecutePipeline(
+    pipeline=[scan, filt, ins],
+    source_specs=[scan],
+    dest_specs=[ins],
+    rule_name='ScanFiltRule',
+  )
+
+  with _force_legacy_branch():
+    legacy_out = compile_pipeline(ep)
+  new_out = compile_pipeline(ep)
+
+  assert legacy_out == new_out
+  assert 'if (x < y)' in new_out
+
+
+# -----------------------------------------------------------------------------
+# 8. USE_DECLARATIVE invariants
+# -----------------------------------------------------------------------------
+
+
+def test_use_declarative_contains_scan():
+  '''Pin the ratchet: after this Wave 2A PR, `mir.Scan` must appear
+  in `USE_DECLARATIVE` alongside `mir.Filter` and `mir.ConstantBind`.
+  Future Wave 2A PRs add their MIR ops; the monotonic discipline
+  test (when it lands) catches accidental removals.'''
+  from srdatalog.ir.dialects.relation.sorted_array import USE_DECLARATIVE
+
+  assert mir.Scan in USE_DECLARATIVE
+  assert mir.Filter in USE_DECLARATIVE
+  assert mir.ConstantBind in USE_DECLARATIVE


### PR DESCRIPTION
## Summary
- Adds `mir.Scan` to the per-MIR-op `@lowering` migration (3rd op in spec § 4 table, "medium" difficulty)
- Extends PR #49's template; coexists with B-Filter + B-ConstantBind

## Notes
- **Root-entry only dispatch**: `mir.Scan` is strictly root-position per `_supported_pipeline` — never appears mid-chain. So:
  - New `USE_DECLARATIVE` dispatch block at the top of `lower_scan_pipeline` (mirrors `_lower_inner_chain`'s block for middle ops).
  - `_lower_inner_chain` untouched (Scan would never reach it).
  - `lower_mir_scan_in_chain(op, rest, ctx)` naming kept for symmetry with Filter/ConstantBind; `rest` is the trailing pipeline (matches legacy `_lower_root_scan` signature).
  - Body delegates straight to legacy `_lower_root_scan` — byte-equivalence by construction.

## Test plan
- [x] 15 new tests in `test_lower_mir_scan_byte_equivalent.py` (plain scan, ws-fold, tiled-fold, full-pipeline shapes, dual-path via `_force_legacy_branch`)
- [x] Full suite: 1447 passed, 5 skipped (1 pre-existing entry-point flake)
- [x] Heavy byte-equivalence harness (4 suites, 537 tests): 535 passed + 2 skipped — unchanged
- [x] mypy: 0 new errors
- [x] ruff check + format (CI v0.9.10): clean

## Cross-PR conflict expectations
- B-InsertInto (parallel): mechanical union on `USE_DECLARATIVE` + `_register_passes()` registration block. B-InsertInto's dispatch goes in `_lower_inner_chain` (different location from this PR's new block in `lower_scan_pipeline`), so no body conflict.

🤖 Generated with [Claude Code](https://claude.com/claude-code)