### PR TITLE
B-Aggregate: per-MIR-op @lowering migration (Wave 2A order 8, hard)

### DIFF
--- a/src/srdatalog/ir/dialects/relation/sorted_array/__init__.py
+++ b/src/srdatalog/ir/dialects/relation/sorted_array/__init__.py
@@ -72,6 +72,7 @@ USE_DECLARATIVE: frozenset[type] = frozenset(
     # shape" gate; B-CJ-multi drops the source-count guard there.
     _mir_for_use_declarative.ColumnJoin,
     _mir_for_use_declarative.Negation,
+    _mir_for_use_declarative.Aggregate,
   }
 )
 
@@ -341,6 +342,37 @@ def _register_passes() -> None:
   )
   def _lower_mir_negation_registered(op: Any, ctx: Any) -> Any:
     return lower_mir_negation(op, ctx)
+
+  # Wave 2A / B-Aggregate (per docs/phase_b_lowering_dispatcher.md
+  # §4 row B-Aggregate, difficulty `hard`, order 8): identical
+  # split-with-stub shape to B-Filter / B-ConstantBind /
+  # B-InsertInto above. `mir.Aggregate` is a structurally-supported
+  # MIR op type (see runtime/generalized_datalog/mir_def.h for the
+  # C++ counterpart) but the Python lowering pipeline never
+  # constructs one today — the Nim reference also drops AggClause
+  # during HIR -> MIR lowering, so the legacy `_lower_inner_chain`
+  # has no dedicated branch and Aggregate falls through to the
+  # terminal `raise ValueError('unsupported inner op: ...')`. The
+  # registration here pins dialect ownership for the Phase B
+  # sign-off bullet "every concrete MIR op has an `@lowering`";
+  # `lower_mir_aggregate_in_chain` raises an identical
+  # `ValueError` so byte-equivalence holds against the legacy
+  # fall-through. See `lowerings/lower_mir_aggregate.py` for the
+  # full upgrade-path rationale and the `USE_DECLARATIVE` ratchet
+  # below routes chain dispatch through the new path while keeping
+  # this registration as the dialect-ownership contract.
+  from srdatalog.ir.dialects.relation.sorted_array.lowerings.lower_mir_aggregate import (
+    lower_mir_aggregate,
+  )
+
+  @lowering(
+    DIALECT,
+    mir.Aggregate,
+    consumes=('mir',),
+    produces=('iir.cf',),
+  )
+  def _lower_mir_aggregate_registered(op: Any, ctx: Any) -> Any:
+    return lower_mir_aggregate(op, ctx)
 
   # Verifier scaffolding — per-op invariants (D9: SaHint inside
   # IterURV scope, etc.) land incrementally as we encode them.

--- a/src/srdatalog/ir/dialects/relation/sorted_array/lowerings/__init__.py
+++ b/src/srdatalog/ir/dialects/relation/sorted_array/lowerings/__init__.py
@@ -1171,6 +1171,12 @@ def _lower_inner_chain(
       )
 
       return lower_mir_negation_in_chain(head, tail, ctx)
