### PR TITLE
R3: verify_renderability closure check + DEFAULT_KERNEL_PIPELINE wiring

### DIFF
--- a/src/srdatalog/ir/core/__init__.py
+++ b/src/srdatalog/ir/core/__init__.py
@@ -90,7 +90,11 @@ from srdatalog.ir.core.strategy import (
   top_down,
   try_,
 )
-from srdatalog.ir.core.verifier import VerificationError
+from srdatalog.ir.core.verifier import (
+  UnrenderableOpError,
+  VerificationError,
+  verify_renderability,
+)
 
 
 def assert_never(value: object) -> NoReturn:
@@ -134,6 +138,7 @@ __all__ = [
   'Type',
   'UnconsumedPragmaError',
   'UnregisteredPragmaError',
+  'UnrenderableOpError',
   'VerificationError',
   'ViewLayout',
   'all_',
@@ -152,4 +157,5 @@ __all__ = [
   'some',
   'top_down',
   'try_',
+  'verify_renderability',
 ]

--- a/src/srdatalog/ir/core/verifier.py
+++ b/src/srdatalog/ir/core/verifier.py
@@ -8,11 +8,22 @@ The infra is intentionally thin: an error type, plus an aggregator the
 PassDriver invokes. Per-dialect verifier logic lives in the dialect's
 own module.
 
-See docs/ir_lowering_semantics.md, section 22.
+This module also hosts `verify_renderability` (R3 — the post-IIR closure
+check). For every op type reachable in the post-fixpoint IIR tree,
+EITHER a `@register_render(op_type, target=T)` is registered OR a
+`@rewrite(dialect, op_type)` is registered. The check raises
+`UnrenderableOpError` on the first op type that satisfies neither
+condition. This is "topology check #4" in docs/concept_glossary.md
+section 13.3 — it polices the SOFT boundary within an IR stage
+(multi-dialect IIR tree closure).
+
+See docs/ir_lowering_semantics.md, section 22 and
+docs/concept_glossary.md section 13.6 (the closure invariant).
 '''
 
 from __future__ import annotations
 
+import dataclasses
 from dataclasses import dataclass
 from typing import Any
 
@@ -31,3 +42,158 @@ class VerificationError:
 
   def __str__(self) -> str:
     return f'VerificationError on {type(self.op).__name__}: {self.message}'
+
+
+# -----------------------------------------------------------------------------
+# R3 closure check — verify_renderability
+# -----------------------------------------------------------------------------
+
+
+class UnrenderableOpError(Exception):
+  '''An IIR op type has neither a `@register_render(op_type, target=T)`
+  handler nor a `@rewrite(dialect, op_type)` registered.
+
+  Raised by `verify_renderability` post-fixpoint, before the target
+  renderer runs. This is the loud failure that makes adding a new IIR
+  dialect / plugin safe: if the plugin forgot to ship either a renderer
+  for the target or a decomposing rewrite that maps its ops to ones
+  the target understands, this error fires with a precise op-type name
+  and target — long before the renderer's `KeyError` would surface.
+
+  Per docs/concept_glossary.md section 13.6 (the closure invariant) and
+  docs/code_discipline.md R3.
+  '''
+
+  def __init__(self, op_type: type, target: str) -> None:
+    self.op_type = op_type
+    self.target = target
+    module = getattr(op_type, '__module__', '<unknown>')
+    super().__init__(
+      f'no @register_render({op_type.__name__}, target={target!r}) and no '
+      f'@rewrite registration found for op type {op_type.__name__!r} '
+      f'(module={module!r}). Either ship a renderer in '
+      f'codegen/{target}/render/<dialect>.py or register a @rewrite that '
+      f'decomposes this op into ones the target can render.'
+    )
+
+
+def _walk_op_types(tree: Any) -> set[type]:
+  '''Collect every `type(op)` reachable from `tree` by walking
+  dataclass fields. Mirrors `core.strategy._map_children`'s child-
+  discovery rule: an `Op` field is a child, and `list` / `tuple`
+  fields contribute every Op they contain. Non-Op fields are ignored.
+
+  Returns a set of op type objects (Op subclasses).
+  '''
+  # Local import to avoid the framework-init cycle between
+  # verifier.py and ops.py at module-load time.
+  from srdatalog.ir.core.ops import Op
+
+  seen: set[type] = set()
+  stack: list[Any] = [tree]
+  while stack:
+    node = stack.pop()
+    if isinstance(node, Op):
+      seen.add(type(node))
+      # Op subclasses are dataclasses (D2); discover children by
+      # walking their fields. Per the strategy combinator's
+      # convention, an Op-valued field is a child; list/tuple fields
+      # may contain Ops.
+      for f in dataclasses.fields(node):
+        stack.append(getattr(node, f.name))
+    elif isinstance(node, (list, tuple)):
+      stack.extend(node)
+    # Other field shapes (str, int, dict-of-primitives, ...) are ignored.
+  return seen
+
+
+def _renderable_op_types(target: str) -> set[type]:
+  '''Return the set of op classes that have a `@register_render` for
+  `target` in either statement OR expression mode. Currently only
+  target='cuda' is wired into the codebase; other targets fall back
+  to the empty set.
+
+  Per docs/stage3a_execution_plan.md S3A.8, the per-target renderer
+  registry will eventually move onto a per-`Codegen` instance. Until
+  then, the CUDA registry is the module-globals
+  `_STMT_HANDLERS` + `_EXPR_HANDLERS` in `codegen/cuda/render`.
+  '''
+  if target != 'cuda':
+    return set()
+  # Local import to avoid pulling codegen at framework-init time.
+  from srdatalog.ir.codegen.cuda.render import _EXPR_HANDLERS, _STMT_HANDLERS
+
+  return set(_STMT_HANDLERS.keys()) | set(_EXPR_HANDLERS.keys())
+
+
+def _rewritable_op_types(compiler: Any) -> set[type]:
+  '''Return op classes that have a `@rewrite(dialect, op_type)`
+  registered on any of the compiler's dialects. Used as the closure
+  escape hatch: a COMPOUND op without a target renderer still counts
+  as "renderable" if a rewrite decomposes it.
+
+  When `compiler` is None, no per-Compiler rewrites are visible. The
+  caller must also pass a compiler to consult plugin-registered
+  rewrites; without one, only the global render registry gates closure.
+  '''
+  if compiler is None:
+    return set()
+  out: set[type] = set()
+  for d in compiler.dialects:
+    for r in d.rewrites:
+      out.add(r.matches)
+  return out
+
+
+def verify_renderability(
+  tree: Any,
+  *,
+  target: str = 'cuda',
+  compiler: Any = None,
+) -> None:
+  '''Closure check: every op type in `tree` must EITHER have a
+  registered `@register_render(op_type, target=target)` OR a
+  registered `@rewrite(dialect, op_type)` (in which case the rewrite
+  is presumed to decompose the op into ones that close under the
+  same condition — the recursive guarantee R3 makes).
+
+  Walks `tree` once, collecting reachable op types, then verifies
+  each is in the union of the two registries. Raises
+  `UnrenderableOpError` on the first unrenderable op type, naming
+  the op + target so the caller can either:
+
+    (a) ship a renderer at `codegen/<target>/render/<dialect>.py`, or
+    (b) ship a `@rewrite` that decomposes the op into ones the target
+        already renders.
+
+  Args:
+    tree     — the post-fixpoint IIR root (any `Op` subclass).
+    target   — codegen target name. Defaults to 'cuda' (the only
+               wired-in target today). Other targets return the empty
+               renderer set, which means EVERY op must have a
+               rewrite — useful for testing that a non-CUDA target
+               flow degrades gracefully.
+    compiler — optional `Compiler` whose registered dialects'
+               rewrites are consulted as the escape hatch. When None,
+               only the renderer registry is consulted (production
+               pipelines pass the active compiler so plugin-shipped
+               rewrites count).
+
+  Per docs/concept_glossary.md section 13.6 and docs/code_discipline.md
+  R3 — the closure invariant for multi-dialect IIR.
+  '''
+  reachable = _walk_op_types(tree)
+  renderable = _renderable_op_types(target)
+  rewritable = _rewritable_op_types(compiler)
+  closed = renderable | rewritable
+
+  for op_type in reachable:
+    if op_type not in closed:
+      raise UnrenderableOpError(op_type, target)
+
+
+__all__ = [
+  'UnrenderableOpError',
+  'VerificationError',
+  'verify_renderability',
+]

--- a/src/srdatalog/ir/default_pipelines.py
+++ b/src/srdatalog/ir/default_pipelines.py
@@ -298,6 +298,48 @@ class LowerScanPipelineShim(ProgramPass):
     return dataclasses.replace(state, iir=iir)
 
 
+class VerifyRenderabilityShim(ProgramPass):
+  '''R3 closure check (topology check #4 per
+  docs/concept_glossary.md section 13.3).
+
+  Runs `verify_renderability` on the post-fixpoint IIR tree. For every
+  op type reachable in the tree, asserts either a registered
+  `@register_render(op_type, target='cuda')` OR a `@rewrite` is
+  present. On failure, raises `UnrenderableOpError` naming the op
+  type + target — long before the CUDA renderer's own `KeyError`
+  would surface, and with a precise message pointing at the missing
+  plugin contribution.
+
+  Today's IIR rewrite step is conceptual — `LowerScanPipelineShim`
+  produces the final IIR directly. So this shim runs AFTER
+  `LowerScanPipelineShim` (which produces the IIR) and BEFORE
+  `CudaRenderShim` (which consumes it). The shim is structurally a
+  pass-through on `KernelCtx` — it neither inspects nor mutates the
+  state beyond the closure check.
+
+  `consumes=('iir',)` + `produces=()` because the check doesn't
+  introduce a new pseudo-dialect; it's a gate, not a transformation.
+  Per the spec note in `code_discipline.md` R3, this is exactly the
+  "pipeline-stage closure verification" that prevents silent
+  fall-through in `CudaRenderShim`.'''
+
+  def __init__(self) -> None:
+    super().__init__(
+      name='verify_renderability',
+      consumes=('iir',),
+      produces=(),
+      fn=self._fn,
+    )
+
+  @staticmethod
+  def _fn(state: KernelCtx, compiler: Any) -> KernelCtx:
+    from srdatalog.ir.core.verifier import verify_renderability
+
+    assert state.iir is not None, 'VerifyRenderabilityShim: iir not set'
+    verify_renderability(state.iir, target='cuda', compiler=compiler)
+    return state
+
+
 class CudaRenderShim(ProgramPass):
   '''Wraps `srdatalog.ir.codegen.cuda.emit.emit` with an
   `EmitCtx(indent_level=4)`. Concatenates `view_decls` + emitted IIR
@@ -340,6 +382,7 @@ DEFAULT_KERNEL_PIPELINE: list[Pass] = [
   CollectViewSpecsShim(),
   EmitViewDeclsShim(),
   LowerScanPipelineShim(),
+  VerifyRenderabilityShim(),
   CudaRenderShim(),
 ]
 
@@ -358,4 +401,5 @@ __all__ = [
   'LowerScanPipelineShim',
   'MirOptShim',
   'MirProgramAssembly',
+  'VerifyRenderabilityShim',
 ]

--- a/tests/test_default_pipelines_shims.py
+++ b/tests/test_default_pipelines_shims.py
@@ -101,6 +101,7 @@ def test_kernel_pipeline_names_unique_and_ordered():
     'collect_view_specs',
     'emit_view_decls',
     'lower_scan_pipeline',
+    'verify_renderability',
     'cuda_render',
   ]
   assert len(set(names)) == len(names)

