### PR TITLE
E: ship d2l as the fourth entry-point-discoverable plugin

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -62,6 +62,7 @@ srdatalog = "srdatalog.cli:main"
 # ---------------------------------------------------------------------------
 
 [project.entry-points."srdatalog.plugins"]
+d2l = "srdatalog.ir.dialects.relation.d2l:register"
 iir_cf = "srdatalog.ir.dialects.iir.cf:register"
 sorted_array = "srdatalog.ir.dialects.relation.sorted_array:register"
 

--- a/src/srdatalog/ir/dialects/relation/d2l/__init__.py
+++ b/src/srdatalog/ir/dialects/relation/d2l/__init__.py
@@ -50,6 +50,8 @@ The legacy `plugin_view_count` is the underlying source for
 
 from __future__ import annotations
 
+from typing import Any
+
 from srdatalog.ir.codegen.cuda.envelope import ViewSpec
 from srdatalog.ir.core import Dialect
 
@@ -89,7 +91,13 @@ def view_counts_for_specs(
   return [view_count(sp.version, rel_index_types.get(sp.rel_name, '')) for sp in view_specs]
 
 
-__all__ = ['DIALECT', 'D2lSegmentLoop', 'view_count', 'view_counts_for_specs']
+__all__ = [
+  'DIALECT',
+  'D2lSegmentLoop',
+  'register',
+  'view_count',
+  'view_counts_for_specs',
+]
 
 
 # Verifier scaffolding — D2L invariants (segment_depth coherence, etc.)
@@ -103,3 +111,62 @@ def _register_passes() -> None:
 
 
 _register_passes()
+
+
+# ---------------------------------------------------------------------------
+# Phase E plugin entry point
+# ---------------------------------------------------------------------------
+#
+# `register(compiler)` is the callable invoked by F4's plugin discovery
+# (`Compiler.with_default_plugins()`) AND by explicit user-driven
+# `compiler.register_plugin(...)` calls. Wired in `pyproject.toml` under
+# `[project.entry-points."srdatalog.plugins"]` as `d2l`.
+#
+# Coexistence with legacy direct-import: the module-level
+# `_register_passes()` call above still runs on first import, so the
+# dialect's `verifier` is populated regardless of whether anyone goes
+# through `register(compiler)`. The other side-effect of importing this
+# module — `from . import cuda as _cuda`, which registers the D2L
+# `IndexPlugin` with `codegen.cuda.plugin._PLUGIN_REGISTRY` — also runs
+# at import time and is naturally idempotent (Python's module cache
+# guarantees a single import per process). What `register(compiler)`
+# adds on top is the per-Compiler `register_dialect(DIALECT)` step that
+# F4's plugin loader needs to attribute ownership of the dialect to
+# this plugin and populate the running Compiler's registry.
+#
+# Re-running `register(compiler)` on the same Compiler is safe: F4's
+# `register_plugin` (see `core/dialect.py`) short-circuits on
+# already-loaded plugin names.
+
+
+def register(compiler: Any) -> None:
+  '''Plugin entry point — register the `relation.d2l` dialect on the
+  given Compiler.
+
+  Verifier was wired by `_register_passes()` and the CUDA `IndexPlugin`
+  registration ran via `from . import cuda` — both at module-import
+  time (one-shot side effects; Python's module cache makes them
+  naturally idempotent). This callable only performs the per-Compiler
+  step: `compiler.register_dialect(DIALECT)`.
+
+  Idempotent: F4's `Compiler.register_plugin` short-circuits
+  re-registration of the same plugin name.
+  '''
+  compiler.register_dialect(DIALECT)
+
+
+# Plugin metadata read by F4's topo-sort + conflict detection
+# (see `core/plugin.py` — `_plugin_attr` reads these).
+#
+# `plugin_name` — what F4 records as the loaded-plugin identifier.
+#   Matches the entry-point name `d2l` declared in `pyproject.toml`.
+# `provides` — the dialect name this plugin contributes.
+# `requires` — dialects that must be loaded first. Empty: although
+#   `sorted_array`'s `lower_execute_pipeline` declares
+#   `produces=('iir.cf', 'relation.sorted_array', 'relation.d2l', ...)`,
+#   the D2L dialect itself depends on nothing at registration time —
+#   the cross-dialect production ordering is enforced by the
+#   pass-driver's `consumes`/`produces` walk, not by plugin load order.
+register.plugin_name = 'd2l'  # type: ignore[attr-defined]
+register.provides = ('relation.d2l',)  # type: ignore[attr-defined]
+register.requires = ()  # type: ignore[attr-defined]

--- a/tests/test_d2l_as_plugin.py
+++ b/tests/test_d2l_as_plugin.py
@@ -1,0 +1,230 @@
+'''Phase E discipline test — `relation.d2l` is shipped as a
+discoverable entry-point plugin AND remains usable via the legacy
+direct-import pathway, byte-for-byte equivalent.
+
+Spec: `docs/phase_e_plugin_extensibility.md` §2 (entry-point discovery)
+and §5 (built-ins ARE plugins). Companion to
+`tests/test_sorted_array_as_plugin.py` and
+`tests/test_iir_cf_as_plugin.py`, which exercise the same contract for
+the first two plugins shipped, and `tests/test_core_plugin.py` (which
+exercises the F4 framework with synthetic plugins). This file covers
+the third real built-in dialect — the Device2LevelIndex segment-aware
+companion to `relation.sorted_array`.
+
+Three things asserted:
+
+  1. `Compiler.with_default_plugins()` discovers `d2l` through the
+     `srdatalog.plugins` entry-point group and registers its dialect
+     on the resulting Compiler.
+  2. Calling `compiler.register_plugin(register)` twice is a no-op the
+     second time (F4 idempotency, exercised against the real register
+     callable).
+  3. End-to-end `compile_kernel_body(ep)` returns byte-identical text
+     whether or not the caller first went through
+     `with_default_plugins()` — the legacy direct-import pathway and
+     the plugin-discovered pathway produce the same artifact.
+
+The byte-equivalence anchor (#3) is the load-bearing assertion: if a
+future change inadvertently makes the plugin path diverge from the
+legacy path, this test catches it before it reaches the full
+`test_runner_byte_equivalence.py` suite.
+'''
+
+from __future__ import annotations
+
+import srdatalog.ir.mir.types as mir
+from srdatalog.dsl import Program, Relation, Var
+from srdatalog.ir.codegen.cuda.api import compile_kernel_body
+from srdatalog.ir.core import Compiler
+from srdatalog.ir.core.plugin import ENTRY_POINT_GROUP
+from srdatalog.ir.default_pipelines import (
+  DEFAULT_PROGRAM_PIPELINE,
+  InitialProg,
+)
+from srdatalog.ir.dialects.relation.d2l import (
+  DIALECT as D2L_DIALECT,
+)
+from srdatalog.ir.dialects.relation.d2l import (
+  register as register_d2l,
+)
+
+# -----------------------------------------------------------------------------
+# Fixtures
+# -----------------------------------------------------------------------------
+
+
+def _tc_program() -> Program:
+  '''Tiny TC-style program — same shape as
+  `tests/test_iir_cf_as_plugin.py::_tc_program`. Two rules give the
+  MIR plan an actual `ExecutePipeline` to feed `compile_kernel_body`.
+  '''
+  X, Y, Z = Var('x'), Var('y'), Var('z')
+  arc = Relation('ArcInput', 2)
+  edge = Relation('Edge', 2)
+  path = Relation('Path', 2)
+  return Program(
+    rules=[
+      (edge(X, Y) <= arc(X, Y)).named('EdgeLoad'),
+      (path(X, Y) <= edge(X, Y)).named('TCBase'),
+      (path(X, Z) <= path(X, Y) & edge(Y, Z)).named('TCRec'),
+    ],
+  )
+
+
+def _find_execute_pipelines(node: object) -> list[mir.ExecutePipeline]:
+  '''Walk a MIR plan and collect every ExecutePipeline. Mirrors
+  `_find_execute_pipelines` in `test_iir_cf_as_plugin.py`.
+  '''
+  out: list[mir.ExecutePipeline] = []
+  if isinstance(node, mir.ExecutePipeline):
+    out.append(node)
+  elif isinstance(node, mir.FixpointPlan):
+    for inst in node.instructions:
+      out.extend(_find_execute_pipelines(inst))
+  elif isinstance(node, mir.ParallelGroup):
+    for op in node.ops:
+      out.extend(_find_execute_pipelines(op))
+  return out
+
+
+def _first_ep(mir_prog: mir.Program) -> mir.ExecutePipeline:
+  for step, _is_rec in mir_prog.steps:
+    eps = _find_execute_pipelines(step)
+    if eps:
+      return eps[0]
+  raise AssertionError('no ExecutePipeline in mir_prog')
+
+
+def _build_first_ep_via(compiler: Compiler) -> mir.ExecutePipeline:
+  '''Drive the program-level pipeline on `compiler` to get a real
+  `ExecutePipeline` we can hand to `compile_kernel_body`.'''
+  state = compiler.run(InitialProg(program=_tc_program()), pipeline=DEFAULT_PROGRAM_PIPELINE)
+  assert state.mir_program is not None
+  return _first_ep(state.mir_program)
+
+
+# -----------------------------------------------------------------------------
+# 1. Plugin discovery — `with_default_plugins()` picks up d2l
+# -----------------------------------------------------------------------------
+
+
+def test_d2l_is_discovered_by_with_default_plugins() -> None:
+  '''`Compiler.with_default_plugins()` walks the `srdatalog.plugins`
+  entry-point group; the `d2l` entry point shipped in this repo's
+  `pyproject.toml` is loaded and registers the `relation.d2l` dialect.
+
+  If this test fails with "no plugins loaded", the most likely cause
+  is that the editable install's `.egg-info` is stale — run
+  `pip install -e . --no-deps --force-reinstall` (or `uv sync`) to
+  refresh the entry-point metadata.
+  '''
+  compiler = Compiler.with_default_plugins()
+
+  # The plugin name comes from the entry-point name in pyproject.toml
+  # (`[project.entry-points."srdatalog.plugins"] d2l = "..."`)
+  # — F4's `_resolve_plugin` records that name in `_plugins_loaded`.
+  assert 'd2l' in compiler._plugins_loaded, (
+    f'expected d2l in loaded plugins; got {list(compiler._plugins_loaded)!r}. '
+    f'If empty, the editable install metadata is stale: '
+    f'`pip install -e . --no-deps --force-reinstall`.'
+  )
+
+  # The dialect itself is registered on the Compiler.
+  dialect = compiler.get_dialect('relation.d2l')
+  assert dialect is D2L_DIALECT, (
+    'with_default_plugins registered a different Dialect instance than '
+    'the module-level singleton — the plugin path is not reusing DIALECT'
+  )
+
+  # The dialect's plugin attribution is the entry-point name.
+  assert compiler._dialects_by_plugin['relation.d2l'] == 'd2l'
+
+
+def test_entry_point_group_name_matches_f4() -> None:
+  '''The entry-point group name in `pyproject.toml` is exactly the
+  one F4's plugin discovery walks. Locked at `srdatalog.plugins` per
+  the spec (`docs/phase_e_plugin_extensibility.md` §2).
+  '''
+  assert ENTRY_POINT_GROUP == 'srdatalog.plugins'
+
+
+# -----------------------------------------------------------------------------
+# 2. Idempotency — re-registering the real callable is a no-op
+# -----------------------------------------------------------------------------
+
+
+def test_register_d2l_plugin_idempotent() -> None:
+  '''Calling `register_plugin(register_d2l)` twice on the same
+  Compiler does not double-register the dialect and does not raise.
+  F4's `register_plugin` short-circuits on the plugin name
+  (`register.plugin_name = 'd2l'`) — this test verifies the
+  short-circuit fires for the real register callable, not just the
+  synthetic ones in `test_core_plugin.py`.
+  '''
+  compiler = Compiler()
+  compiler.register_plugin(register_d2l)
+  first_loaded = dict(compiler._plugins_loaded)
+  first_dialect_count = len(compiler.dialects)
+
+  # Second call must be a no-op (not raise PluginConflictError, not
+  # double-register the dialect, not append a second lowering, etc.).
+  compiler.register_plugin(register_d2l)
+
+  assert compiler._plugins_loaded == first_loaded
+  assert len(compiler.dialects) == first_dialect_count
+  assert compiler.get_dialect('relation.d2l') is D2L_DIALECT
+
+
+def test_register_d2l_metadata_matches_entry_point() -> None:
+  '''The `register` callable's `plugin_name` / `provides` / `requires`
+  attributes match the entry-point declaration in `pyproject.toml`.
+  These attributes are what F4 topo-sorts on (see
+  `core/plugin.py::_topo_sort_plugins`) — getting them wrong silently
+  breaks dependency ordering, so we pin them here.
+  '''
+  assert register_d2l.plugin_name == 'd2l'  # type: ignore[attr-defined]
+  assert register_d2l.provides == ('relation.d2l',)  # type: ignore[attr-defined]
+  assert register_d2l.requires == ()  # type: ignore[attr-defined]
+
+
+# -----------------------------------------------------------------------------
+# 3. Byte-equivalence — plugin path and legacy path produce same output
+# -----------------------------------------------------------------------------
+
+
+def test_compile_kernel_body_byte_equivalent_across_plugin_paths() -> None:
+  '''The full `compile_kernel_body(ep)` text is byte-identical whether
+  the caller obtains its `ep` via a plugin-discovered Compiler
+  (`with_default_plugins`) or via a Compiler that explicitly invokes
+  the register callable. This is the load-bearing assertion: it pins
+  that wrapping the dialect as a plugin did not perturb the codegen
+  output.
+
+  We deliberately check both phases (count + materialize) since the
+  kernel-body pipeline branches on `is_counting` and a subtle plugin
+  ordering bug could surface in only one phase.
+  '''
+  # Path A: full plugin discovery via the entry-point group.
+  compiler_via_plugin = Compiler.with_default_plugins()
+  ep_via_plugin = _build_first_ep_via(compiler_via_plugin)
+
+  # Path B: explicit plugin registration (skips entry-point walk).
+  compiler_explicit = Compiler()
+  compiler_explicit.register_plugin(register_d2l)
+  ep_explicit = _build_first_ep_via(compiler_explicit)
+
+  # Materialize phase.
+  text_a = compile_kernel_body(ep_via_plugin, is_counting=False)
+  text_b = compile_kernel_body(ep_explicit, is_counting=False)
+  assert text_a == text_b, (
+    'compile_kernel_body diverged between plugin-discovered and '
+    'explicit-register Compilers (materialize phase)'
+  )
+
+  # Count phase — mirrors the runner emit's per-kernel knobs.
+  text_a_ct = compile_kernel_body(ep_via_plugin, is_counting=True, output_var_name='output_ctx')
+  text_b_ct = compile_kernel_body(ep_explicit, is_counting=True, output_var_name='output_ctx')
+  assert text_a_ct == text_b_ct, (
+    'compile_kernel_body diverged between plugin-discovered and '
+    'explicit-register Compilers (count phase)'
+  )


### PR DESCRIPTION
## Summary
- 4th dialect plugin: `register(compiler)` in `relation/d2l/__init__.py` + entry point in `pyproject.toml`
- `plugin_name='d2l'`, `provides=('relation.d2l',)`, `requires=()` (the cross-dialect `produces` from sorted_array's `lower_execute_pipeline` is enforced by pass-driver's consumes/produces walk, not plugin load order)
- Coexistence: module-level `_register_passes()` + pre-existing side-effect import `from . import cuda as _cuda` (which registers D2L IndexPlugin in `codegen.cuda.plugin._PLUGIN_REGISTRY`) both keep running. Naturally idempotent via Python's module cache.

## Test plan
- [x] 34 plugin tests pass across `d2l` + `iir_cf` + `sorted_array` + `core_plugin`
- [x] Full suite: 1497 passed, 5 skipped
- [x] Byte-equivalence: 532 passed + 2 skipped (`test_runner_byte_equivalence` + `test_cuda_complete_runner` + `test_byte_equivalence_jit`)
- [x] sphinx -W clean
- [x] mypy: 1 pre-existing `[no-untyped-def]` on inner verifier closure (matches iir.cf + sorted_array pattern); no new errors
- [x] ruff check + format on changed files: clean

## Cross-PR conflict expectations
- **E-parallel-data** (parallel): mechanical `pyproject.toml` conflict on the entry-points block. Trivial union.

## Note on local-env pollination
Same shared `.pth` race observed (mentioned in #parallel-data PR too). CI unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)