+    if isinstance(head, mir.Aggregate):
+      from srdatalog.ir.dialects.relation.sorted_array.lowerings.lower_mir_aggregate import (
+        lower_mir_aggregate_in_chain,
+      )
+
+      return lower_mir_aggregate_in_chain(head, tail, ctx)
     raise AssertionError(
       f'_lower_inner_chain: USE_DECLARATIVE contains {type(head).__name__!r} '
       f'but no chain-dispatch wiring exists for it. Add the '

--- a/src/srdatalog/ir/dialects/relation/sorted_array/lowerings/lower_mir_aggregate.py
+++ b/src/srdatalog/ir/dialects/relation/sorted_array/lowerings/lower_mir_aggregate.py
@@ -1,0 +1,150 @@
+'''Lowering: `mir.Aggregate` -> iir.cf — Wave 2A per-op migration (order 8).
+
+Per `docs/phase_b_lowering_dispatcher.md` §4 (per-MIR-op work-unit
+table, row B-Aggregate, difficulty `hard`) and §4.1 (per-PR
+template): each MIR op type gets one `@lowering(target=iir.cf,
+source=mir.X)` rule in its own file under
+`dialects/relation/sorted_array/lowerings/`. The registry
+registration lives alongside the dialect's other lowerings in
+`__init__.py:_register_passes`.
+
+Byte-equivalence contract (§4.2): the migrated op produces the same
+IIR tree as the legacy `if isinstance(head, mir.Aggregate):` branch
+inside `_lower_inner_chain` on every fixture that exercises it.
+
+Aggregate-specific note (status as of Wave 2A, mirrors the long-
+standing Nim-also-broken state documented in `tests/test_aggregate.py`):
+
+  The Nim HIR pipeline parses `AggClause` into HIR JSON
+  (`kind="aggregation"`) but NEVER constructs a `moAggregate` MIR
+  node from it in its lowering pipeline. Python mirrors that exactly
+  — DSL `agg(...)` / `count(...)` round-trips through HIR but the
+  `Agg` clause disappears during MIR lowering, so `mir.Aggregate`
+  is never produced by `compile_to_mir`. The `mir.Aggregate`
+  dataclass exists for parity with the runtime C++
+  `mir::Aggregate<...>` template (see
+  `runtime/generalized_datalog/mir_def.h`) and for the structural
+  helpers (`_var_used_in_op`, `view_slots.py`, the codegen
+  `Scan|Negation|Aggregate` triples) that treat Aggregate as a
+  spec-list source.
+
+  Consequently the legacy `_lower_inner_chain` has NO
+  `if isinstance(head, mir.Aggregate):` branch — Aggregate falls
+  through to the terminal `raise ValueError(f'unsupported inner
+  op: {type(head).__name__}')`. Likewise `_supported_pipeline`
+  REJECTS any pipeline containing a `mir.Aggregate`, so an
+  Aggregate can only reach `_lower_inner_chain` via a direct
+  call (tests / future paths) — never via `compile_pipeline`.
+
+  This migration therefore registers `mir.Aggregate` for dialect
+  ownership + completeness (so the per-op `@lowering` table covers
+  every MIR op family per the Phase B sign-off bullet "every concrete
+  MIR op has an `@lowering`") and pins the chain-aware variant to
+  the same "unsupported" raise. Byte-equivalence holds vacuously
+  on real pipelines (Aggregate never appears) and structurally on
+  direct calls (both legacy and new paths raise an identical
+  `ValueError` for the unsupported op).
+
+  When a future PR teaches the dialect to lower `mir.Aggregate` for
+  real (analogous to `_lower_negation` for `mir.Negation`), it will
+  replace the `_unsupported` body here with the real emission —
+  the registration scaffold + dispatch wiring will already be in
+  place.
+
+Chain-aware split (mirrors B-Filter / B-ConstantBind / B-InsertInto):
+two entry points whose names match the established Wave 2A
+convention so the table-of-contents in
+`lowerings/__init__.py:_register_passes` stays uniform:
+
+  - `lower_mir_aggregate_in_chain(op, tail, ctx)`: the real entry
+    called from `_lower_inner_chain` (legacy) when
+    `type(head) in USE_DECLARATIVE`. Today this raises a
+    `ValueError` whose text matches the legacy fall-through
+    exception ("unsupported inner op: Aggregate") so the byte-
+    equivalent test can pin both paths to the same error string.
+  - `lower_mir_aggregate(op, ctx)`: the `@lowering`-registered
+    stub. Asserts on direct invocation — the framework dispatch
+    path is reserved for a future MIR-IIR walker that no longer
+    routes through `_lower_inner_chain` and can plumb `tail`
+    through.
+
+The split lets the registry pin dialect ownership (`Aggregate`
+belongs to `relation.sorted_array`) without forcing the chain
+dispatcher through the registry today.
+'''
+
+from __future__ import annotations
+
+from typing import Any
+
+import srdatalog.ir.mir.types as mir
+from srdatalog.ir.core import Op
+
+
+def lower_mir_aggregate_in_chain(
+  op: mir.Aggregate,
+  tail: list[Any],
+  ctx: Any,
+) -> Op:
+  '''Emit the IIR for a `mir.Aggregate` chain head with trailing
+  `tail`.
+
+  Mirrors the (vacuous) legacy fall-through in `_lower_inner_chain`
+  byte-for-byte: there is no `if isinstance(head, mir.Aggregate):`
+  branch upstream, so the legacy path raises `ValueError` with the
+  text `'unsupported inner op: Aggregate'` when an Aggregate ever
+  reaches the chain dispatcher. We raise the same `ValueError`
+  here so the dispatch under `USE_DECLARATIVE` matches the legacy
+  fall-through exactly — the byte-equivalent test asserts both
+  paths raise the same error.
+
+  See module docstring for why Aggregate is "vacuous today"
+  (Nim-also-broken: AggClause -> HIR JSON only, never -> MIR
+  Aggregate) and the upgrade path when a real lowering lands.
+
+  The `tail` and `ctx` parameters are accepted to match the
+  Wave 2A `_in_chain` signature; both are ignored until a real
+  lowering replaces this body.
+  '''
+  # Match the legacy `raise ValueError(f'unsupported inner op:
+  # {type(head).__name__}')` text exactly so the byte-equivalence
+  # test can pin both paths to the same error string. Tail and ctx
+  # are unused (no real emission yet) — del to silence linters and
+  # signal intent to future readers.
+  del tail, ctx
+  raise ValueError(f'unsupported inner op: {type(op).__name__}')
+
+
+def lower_mir_aggregate(op: mir.Aggregate, ctx: Any) -> Op:
+  '''Framework-registry stub for `@lowering(target=iir.cf,
+  source=mir.Aggregate)`. The actual dispatch lives in
+  `lowerings._lower_inner_chain` (via the `USE_DECLARATIVE`
+  ratchet), which calls `lower_mir_aggregate_in_chain` with the
+  trailing chain in scope.
+
+  This stub exists so the dialect's `lowerings` list pins the
+  (consumes, produces) contract for `mir.Aggregate` — the
+  discipline test consults the dialect to verify ownership, and
+  the Phase B sign-off bullet "every concrete MIR op has an
+  `@lowering`" requires this registration regardless of whether
+  the chain dispatcher reaches a real Aggregate today.
+
+  Calling this stub directly raises a structural assertion — the
+  framework path is reserved for future readers who can plumb in
+  the missing `tail` (e.g. a refactored MIR-IIR walker that no
+  longer routes through `_lower_inner_chain`).
+  '''
+  raise AssertionError(
+    'lower_mir_aggregate: dispatch goes through '
+    '`lowerings._lower_inner_chain` -> `lower_mir_aggregate_in_chain` '
+    'so the trailing chain is in scope. Direct invocation '
+    'indicates a refactor that bypassed the chain dispatch — '
+    'plumb the `tail` through and call '
+    '`lower_mir_aggregate_in_chain` instead.'
+  )
+
+
+__all__ = [
+  'lower_mir_aggregate',
+  'lower_mir_aggregate_in_chain',
+]

--- a/tests/test_lower_mir_aggregate_byte_equivalent.py
+++ b/tests/test_lower_mir_aggregate_byte_equivalent.py
@@ -1,0 +1,424 @@
+'''Byte-equivalence test for Wave 2A B-Aggregate migration.
+
+Per `docs/phase_b_lowering_dispatcher.md` §4.2 (per-PR acceptance
+gate): each per-MIR-op migration ships a
+`test_lower_mir_<op>_byte_equivalent` test that runs the migrated
+path on every relevant fixture and asserts byte equality with the
+legacy `if isinstance(head, mir.X):` branch.
+
+Aggregate-specific notes (mirrors the long-standing Nim-also-broken
+state documented in `tests/test_aggregate.py` and in
+`lowerings/lower_mir_aggregate.py`'s module docstring):
+
+  The Nim HIR pipeline parses `AggClause` into HIR JSON
+  (`kind="aggregation"`) but NEVER constructs a `moAggregate`
+  MIR node from it during HIR -> MIR lowering. Python mirrors
+  that exactly — DSL `agg(...)` / `count(...)` round-trips
+  through HIR but the `Agg` clause disappears, so `mir.Aggregate`
+  is never produced by `compile_to_mir` today. The
+  `mir.Aggregate` dataclass exists for parity with the runtime
+  C++ `mir::Aggregate<...>` template + structural helpers
+  (`_var_used_in_op`, `view_slots.py`, the codegen
+  `Scan|Negation|Aggregate` triples).
+
+  Consequently the legacy `_lower_inner_chain` has NO
+  `if isinstance(head, mir.Aggregate):` branch — Aggregate falls
+  through to the terminal `raise ValueError(f'unsupported inner
+  op: {type(head).__name__}')`. The B-Aggregate migration
+  preserves this contract byte-for-byte (both paths raise the
+  same `ValueError` text) so the registration scaffold can land
+  ahead of a future real lowering replacing the raise.
+
+  Likewise `_supported_pipeline` REJECTS any pipeline containing
+  a `mir.Aggregate`, so `mir.Aggregate` can only reach the
+  chain dispatcher via direct `_lower_inner_chain([agg, ins], ctx)`
+  calls — never via `compile_pipeline`. This file therefore
+  exercises the dispatch surface directly; there is no full-
+  `compile_pipeline` smoke test (it would be DOA at
+  `_supported_pipeline`).
+
+The test compares two compilation paths:
+
+  - LEGACY: `USE_DECLARATIVE` patched to NOT contain
+    `mir.Aggregate`, so `_lower_inner_chain` falls into the
+    terminal `raise ValueError(...)` for unsupported inner ops.
+  - NEW: `USE_DECLARATIVE` left alone (Aggregate IS in the set),
+    so `_lower_inner_chain` routes through
+    `lower_mir_aggregate_in_chain` (which raises the same
+    `ValueError`).
+
+Byte-equivalence is asserted on the exception text (the only
+observable output today). When a future PR replaces the raise
+with a real lowering, this file gains rendered-IIR assertions
+mirroring the other Wave 2A tests.
+'''
+
+from __future__ import annotations
+
+from contextlib import contextmanager
+from typing import Any
+
+import pytest
+
+import srdatalog.ir.mir.types as mir
+from srdatalog.ir.dialects.relation.sorted_array.lowerings import (
+  LoweringCtx,
+  _lower_inner_chain,
+)
+from srdatalog.ir.dialects.relation.sorted_array.lowerings.lower_mir_aggregate import (
+  lower_mir_aggregate,
+  lower_mir_aggregate_in_chain,
+)
+from srdatalog.ir.hir.types import Version
+
+# -----------------------------------------------------------------------------
+# Helpers
+# -----------------------------------------------------------------------------
+
+
+@contextmanager
+def _force_legacy_branch():
+  '''Temporarily strip `mir.Aggregate` from `USE_DECLARATIVE` so
+  `_lower_inner_chain` falls into the legacy fall-through (which
+  raises `ValueError('unsupported inner op: Aggregate')`).
+
+  Save / restore as a context manager — discipline test
+  `test_use_declarative_is_monotonic` (when it lands) ratchets the
+  set at module import time, but this test mutates the dialect's
+  re-bound name for the duration of one call only.
+  '''
+  import srdatalog.ir.dialects.relation.sorted_array as sa_dialect
+
+  saved = sa_dialect.USE_DECLARATIVE
+  sa_dialect.USE_DECLARATIVE = frozenset(saved - {mir.Aggregate})
+  try:
+    yield
+  finally:
+    sa_dialect.USE_DECLARATIVE = saved
+
+
+def _insert_into(arity: int = 2) -> mir.InsertInto:
+  vars_ = [f'v{i}' for i in range(arity)]
+  return mir.InsertInto(
+    rel_name='Dst',
+    version=Version.NEW,
+    vars=vars_,
+    index=list(range(arity)),
+  )
+
+
+def _agg_count(
+  result_var: str = 'cnt',
+  rel_name: str = 'R',
+  prefix_vars: list[str] | None = None,
+  index: list[int] | None = None,
+  handle_start: int = 1,
+  version: Version = Version.FULL,
+) -> mir.Aggregate:
+  '''Build a `mir.Aggregate` with sensible defaults. Mirrors the
+  shape `count(cnt, R(x, y))` produces if it ever reached MIR.'''
+  return mir.Aggregate(
+    result_var=result_var,
+    agg_func='AggCount',
+    rel_name=rel_name,
+    version=version,
+    index=index if index is not None else [0, 1],
+    prefix_vars=prefix_vars if prefix_vars is not None else [],
+    handle_start=handle_start,
+  )
+
+
+def _new_ctx(**kwargs: Any) -> LoweringCtx:
+  '''Fresh LoweringCtx — counters reset so both paths bump identically.'''
+  return LoweringCtx(output_var='ctx0', **kwargs)
+
+
+# -----------------------------------------------------------------------------
+# 1. Default-shape Aggregate (AggCount, no prefix_vars)
+# -----------------------------------------------------------------------------
+
+
+def test_aggregate_default_count_byte_equivalent_raise():
+  '''Default `count(cnt, R(x, y))`-shaped Aggregate. Both paths
+  raise the same `ValueError` with text
+  `'unsupported inner op: Aggregate'`.'''
+  agg = _agg_count()
+  ins = _insert_into(1)
+
+  with _force_legacy_branch(), pytest.raises(ValueError) as legacy_exc:
+    _lower_inner_chain([agg, ins], _new_ctx())
+
+  with pytest.raises(ValueError) as new_exc:
+    _lower_inner_chain([agg, ins], _new_ctx())
+
+  assert str(legacy_exc.value) == str(new_exc.value)
+  assert str(legacy_exc.value) == 'unsupported inner op: Aggregate'
+
+
+# -----------------------------------------------------------------------------
+# 2. Aggregate with prefix_vars (join-prefixed shape)
+# -----------------------------------------------------------------------------
+
+
+def test_aggregate_with_prefix_vars_byte_equivalent_raise():
+  '''Aggregate carrying join-prefix vars (e.g. `count(cnt, R(x, y))`
+  inside a body where `x` is bound). Both paths raise the same
+  error — prefix_vars are inspected by `_var_used_in_op` only
+  (line 2458), not by the chain dispatcher.'''
+  agg = _agg_count(prefix_vars=['x', 'y'])
+  ins = _insert_into(1)
+
+  with _force_legacy_branch(), pytest.raises(ValueError) as legacy_exc:
+    _lower_inner_chain([agg, ins], _new_ctx())
+
+  with pytest.raises(ValueError) as new_exc:
+    _lower_inner_chain([agg, ins], _new_ctx())
+
+  assert str(legacy_exc.value) == str(new_exc.value)
+
+
+# -----------------------------------------------------------------------------
+# 3. Aggregate with a non-default agg_func (custom aggregator)
+# -----------------------------------------------------------------------------
+
+
+def test_aggregate_custom_agg_func_byte_equivalent_raise():
+  '''Aggregate with a non-AggCount aggregator (`AggSum`, `MyAgg<int>`,
+  etc.). The agg_func is not consulted by either path today.'''
+  agg = _agg_count()
+  agg = mir.Aggregate(
+    result_var=agg.result_var,
+    agg_func='AggSum',
+    rel_name=agg.rel_name,
+    version=agg.version,
+    index=agg.index,
+    prefix_vars=agg.prefix_vars,
+    handle_start=agg.handle_start,
+  )
+  ins = _insert_into(1)
+
+  with _force_legacy_branch(), pytest.raises(ValueError) as legacy_exc:
+    _lower_inner_chain([agg, ins], _new_ctx())
+
+  with pytest.raises(ValueError) as new_exc:
+    _lower_inner_chain([agg, ins], _new_ctx())
+
+  assert str(legacy_exc.value) == str(new_exc.value)
+
+
+# -----------------------------------------------------------------------------
+# 4. Aggregate with a non-default version (NEW / DELTA)
+# -----------------------------------------------------------------------------
+
+
+def test_aggregate_version_new_byte_equivalent_raise():
+  '''Aggregate over a NEW version of the relation. Version is not
+  consulted by either path today.'''
+  agg = _agg_count(version=Version.NEW)
+  ins = _insert_into(1)
+
+  with _force_legacy_branch(), pytest.raises(ValueError) as legacy_exc:
+    _lower_inner_chain([agg, ins], _new_ctx())
+
+  with pytest.raises(ValueError) as new_exc:
+    _lower_inner_chain([agg, ins], _new_ctx())
+
+  assert str(legacy_exc.value) == str(new_exc.value)
+
+
+# -----------------------------------------------------------------------------
+# 5. Aggregate as the SOLE chain head (no trailing tail)
+# -----------------------------------------------------------------------------
+
+
+def test_aggregate_no_tail_byte_equivalent_raise():
+  '''Aggregate followed by a single InsertInto (minimum legal
+  chain — `_lower_inner_chain` requires non-empty `rest`). Both
+  paths raise on Aggregate before tail processing.'''
+  agg = _agg_count()
+  ins = _insert_into(2)
+
+  with _force_legacy_branch(), pytest.raises(ValueError) as legacy_exc:
+    _lower_inner_chain([agg, ins], _new_ctx())
+
+  with pytest.raises(ValueError) as new_exc:
+    _lower_inner_chain([agg, ins], _new_ctx())
+
+  assert str(legacy_exc.value) == str(new_exc.value)
+  assert 'Aggregate' in str(legacy_exc.value)
+
+
+# -----------------------------------------------------------------------------
+# 6. Aggregate followed by Filter (would be a real downstream chain
+#    once a real lowering lands)
+# -----------------------------------------------------------------------------
+
+
+def test_aggregate_with_filter_tail_byte_equivalent_raise():
+  '''Aggregate followed by a Filter then InsertInto. Both paths
+  still raise on the Aggregate head before the tail is considered.
+  Future real lowering will keep this dispatch-on-head invariant.'''
+  agg = _agg_count()
+  filt = mir.Filter(vars=['cnt'], code='return cnt > 0;')
+  ins = _insert_into(1)
+
+  with _force_legacy_branch(), pytest.raises(ValueError) as legacy_exc:
+    _lower_inner_chain([agg, filt, ins], _new_ctx())
+
+  with pytest.raises(ValueError) as new_exc:
+    _lower_inner_chain([agg, filt, ins], _new_ctx())
+
+  assert str(legacy_exc.value) == str(new_exc.value)
+
+
+# -----------------------------------------------------------------------------
+# 7. Direct call to `lower_mir_aggregate_in_chain` matches dispatch
+# -----------------------------------------------------------------------------
+
+
+def test_lower_mir_aggregate_in_chain_raises_unsupported():
+  '''Pin the chain-aware entry's exception text directly (independent
+  of dispatch routing). The legacy fall-through is
+  `f'unsupported inner op: {type(head).__name__}'`.'''
+  agg = _agg_count()
+  ins = _insert_into(1)
+
+  with pytest.raises(ValueError) as exc:
+    lower_mir_aggregate_in_chain(agg, [ins], _new_ctx())
+  assert str(exc.value) == 'unsupported inner op: Aggregate'
+
+
+# -----------------------------------------------------------------------------
+# 8. Registry contract — stub asserts on direct call
+# -----------------------------------------------------------------------------
+
+
+def test_lower_mir_aggregate_registry_stub_asserts():
+  '''The `@lowering(target=iir.cf, source=mir.Aggregate)` registry
+  entry is a stub that asserts on direct invocation — dispatch is
+  expected to flow through `_lower_inner_chain` -> the chain-aware
+  variant. Mirrors the C5 `lower_tiled_cartesian` split + the other
+  Wave 2A migrations.
+  '''
+  agg = _agg_count()
+  ctx = _new_ctx()
+  with pytest.raises(AssertionError, match=r'lower_mir_aggregate_in_chain'):
+    lower_mir_aggregate(agg, ctx)
+
+
+def test_lower_mir_aggregate_is_registered_on_sorted_array_dialect():
+  '''The `Aggregate` `@lowering` is registered on the
+  `relation.sorted_array` dialect. Pins dialect ownership per
+  `docs/phase_b_lowering_dispatcher.md` §4 (one `@lowering` per MIR
+  op, on the dialect that lowers it).
+  '''
+  from srdatalog.ir.dialects.relation.sorted_array import DIALECT as SA_DIALECT
+
+  matched = [low for low in SA_DIALECT.lowerings if low.matches is mir.Aggregate]
+  assert len(matched) == 1
+  assert matched[0].consumes == ('mir',)
+  assert 'iir.cf' in matched[0].produces
+
+
+# -----------------------------------------------------------------------------
+# 9. Aggregate is in USE_DECLARATIVE (ratchet contract)
+# -----------------------------------------------------------------------------
+
+
+def test_aggregate_in_use_declarative_ratchet():
+  '''`mir.Aggregate` must be in the `USE_DECLARATIVE` set so the
+  chain dispatcher routes through the per-op file. The set is
+  monotonically growing during Phase B — removing this entry
+  requires owner sign-off.'''
+  from srdatalog.ir.dialects.relation.sorted_array import USE_DECLARATIVE
+
+  assert mir.Aggregate in USE_DECLARATIVE
+
+
+# -----------------------------------------------------------------------------
+# 10. Full-pipeline shape: _supported_pipeline rejects Aggregate
+# -----------------------------------------------------------------------------
+
+
+def test_aggregate_in_pipeline_rejected_by_supported_predicate():
+  '''Sanity: `_supported_pipeline` rejects any pipeline that
+  contains an Aggregate, so the chain dispatcher is never reached
+  via `compile_pipeline` today. Both legacy and new paths share
+  this gate.'''
+  from srdatalog.ir.dialects.relation.sorted_array.lowerings import (
+    _supported_pipeline,
+  )
+
+  scan = mir.Scan(
+    vars=['x', 'y'],
+    rel_name='Src',
+    version=Version.FULL,
+    index=[0, 1],
+    handle_start=0,
+  )
+  agg = _agg_count()
+  ins = mir.InsertInto(
+    rel_name='Dst',
+    version=Version.NEW,
+    vars=['cnt'],
+    index=[0],
+  )
+
+  # Scan-rooted pipeline with Aggregate in the middle: not supported.
+  assert not _supported_pipeline([scan, agg, ins])
+  # Aggregate-rooted: also not supported.
+  assert not _supported_pipeline([agg, ins])
+
+
+# -----------------------------------------------------------------------------
+# 11. Dispatch routing: with USE_DECLARATIVE present the path is
+#     the per-op file, not the legacy fall-through
+# -----------------------------------------------------------------------------
+
+
+def test_aggregate_dispatch_routes_through_per_op_file_when_in_use_declarative():
+  '''When `mir.Aggregate` is in `USE_DECLARATIVE`, the dispatcher
+  routes through `lower_mir_aggregate_in_chain` rather than the
+  legacy fall-through. We verify this by monkey-patching the per-op
+  file's entry and confirming it is the one that runs.'''
+  import srdatalog.ir.dialects.relation.sorted_array.lowerings.lower_mir_aggregate as agg_mod
+
+  marker: list[int] = []
+  original = agg_mod.lower_mir_aggregate_in_chain
+
+  def _spy(op: Any, tail: list[Any], ctx: Any) -> Any:
+    marker.append(1)
+    return original(op, tail, ctx)
+
+  agg_mod.lower_mir_aggregate_in_chain = _spy
+  try:
+    agg = _agg_count()
+    ins = _insert_into(1)
+    with pytest.raises(ValueError):
+      _lower_inner_chain([agg, ins], _new_ctx())
+    assert marker == [1]
+  finally:
+    agg_mod.lower_mir_aggregate_in_chain = original
+
+
+def test_aggregate_dispatch_skips_per_op_file_in_legacy_mode():
+  '''Sanity inverse: under `_force_legacy_branch`, the per-op file's
+  entry is NOT called — the legacy fall-through raises directly.'''
+  import srdatalog.ir.dialects.relation.sorted_array.lowerings.lower_mir_aggregate as agg_mod
+
+  marker: list[int] = []
+  original = agg_mod.lower_mir_aggregate_in_chain
+
+  def _spy(op: Any, tail: list[Any], ctx: Any) -> Any:
+    marker.append(1)
+    return original(op, tail, ctx)
+
+  agg_mod.lower_mir_aggregate_in_chain = _spy
+  try:
+    agg = _agg_count()
+    ins = _insert_into(1)
+    with _force_legacy_branch(), pytest.raises(ValueError):
+      _lower_inner_chain([agg, ins], _new_ctx())
+    assert marker == []  # Per-op entry was bypassed.
+  finally:
+    agg_mod.lower_mir_aggregate_in_chain = original


### PR DESCRIPTION
## Summary
- Adds `mir.Aggregate` to `USE_DECLARATIVE` + `lowerings/lower_mir_aggregate.py`
- 7th Phase B op migrated

## Key finding — no legacy helper to delegate to
There is no `_lower_aggregate` helper in the legacy monolith. The Nim HIR pipeline never constructs `moAggregate` MIR nodes (`tests/test_aggregate.py`: "MIR loses the aggregate (both Nim and Python drop AggClause during lowering)"); Python mirrors this exactly — `compile_to_mir` never emits `mir.Aggregate`. The legacy `_lower_inner_chain` has no Aggregate branch — it falls through to the terminal `raise ValueError('unsupported inner op: Aggregate')`.

The `mir.Aggregate` dataclass exists only for parity with the runtime C++ `mir::Aggregate<...>` template + structural helpers (`_var_used_in_op`, `view_slots`, codegen `Scan|Negation|Aggregate` triples). `_supported_pipeline` rejects any pipeline containing it.

**Migration approach**: `lower_mir_aggregate_in_chain` raises `ValueError('unsupported inner op: Aggregate')` — identical text to the legacy fall-through. Both `USE_DECLARATIVE`-enabled and `_force_legacy_branch()`-disabled paths produce identical exceptions. Satisfies the Phase B sign-off bullet "every concrete MIR op has an `@lowering`" while preserving byte-equivalence. Future PR swaps the raise for real emission without touching the registration scaffold.

## Test plan
- [x] 13 new tests in `test_lower_mir_aggregate_byte_equivalent.py` (raise-byte-equivalence in both paths + registry/stub contract + dialect-registration + USE_DECLARATIVE invariant)
- [x] Full suite: 1531 passed, 5 skipped — no regressions
- [x] Byte-equivalence (3 suites): 532 passed + 2 skipped — unchanged
- [x] ruff check + format (CI v0.9.10): clean

## Cross-PR conflict expectations
- **#59** B-CJ-single, **#61** B-Negation (just opened): mechanical union on `sorted_array/__init__.py` USE_DECLARATIVE + `_register_passes` block. Trivial.

🤖 Generated with [Claude Code](https://claude.com/claude-code)