--- a/tests/test_verify_renderability.py
+++ b/tests/test_verify_renderability.py
@@ -1,0 +1,361 @@
+'''R3 closure check — `verify_renderability` + `VerifyRenderabilityShim`.
+
+Spec: docs/code_discipline.md R3 + docs/concept_glossary.md section 13.6
+(the closure invariant). Topology check #4 in docs/concept_glossary.md
+section 13.3.
+
+Four shapes covered:
+  1. Smoke: an IIR tree built from production-registered ops passes.
+  2. Negative: a synthetic op with neither @register_render nor a
+     @rewrite raises `UnrenderableOpError` naming the op + target.
+  3. Rewrite escape hatch: registering a @rewrite for an otherwise
+     unrenderable op closes the check.
+  4. Integration: `Compiler.run(KernelCtx, pipeline=DEFAULT_KERNEL_PIPELINE)`
+     on a TC fixture passes (because every op renders); inserting a
+     fake shim that produces an unrenderable op raises at the
+     `VerifyRenderabilityShim` step, BEFORE `CudaRenderShim` runs.
+'''
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+import pytest
+
+import srdatalog.ir.mir.types as mir
+from srdatalog.dsl import Program, Relation, Var
+from srdatalog.ir.core import (
+  Compiler,
+  Dialect,
+  Op,
+  ProgramPass,
+  UnrenderableOpError,
+  verify_renderability,
+)
+from srdatalog.ir.core.passes import rewrite
+from srdatalog.ir.default_pipelines import (
+  DEFAULT_KERNEL_PIPELINE,
+  DEFAULT_PROGRAM_PIPELINE,
+  InitialProg,
+  KernelCtx,
+  VerifyRenderabilityShim,
+)
+from srdatalog.ir.dialects.iir.cf.ops import Block, RawString, VarRef
+
+# -----------------------------------------------------------------------------
+# Synthetic op fixtures (NOT registered in any production renderer)
+# -----------------------------------------------------------------------------
+
+
+@dataclass(frozen=True, slots=True)
+class _SyntheticUnrenderableOp(Op):
+  '''An op type that no production renderer claims. Used to drive the
+  negative path of `verify_renderability`.
+
+  Carries one child Op so we can also test the walker's recursion into
+  nested unrenderable subtrees.'''
+
+  payload: str
+  child: Op | None = None
+
+
+@dataclass(frozen=True, slots=True)
+class _SyntheticLeaf(Op):
+  '''Companion leaf for `_SyntheticUnrenderableOp`. Also unrenderable
+  unless a rewrite is registered.'''
+
+  name: str
+
+
+# -----------------------------------------------------------------------------
+# Fixtures
+# -----------------------------------------------------------------------------
+
+
+def _tc_program() -> Program:
+  '''Tiny TC-style program: ArcInput -> Edge, Edge -> Path (base + rec).
+  Same fixture as test_default_pipelines_shims.py and test_f5_acceptance.py.'''
+  X, Y, Z = Var('x'), Var('y'), Var('z')
+  arc = Relation('ArcInput', 2)
+  edge = Relation('Edge', 2)
+  path = Relation('Path', 2)
+  return Program(
+    rules=[
+      (edge(X, Y) <= arc(X, Y)).named('EdgeLoad'),
+      (path(X, Y) <= edge(X, Y)).named('TCBase'),
+      (path(X, Z) <= path(X, Y) & edge(Y, Z)).named('TCRec'),
+    ],
+  )
+
+
+def _find_execute_pipelines(node: object) -> list[mir.ExecutePipeline]:
+  out: list[mir.ExecutePipeline] = []
+  if isinstance(node, mir.ExecutePipeline):
+    out.append(node)
+  elif isinstance(node, mir.FixpointPlan):
+    for inst in node.instructions:
+      out.extend(_find_execute_pipelines(inst))
+  elif isinstance(node, mir.ParallelGroup):
+    for op in node.ops:
+      out.extend(_find_execute_pipelines(op))
+  return out
+
+
+def _first_ep(mir_prog: mir.Program) -> mir.ExecutePipeline:
+  for step, _is_rec in mir_prog.steps:
+    eps = _find_execute_pipelines(step)
+    if eps:
+      return eps[0]
+  raise AssertionError('no ExecutePipeline in mir_prog')
+
+
+def _real_iir_tree() -> object:
+  '''Build a production IIR tree by running the kernel pipeline up to
+  (but not including) the renderability check. Returns the populated
+  `iir` field — guaranteed to consist only of registered op types.'''
+  compiler = Compiler.with_default_plugins()
+  prog_state = compiler.run(InitialProg(program=_tc_program()), pipeline=DEFAULT_PROGRAM_PIPELINE)
+  assert prog_state.mir_program is not None
+  ep = _first_ep(prog_state.mir_program)
+  # Run kernel pipeline up through LowerScanPipelineShim (inclusive)
+  # — i.e. everything BEFORE the gate we're testing. This avoids
+  # recursion (we're literally building the fixture the gate consumes).
+  partial_pipeline = []
+  for p in DEFAULT_KERNEL_PIPELINE:
+    if p.name == 'verify_renderability':
+      break
+    partial_pipeline.append(p)
+  state = compiler.run(KernelCtx(ep=ep, is_counting=False), pipeline=partial_pipeline)
+  assert state.iir is not None
+  return state.iir
+
+
+# -----------------------------------------------------------------------------
+# 1. Smoke: production IIR tree passes
+# -----------------------------------------------------------------------------
+
+
+def test_verify_renderability_passes_on_production_iir():
+  '''An IIR tree built from the TC fixture contains only ops that
+  every production renderer registers. The check returns None
+  (no exception).'''
+  tree = _real_iir_tree()
+  # No exception = success. Pass `compiler` to mirror production
+  # call site in `VerifyRenderabilityShim`.
+  compiler = Compiler.with_default_plugins()
+  assert verify_renderability(tree, target='cuda', compiler=compiler) is None
+
+
+def test_verify_renderability_passes_on_minimal_block():
+  '''The simplest renderable tree — a `Block` of a `RawString`. Both
+  classes are registered in `codegen/cuda/render/iir_cf.py`. Closure
+  check must pass without a Compiler.'''
+  tree = Block(stmts=(RawString(text='int x = 0;'),))
+  # Without a compiler — only the global render registry gates.
+  assert verify_renderability(tree, target='cuda') is None
+
+
+def test_verify_renderability_passes_on_var_ref_expression():
+  '''VarRef is registered in expr mode only — the closure check counts
+  expression-mode handlers as renderable even though they don't
+  appear in the statement-mode dispatch path.'''
+  tree = VarRef(name='x')
+  assert verify_renderability(tree, target='cuda') is None
+
+
+# -----------------------------------------------------------------------------
+# 2. Negative: synthetic unrenderable op raises
+# -----------------------------------------------------------------------------
+
+
+def test_verify_renderability_raises_on_synthetic_unrenderable_op():
+  '''A tree rooted at a synthetic op with no @register_render and no
+  @rewrite raises `UnrenderableOpError` naming both the op type and
+  the target.'''
+  tree = _SyntheticUnrenderableOp(payload='nope', child=None)
+  with pytest.raises(UnrenderableOpError) as excinfo:
+    verify_renderability(tree, target='cuda')
+  err = excinfo.value
+  assert err.op_type is _SyntheticUnrenderableOp
+  assert err.target == 'cuda'
+  # Message must name the op + target so the failure is actionable.
+  msg = str(err)
+  assert '_SyntheticUnrenderableOp' in msg
+  assert "'cuda'" in msg
+
+
+def test_verify_renderability_raises_on_nested_unrenderable_op():
+  '''A renderable root that contains an unrenderable child still
+  raises — the check is closure over the entire tree, not just the
+  root. Here `Block` is renderable but `_SyntheticUnrenderableOp`
+  (nested two levels deep) is not.'''
+  inner = _SyntheticUnrenderableOp(payload='nested', child=None)
+  tree = Block(stmts=(RawString(text='ok'), inner))
+  with pytest.raises(UnrenderableOpError) as excinfo:
+    verify_renderability(tree, target='cuda')
+  assert excinfo.value.op_type is _SyntheticUnrenderableOp
+
+
+def test_verify_renderability_raises_on_unknown_target():
+  '''Asking for a target that has no registered renderers fails on the
+  first renderable-but-only-via-cuda op. This exercises the "other
+  target degrades gracefully" branch — useful for plugin authors
+  scaffolding a non-CUDA backend.'''
+  tree = Block(stmts=(RawString(text='hi'),))
+  with pytest.raises(UnrenderableOpError) as excinfo:
+    verify_renderability(tree, target='metal')
+  # First reachable op type (deterministic from set iteration order
+  # isn't guaranteed; just assert SOMETHING reachable raised).
+  assert excinfo.value.target == 'metal'
+  assert excinfo.value.op_type in (Block, RawString)
+
+
+# -----------------------------------------------------------------------------
+# 3. Rewrite escape hatch
+# -----------------------------------------------------------------------------
+
+
+def test_rewrite_closes_an_otherwise_unrenderable_op():
+  '''If a @rewrite is registered on a Dialect for an op type, the
+  closure check treats that op as renderable (the rewrite is presumed
+  to decompose it into ops that are themselves closed). Without the
+  Compiler, the SAME tree raises — with the Compiler, it passes.
+  '''
+  # Set up: a synthetic dialect with a rewrite registered for
+  # _SyntheticLeaf. The rewrite body is a no-op identity (the
+  # closure check doesn't actually invoke rewrites — it only consults
+  # the REGISTRATION).
+  dialect = Dialect(name='test.synthetic.rewrite_close')
+
+  @rewrite(dialect, _SyntheticLeaf)
+  def _identity_rewrite(op, _compiler):
+    return op
+
+  compiler = Compiler()
+  compiler.register_dialect(dialect)
+
+  tree = _SyntheticLeaf(name='x')
+
+  # Without the compiler: only the render registry counts → raises.
+  with pytest.raises(UnrenderableOpError):
+    verify_renderability(tree, target='cuda')
+
+  # With the compiler: the rewrite registration closes the op type.
+  assert verify_renderability(tree, target='cuda', compiler=compiler) is None
+
+
+# -----------------------------------------------------------------------------
+# 4. Integration: VerifyRenderabilityShim in DEFAULT_KERNEL_PIPELINE
+# -----------------------------------------------------------------------------
+
+
+def test_verify_renderability_shim_is_between_lower_scan_and_cuda_render():
+  '''Pipeline shape contract: the gate runs AFTER LowerScanPipelineShim
+  (which produces IIR) and BEFORE CudaRenderShim (which consumes it).'''
+  names = [p.name for p in DEFAULT_KERNEL_PIPELINE]
+  i_lower = names.index('lower_scan_pipeline')
+  i_verify = names.index('verify_renderability')
+  i_render = names.index('cuda_render')
+  assert i_lower < i_verify < i_render
+
+
+def test_verify_renderability_shim_is_a_pass_through():
+  '''The shim is a gate, not a transformation. It returns the
+  KernelCtx unchanged on success.'''
+  compiler = Compiler.with_default_plugins()
+  prog_state = compiler.run(InitialProg(program=_tc_program()), pipeline=DEFAULT_PROGRAM_PIPELINE)
+  assert prog_state.mir_program is not None
+  ep = _first_ep(prog_state.mir_program)
+
+  partial_pipeline = []
+  for p in DEFAULT_KERNEL_PIPELINE:
+    if p.name == 'verify_renderability':
+      break
+    partial_pipeline.append(p)
+  state = compiler.run(KernelCtx(ep=ep, is_counting=False), pipeline=partial_pipeline)
+
+  out = VerifyRenderabilityShim().apply(state, compiler)
+  assert out is state  # pass-through
+
+
+def test_default_kernel_pipeline_runs_end_to_end_with_gate():
+  '''The full DEFAULT_KERNEL_PIPELINE (now including the gate) runs
+  cleanly on a TC fixture. This is the regression guard for "every
+  op type in production IIR has a renderer".'''
+  compiler = Compiler.with_default_plugins()
+  prog_state = compiler.run(InitialProg(program=_tc_program()), pipeline=DEFAULT_PROGRAM_PIPELINE)
+  assert prog_state.mir_program is not None
+  ep = _first_ep(prog_state.mir_program)
+  out = compiler.run(KernelCtx(ep=ep, is_counting=False), pipeline=DEFAULT_KERNEL_PIPELINE)
+  assert isinstance(out.body_text, str)
+  assert len(out.body_text) > 0
+
+
+def test_kernel_pipeline_with_injected_unrenderable_op_raises_at_gate():
+  '''Negative integration: insert a shim that REPLACES the IIR with a
+  tree containing an unrenderable synthetic op. The pipeline must
+  raise `UnrenderableOpError` at `VerifyRenderabilityShim` — BEFORE
+  `CudaRenderShim` runs (which would otherwise hit its own KeyError).
+
+  The injected shim consumes 'iir' and produces 'iir' so the pipeline
+  ordering check still passes; only the closure check fires.'''
+  import dataclasses
+
+  class _InjectUnrenderable(ProgramPass):
+    def __init__(self) -> None:
+      super().__init__(
+        name='inject_unrenderable',
+        consumes=('iir',),
+        produces=('iir',),
+        fn=self._fn,
+      )
+
+    @staticmethod
+    def _fn(state: KernelCtx, _compiler):
+      return dataclasses.replace(
+        state, iir=_SyntheticUnrenderableOp(payload='injected', child=None)
+      )
+
+  compiler = Compiler.with_default_plugins()
+  prog_state = compiler.run(InitialProg(program=_tc_program()), pipeline=DEFAULT_PROGRAM_PIPELINE)
+  assert prog_state.mir_program is not None
+  ep = _first_ep(prog_state.mir_program)
+
+  # Build a pipeline that injects the unrenderable op AFTER
+  # LowerScanPipelineShim but BEFORE the gate. The gate must catch it.
+  inject = _InjectUnrenderable()
+  patched: list = []
+  for p in DEFAULT_KERNEL_PIPELINE:
+    patched.append(p)
+    if p.name == 'lower_scan_pipeline':
+      patched.append(inject)
+
+  with pytest.raises(UnrenderableOpError) as excinfo:
+    compiler.run(KernelCtx(ep=ep, is_counting=False), pipeline=patched)
+  assert excinfo.value.op_type is _SyntheticUnrenderableOp
+  assert excinfo.value.target == 'cuda'
+
+
+def test_verify_renderability_shim_consumes_iir_produces_nothing():
+  '''Pipeline-data contract: the gate consumes the iir dialect produced
+  by LowerScanPipelineShim. Because it doesn't introduce a new
+  pseudo-dialect, `produces=()`.'''
+  shim = VerifyRenderabilityShim()
+  assert shim.consumes == ('iir',)
+  assert shim.produces == ()
+
+
+if __name__ == '__main__':
+  test_verify_renderability_passes_on_production_iir()
+  test_verify_renderability_passes_on_minimal_block()
+  test_verify_renderability_passes_on_var_ref_expression()
+  test_verify_renderability_raises_on_synthetic_unrenderable_op()
+  test_verify_renderability_raises_on_nested_unrenderable_op()
+  test_verify_renderability_raises_on_unknown_target()
+  test_rewrite_closes_an_otherwise_unrenderable_op()
+  test_verify_renderability_shim_is_between_lower_scan_and_cuda_render()
+  test_verify_renderability_shim_is_a_pass_through()
+  test_default_kernel_pipeline_runs_end_to_end_with_gate()
+  test_kernel_pipeline_with_injected_unrenderable_op_raises_at_gate()
+  test_verify_renderability_shim_consumes_iir_produces_nothing()
+  print('OK')


### PR DESCRIPTION
## Summary
Closes the composable-IR axis to 100% — adds the renderability closure check from `docs/concept_glossary.md` § 13.6 and wires it into the kernel pipeline.

## What lands
- `UnrenderableOpError(Exception)` in `core/verifier.py` — descriptive error with `op_type` + `target` attrs
- `verify_renderability(tree, *, target='cuda', compiler=None)` — walks IIR tree; for each reachable op type, checks renderer OR rewrite is registered; raises if neither
- `VerifyRenderabilityShim(ProgramPass)` — inserted into `DEFAULT_KERNEL_PIPELINE` between `LowerScanPipelineShim` (produces `'iir'`) and `CudaRenderShim` (consumes `'iir'`). `consumes=('iir',)`, `produces=()` — gate, not transformation. Pass-through on success.

## Implementation notes
- **Render side**: for `target='cuda'`, reads `_STMT_HANDLERS ∪ _EXPR_HANDLERS` from `srdatalog.ir.codegen.cuda.render` (the `@register_render` populated module-globals). Other targets fall back to empty set (graceful degradation for non-CUDA plugin authors).
- **Rewrite side**: when `compiler` passed, walks `compiler.dialects` and collects `Rewrite.matches` from each `dialect.rewrites`. When `compiler=None`, only renderer registry gates (caller-controlled strictness).
- **Tree walk**: dataclass-field traversal mirroring `core.strategy._map_children`.
- Function only consults registrations; doesn't invoke them.

## Test plan
- [x] 12 new tests (~315 LOC): smoke (production TC IIR + minimal Block/RawString + VarRef-only), negative (synthetic unrenderable + nested + unknown target), rewrite escape hatch, pipeline shape, full DEFAULT_KERNEL_PIPELINE integration, fake-shim injection that triggers the gate (not CudaRender's `KeyError`)
- [x] Targeted suites (`test_verify_renderability` + `test_default_pipelines_shims` + `test_f5_acceptance`): 41 passed
- [x] Full suite: 1583 passed, 5 skipped
- [x] Byte-equivalence: 532 passed + 2 skipped (production fixtures unchanged)
- [x] sphinx -W + ruff check + format (CI v0.9.10): clean
- [x] mypy on touched files: clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)