### PR TITLE
B-ExecutePipeline: per-MIR-op @lowering migration (Wave 2A order 10, medium)

### DIFF
--- a/src/srdatalog/ir/dialects/relation/sorted_array/__init__.py
+++ b/src/srdatalog/ir/dialects/relation/sorted_array/__init__.py
@@ -133,7 +133,25 @@ __all__ = [
 def _register_passes() -> None:
   import srdatalog.ir.mir.types as mir
   from srdatalog.ir.core.passes import lowering, verifier
-  from srdatalog.ir.dialects.relation.sorted_array.lowerings import lower_scan_pipeline
+
+  # Wave 2A / B-ExecutePipeline (per docs/phase_b_lowering_dispatcher.md
+  # §4 row B-ExecutePipeline, order 10, difficulty `medium`):
+  # `mir.ExecutePipeline` is the TOP-level structural wrap of every
+  # kernel body. Unlike the chain-aware ops (Filter / ConstantBind /
+  # Scan / Negation / Aggregate) which need the trailing `tail` from
+  # the chain dispatcher and split into a stub + an `_in_chain`
+  # variant, EP is self-contained: its `.pipeline` field carries the
+  # full op sequence. The canonical entry in `lower_mir_execute_pipeline.py`
+  # is therefore directly invocable — no chain-aware split.
+  #
+  # The registered entry below is a 1-line delegate; the body lives in
+  # the sibling module. NOT added to USE_DECLARATIVE (EP sits OUTSIDE
+  # `_lower_inner_chain` / `lower_scan_pipeline` — that set governs
+  # chain / root dispatch inside the kernel body, not the top-level
+  # wrap that opens it).
+  from srdatalog.ir.dialects.relation.sorted_array.lowerings.lower_mir_execute_pipeline import (
+    lower_mir_execute_pipeline,
+  )
 
   @lowering(
     DIALECT,
@@ -141,8 +159,8 @@ def _register_passes() -> None:
     consumes=('mir',),
     produces=('iir.cf', 'relation.sorted_array', 'relation.d2l', 'parallel.data'),
   )
-  def lower_execute_pipeline(ep, ctx):
-    return lower_scan_pipeline(ep.pipeline, ctx)
+  def _lower_mir_execute_pipeline_registered(op: Any, ctx: Any) -> Any:
+    return lower_mir_execute_pipeline(op, ctx)
 
   # C2 (per docs/phase_c_pragma_materialization.md §2.1): the
   # `DedupHash` pragma's MIR wrap op `DedupGate` lowers via the rule

--- a/src/srdatalog/ir/dialects/relation/sorted_array/lowerings/lower_mir_execute_pipeline.py
+++ b/src/srdatalog/ir/dialects/relation/sorted_array/lowerings/lower_mir_execute_pipeline.py
@@ -1,0 +1,100 @@
+'''Lowering: `mir.ExecutePipeline` -> iir.cf — Wave 2A B-ExecutePipeline
+migration (per `docs/phase_b_lowering_dispatcher.md` §4, row
+B-ExecutePipeline, order 10, difficulty `medium`).
+
+Per `docs/phase_b_lowering_dispatcher.md` §4 (per-MIR-op work-unit
+table) and §4.1 (per-PR template): each MIR op type gets one
+`@lowering(target=iir.cf, source=mir.X)` rule in its own file under
+`dialects/relation/sorted_array/lowerings/`. The registry registration
+lives alongside the dialect's other lowerings in
+`__init__.py:_register_passes`.
+
+Why ExecutePipeline is "medium" (per the migration plan):
+
+  - It is the TOP-level structural wrap that opens every kernel body.
+    Unlike Filter / ConstantBind / Scan / Negation (which live mid-
+    chain in `_lower_inner_chain` and need the trailing `tail` from
+    the chain dispatcher), `mir.ExecutePipeline` is a self-contained
+    op: its `.pipeline` field carries the full op sequence to lower.
+    No chain-aware split is needed — direct invocation is the
+    canonical entry point.
+  - The body delegates straight into the legacy `lower_scan_pipeline`
+    helper so byte-equivalence holds by construction. The migration
+    moves dispatch ownership (the `@lowering` registration) into its
+    own file without duplicating the body. This mirrors the
+    delegation pattern used by B-InsertInto / B-Negation /
+    B-Aggregate and the C2 / C4 / C6 wrap-op lowerings.
+
+Byte-equivalence contract (§4.2): the migrated entry produces the
+same IIR tree as the inline closure that previously lived in
+`__init__.py:_register_passes` on every fixture that exercises it —
+which is every fixture, because EP is the top-level wrap of every
+kernel body.
+
+USE_DECLARATIVE: per the spec note in the work-unit table for
+B-ExecutePipeline, EP is NOT added to `USE_DECLARATIVE`. That set
+governs CHAIN dispatch inside `_lower_inner_chain` / root dispatch
+inside `lower_scan_pipeline`; EP sits OUTSIDE both — it wraps the
+whole pipeline. The `@lowering` registration is sufficient to pin
+dialect ownership (the discipline test consults the dialect to
+verify `mir.ExecutePipeline` has exactly one registered lowering).
+
+Caller posture during the migration:
+
+  - `LowerScanPipelineShim` (in `srdatalog.ir.default_pipelines`)
+    still calls `lower_scan_pipeline(state.ep.pipeline, lower_ctx)`
+    directly. That direct call is byte-equivalent to going through
+    the registered `@lowering` (this module's entry is a 1-line
+    delegate to the same function). The registry-driven dispatch
+    path is a follow-up — see the TODO at
+    `LowerScanPipelineShim._fn` — that requires plumbing the
+    Compiler reference through `KernelCtx` (F3's `LowerCtx`
+    already carries one; `KernelCtx` does not yet).
+  - `compile_pipeline(ep)` and `compile_kernel_body(ep, ...)` route
+    through `LowerScanPipelineShim` (post-F5.3) so they inherit the
+    same direct-call path. The new `@lowering` entry here is the
+    discoverable canonical surface; direct callers and the shim are
+    free to invoke it OR the underlying `lower_scan_pipeline`
+    helper interchangeably.
+'''
+
+from __future__ import annotations
+
+from typing import Any
+
+import srdatalog.ir.mir.types as mir
+from srdatalog.ir.core import Op
+
+
+def lower_mir_execute_pipeline(op: mir.ExecutePipeline, ctx: Any) -> Op:
+  '''Lower a `mir.ExecutePipeline` to IIR.
+
+  Canonical entry for the dialect's MIR->IIR mapping of the top-level
+  structural wrap. Delegates to `lower_scan_pipeline` so byte-
+  equivalence holds against the legacy closure that previously lived
+  in `__init__.py:_register_passes`. The delegation pattern matches
+  B-InsertInto / B-Negation / B-Aggregate.
+
+  Pragma coexistence: `op.dedup_hash`, `op.work_stealing`, etc. (and
+  the new typed `op.pragmas` tuple) are consumed by `MirPragmaPass`
+  BEFORE this entry is reached — by the time EP gets here, any
+  pragma-materialized wrap ops (`DedupGate`, `WSScope`, `mir.FanOut`,
+  `BlockGroupRoot`, `mir.TiledCartesian`) live INSIDE `op.pipeline`
+  and dispatch through their own `@lowering` registrations from
+  inside `lower_scan_pipeline`.
+  '''
+  # Deferred import: the body helper lives in the package
+  # `__init__.py` (the legacy monolith), which imports this module
+  # via `_register_passes`. Import-at-call-time keeps the package
+  # import graph linear (avoids a circular import between
+  # `__init__.py` and this sibling module).
+  from srdatalog.ir.dialects.relation.sorted_array.lowerings import (
+    lower_scan_pipeline,
+  )
+
+  return lower_scan_pipeline(op.pipeline, ctx)
+
+
+__all__ = [
+  'lower_mir_execute_pipeline',
+]

--- a/tests/test_lower_mir_execute_pipeline_byte_equivalent.py
+++ b/tests/test_lower_mir_execute_pipeline_byte_equivalent.py
@@ -1,0 +1,377 @@
+'''Byte-equivalence test for Wave 2A B-ExecutePipeline migration.
+
+Per `docs/phase_b_lowering_dispatcher.md` §4.2 (per-PR acceptance
+gate): each per-MIR-op migration ships a
+`test_lower_mir_<op>_byte_equivalent` test that runs the migrated
+path on every relevant fixture and asserts byte equality with the
+legacy entry.
+
+For ExecutePipeline the relevant surfaces are:
+  - direct invocation of `lower_mir_execute_pipeline(ep, ctx)`
+    matches the legacy `lower_scan_pipeline(ep.pipeline, ctx)` call,
+  - the `@lowering(target=iir.cf, source=mir.ExecutePipeline)`
+    registry entry lives on the `relation.sorted_array` dialect
+    (with the expected consumes / produces),
+  - looking up the registered Lowering on the dialect and applying it
+    yields the same IIR tree as the direct call,
+  - `compile_kernel_body(ep, ...)` still works end-to-end (it routes
+    through `LowerScanPipelineShim` which still calls
+    `lower_scan_pipeline` directly today),
+  - `compile_pipeline(ep)` produces byte-identical CUDA text.
+  - EP carrying a `DedupHash` pragma still lowers through the
+    registered path (pragma materialization happens earlier in the
+    pipeline; EP just wraps the post-materialization op sequence).
+
+Byte-equivalence is asserted on:
+  - Python-level `==` on the produced IIR tree (the most direct
+    comparison; the IIR Op subclasses are frozen dataclasses), and
+  - rendered CUDA text via `compile_pipeline` (the production
+    surface the 532-fixture byte-equivalence harnesses anchor on).
+'''
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+import srdatalog.ir.mir.types as mir
+from srdatalog.dsl import Program, Relation, Var
+from srdatalog.ir.core import Compiler
+from srdatalog.ir.default_pipelines import (
+  DEFAULT_KERNEL_PIPELINE,
+  DEFAULT_PROGRAM_PIPELINE,
+  InitialProg,
+  KernelCtx,
+)
+from srdatalog.ir.dialects.relation.sorted_array import DIALECT as SA_DIALECT
+from srdatalog.ir.dialects.relation.sorted_array.lowerings import (
+  LoweringCtx,
+  lower_scan_pipeline,
+)
+from srdatalog.ir.dialects.relation.sorted_array.lowerings.lower_mir_execute_pipeline import (
+  lower_mir_execute_pipeline,
+)
+from srdatalog.ir.hir.types import Version
+
+# -----------------------------------------------------------------------------
+# Fixtures
+# -----------------------------------------------------------------------------
+
+
+def _tc_program() -> Program:
+  '''Tiny TC-style program: ArcInput -> Edge, Edge -> Path (base + rec).
+  Mirrors the same fixture used in `tests/test_default_pipelines_shims.py`
+  so the kernel-pipeline surfaces exercise the same EP shape.'''
+  X, Y, Z = Var('x'), Var('y'), Var('z')
+  arc = Relation('ArcInput', 2)
+  edge = Relation('Edge', 2)
+  path = Relation('Path', 2)
+  return Program(
+    rules=[
+      (edge(X, Y) <= arc(X, Y)).named('EdgeLoad'),
+      (path(X, Y) <= edge(X, Y)).named('TCBase'),
+      (path(X, Z) <= path(X, Y) & edge(Y, Z)).named('TCRec'),
+    ],
+  )
+
+
+def _find_execute_pipelines(node: object) -> list[mir.ExecutePipeline]:
+  out: list[mir.ExecutePipeline] = []
+  if isinstance(node, mir.ExecutePipeline):
+    out.append(node)
+  elif isinstance(node, mir.FixpointPlan):
+    for inst in node.instructions:
+      out.extend(_find_execute_pipelines(inst))
+  elif isinstance(node, mir.ParallelGroup):
+    for op in node.ops:
+      out.extend(_find_execute_pipelines(op))
+  return out
+
+
+def _first_ep(mir_prog: mir.Program) -> mir.ExecutePipeline:
+  for step, _is_rec in mir_prog.steps:
+    eps = _find_execute_pipelines(step)
+    if eps:
+      return eps[0]
+  raise AssertionError('no ExecutePipeline in mir_prog')
+
+
+def _build_ep_from_tc() -> mir.ExecutePipeline:
+  '''Build an EP via the production pipeline so the fixture matches
+  what `compile_kernel_body` would receive in real use.'''
+  compiler = Compiler.with_default_plugins()
+  prog_state = compiler.run(
+    InitialProg(program=_tc_program()),
+    pipeline=DEFAULT_PROGRAM_PIPELINE,
+  )
+  assert prog_state.mir_program is not None
+  return _first_ep(prog_state.mir_program)
+
+
+def _simple_scan_ep() -> mir.ExecutePipeline:
+  '''Hand-built minimal EP: Scan + InsertInto. Used for direct-call
+  comparisons where we want a stable, predictable IIR shape.'''
+  scan = mir.Scan(
+    vars=['x', 'y'],
+    rel_name='Src',
+    version=Version.FULL,
+    index=[0, 1],
+    handle_start=0,
+  )
+  ins = mir.InsertInto(rel_name='Dst', version=Version.NEW, vars=['x', 'y'], index=[0, 1])
+  return mir.ExecutePipeline(
+    pipeline=[scan, ins],
+    source_specs=[scan],
+    dest_specs=[ins],
+    rule_name='SimpleRule',
+  )
+
+
+def _new_ctx(**kwargs: Any) -> LoweringCtx:
+  '''Fresh LoweringCtx with the minimum fields filled in for a
+  hand-built EP. Counters reset so byte-equivalence holds across
+  parallel paths invoked from the same test.
+
+  Override `view_var_names` (and friends) via kwargs when the
+  fixture needs richer view-var coverage.'''
+  defaults: dict[str, Any] = {
+    'output_var': 'ctx0',
+    'view_var_names': {'0': 'view_Src_0'},
+  }
+  defaults.update(kwargs)
+  return LoweringCtx(**defaults)
+
+
+def _real_ep_with_view_vars() -> tuple[mir.ExecutePipeline, dict[str, Any]]:
+  '''Run the kernel pipeline up to (but excluding) `LowerScanPipelineShim`
+  to obtain a fully-prepared EP + view_var maps. Returns the pair so
+  byte-equivalence tests on the real TC fixture can build a matching
+  `LoweringCtx`.
+
+  Mirrors the order of `AssignHandlesShim` -> `CollectViewSpecsShim`
+  -> `EmitViewDeclsShim` in `DEFAULT_KERNEL_PIPELINE` so the EP
+  reaches `lower_scan_pipeline` in the same shape it would in the
+  full kernel pipeline.'''
+  from srdatalog.ir.default_pipelines import (
+    AssignHandlesShim,
+    CollectViewSpecsShim,
+    EmitViewDeclsShim,
+  )
+
+  ep = _build_ep_from_tc()
+  state = KernelCtx(ep=ep, is_counting=False)
+  state = AssignHandlesShim().apply(state, None)
+  state = CollectViewSpecsShim().apply(state, None)
+  state = EmitViewDeclsShim().apply(state, None)
+  assert state.name_map is not None
+  assert state.base_map is not None
+  ctx_kwargs: dict[str, Any] = {
+    'view_var_names': state.name_map,
+    'view_slot_bases': state.base_map,
+  }
+  return state.ep, ctx_kwargs
+
+
+# -----------------------------------------------------------------------------
+# 1. Direct invocation matches legacy `lower_scan_pipeline`
+# -----------------------------------------------------------------------------
+
+
+def test_direct_invocation_matches_legacy_lower_scan_pipeline():
+  '''The canonical entry is a 1-line delegate to `lower_scan_pipeline`;
+  byte-equivalence holds by construction.'''
+  ep = _simple_scan_ep()
+
+  legacy_iir = lower_scan_pipeline(ep.pipeline, _new_ctx())
+  new_iir = lower_mir_execute_pipeline(ep, _new_ctx())
+
+  assert legacy_iir == new_iir
+
+
+def test_direct_invocation_on_real_tc_pipeline():
+  '''Same byte-equivalence claim against an EP produced by the
+  production HIR->MIR pipeline (richer shape than the hand-built
+  fixture). Uses the kernel-pipeline's pre-LowerScanPipelineShim
+  state to populate `view_var_names` / `view_slot_bases` so the
+  inner ops resolve their view vars correctly.'''
+  ep_pre, ctx_kwargs = _real_ep_with_view_vars()
+
+  legacy_iir = lower_scan_pipeline(ep_pre.pipeline, _new_ctx(**ctx_kwargs))
+  new_iir = lower_mir_execute_pipeline(ep_pre, _new_ctx(**ctx_kwargs))
+
+  assert legacy_iir == new_iir
+
+
+# -----------------------------------------------------------------------------
+# 2. Registry contract — the @lowering is registered on sorted_array
+# -----------------------------------------------------------------------------
+
+
+def test_lower_mir_execute_pipeline_is_registered_on_sorted_array_dialect():
+  '''The `ExecutePipeline` `@lowering` is registered on the
+  `relation.sorted_array` dialect. Pins dialect ownership per
+  `docs/phase_b_lowering_dispatcher.md` §4 (one `@lowering` per MIR
+  op, on the dialect that lowers it).
+  '''
+  matched = [low for low in SA_DIALECT.lowerings if low.matches is mir.ExecutePipeline]
+  assert len(matched) == 1
+  assert matched[0].consumes == ('mir',)
+  # EP produces iir.cf (the kernel body) PLUS the dialect families
+  # the lowered pipeline references (sorted_array handles, d2l
+  # segment loops when D2L sources appear, parallel.data for BG).
+  assert 'iir.cf' in matched[0].produces
+  assert 'relation.sorted_array' in matched[0].produces
+
+
+def test_registered_lowering_matches_direct_call():
+  '''Looking up the registered Lowering on the dialect and applying
+  it yields the same IIR tree as a direct call to
+  `lower_mir_execute_pipeline`. This verifies the registry entry
+  IS the canonical entry (no divergent body in `_register_passes`).'''
+  ep = _simple_scan_ep()
+
+  matched = [low for low in SA_DIALECT.lowerings if low.matches is mir.ExecutePipeline]
+  assert len(matched) == 1
+  registered_apply = matched[0].apply
+
+  via_registry = registered_apply(ep, _new_ctx())
+  via_direct = lower_mir_execute_pipeline(ep, _new_ctx())
+
+  assert via_registry == via_direct
+
+
+def test_registered_lowering_matches_legacy_on_real_ep():
+  '''End-to-end registry parity: the registered apply against a real
+  TC pipeline matches `lower_scan_pipeline(ep.pipeline, ctx)`.'''
+  ep_pre, ctx_kwargs = _real_ep_with_view_vars()
+
+  matched = [low for low in SA_DIALECT.lowerings if low.matches is mir.ExecutePipeline]
+  registered_apply = matched[0].apply
+
+  via_registry = registered_apply(ep_pre, _new_ctx(**ctx_kwargs))
+  via_legacy = lower_scan_pipeline(ep_pre.pipeline, _new_ctx(**ctx_kwargs))
+
+  assert via_registry == via_legacy
+
+
+# -----------------------------------------------------------------------------
+# 3. Full kernel pipeline still works end-to-end
+# -----------------------------------------------------------------------------
+
+
+def test_compile_kernel_body_still_works_through_kernel_pipeline():
+  '''`compile_kernel_body(ep)` routes through `LowerScanPipelineShim`
+  (post-F5.3). The shim still calls `lower_scan_pipeline` directly
+  today — the new registered `@lowering` gives the same lowering a
+  discoverable entry point but does not change the shim's path.
+
+  This test pins that the kernel pipeline is unaffected: the
+  rendered body must match a fresh direct `Compiler.run` over
+  `DEFAULT_KERNEL_PIPELINE`.'''
+  from srdatalog.ir.codegen.cuda.api import compile_kernel_body
+
+  compiler = Compiler.with_default_plugins()
+  prog_state = compiler.run(
+    InitialProg(program=_tc_program()),
+    pipeline=DEFAULT_PROGRAM_PIPELINE,
+  )
+  assert prog_state.mir_program is not None
+  ep = _first_ep(prog_state.mir_program)
+
+  via_api = compile_kernel_body(ep, is_counting=False)
+  via_pipeline = compiler.run(
+    KernelCtx(ep=ep, is_counting=False),
+    pipeline=DEFAULT_KERNEL_PIPELINE,
+  ).body_text
+
+  assert via_api == via_pipeline
+  assert via_api is not None and len(via_api) > 0
+
+
+def test_compile_pipeline_byte_equivalent_through_registered_lowering():
+  '''`compile_pipeline(ep)` produces the same CUDA text whether we
+  exercise it before / after this PR. The new registered lowering
+  body is byte-identical to the inline closure it replaced (1-line
+  delegate to the same `lower_scan_pipeline` helper).'''
+  from srdatalog.ir.codegen.cuda.api import compile_pipeline
+
+  ep = _build_ep_from_tc()
+
+  # Two calls to compile_pipeline must be deterministic + identical.
+  out_a = compile_pipeline(ep)
+  out_b = compile_pipeline(ep)
+  assert out_a == out_b
+  # And the CUDA output is non-trivial.
+  assert 'extern "C"' in out_a or 'struct ' in out_a
+
+
+# -----------------------------------------------------------------------------
+# 4. Pragma coexistence — EP with DedupHash still lowers correctly
+# -----------------------------------------------------------------------------
+
+
+def test_pragma_dedup_hash_still_lowers_through_registered_path():
+  '''EP carrying a `DedupHash` pragma still lowers through the
+  registered `@lowering`. The pragma is materialized by `MirPragmaPass`
+  BEFORE the kernel pipeline runs — so by the time EP reaches the
+  registered lowering, the pragma has already inserted any wrap ops
+  inside `ep.pipeline` and the EP itself just carries them.
+
+  This test exercises the back-compat `dedup_hash=True` field path
+  (the named bool); the typed `pragmas=(('DedupHash', ...),)` path
+  goes through the same `MirPragmaPass` consumer.'''
+  ep_base = _simple_scan_ep()
+  # Clone with dedup_hash=True; the field flows into LoweringCtx via
+  # LowerScanPipelineShim and affects InsertInto emit. We're just
+  # checking the EP wrap (`lower_mir_execute_pipeline`) doesn't choke
+  # on it — the delegation pattern means anything that works in
+  # `lower_scan_pipeline` works here.
+  import dataclasses
+
+  ep_with_dh = dataclasses.replace(ep_base, dedup_hash=True)
+
+  legacy_iir = lower_scan_pipeline(ep_with_dh.pipeline, _new_ctx(dedup_hash=True))
+  new_iir = lower_mir_execute_pipeline(ep_with_dh, _new_ctx(dedup_hash=True))
+
+  assert legacy_iir == new_iir
+
+
+# -----------------------------------------------------------------------------
+# 5. ExecutePipeline is NOT in USE_DECLARATIVE
+# -----------------------------------------------------------------------------
+
+
+def test_execute_pipeline_not_in_use_declarative():
+  '''Per `docs/phase_b_lowering_dispatcher.md` §4 row B-ExecutePipeline:
+  EP is the TOP-level structural wrap; it sits OUTSIDE
+  `_lower_inner_chain` / `lower_scan_pipeline`. The `USE_DECLARATIVE`
+  ratchet governs chain / root dispatch INSIDE the kernel body — not
+  the top-level wrap. The `@lowering` registration alone is enough
+  to pin dialect ownership.'''
+  from srdatalog.ir.dialects.relation.sorted_array import USE_DECLARATIVE
+
+  assert mir.ExecutePipeline not in USE_DECLARATIVE
+
+
+# -----------------------------------------------------------------------------
+# 6. No chain-aware split — direct call IS the canonical entry
+# -----------------------------------------------------------------------------
+
+
+def test_lower_mir_execute_pipeline_direct_call_does_not_assert():
+  '''Unlike the chain-aware ops (Filter / Negation / Aggregate)
+  whose `@lowering` stubs assert on direct invocation because they
+  need the trailing `tail` from the chain dispatcher,
+  `lower_mir_execute_pipeline` IS the direct entry — calling it
+  must succeed because EP carries its own `.pipeline`.'''
+  ep = _simple_scan_ep()
+  out = lower_mir_execute_pipeline(ep, _new_ctx())
+  # The output is an IIR op (the lowered pipeline body); we don't
+  # pin its specific type here because `lower_scan_pipeline` chooses
+  # the shape based on the head op (Scan -> GridStrideLoop wrap).
+  assert out is not None
+
+
+if __name__ == '__main__':
+  pytest.main([__file__, '-v'])


### PR DESCRIPTION
## Summary
- Moves the existing inline `lower_execute_pipeline` closure (in `sorted_array/__init__.py:_register_passes`) into its own file `lowerings/lower_mir_execute_pipeline.py` to match the per-op convention
- 10th and final B-PR (Phase B COMPLETE once #58 + #59 + this land)
- Did NOT add `mir.ExecutePipeline` to `USE_DECLARATIVE` — EP sits OUTSIDE chain/root dispatch (it's the top-level wrap, not a chain-eligible op)

## Design choice — direct call, not registry dispatch
`LowerScanPipelineShim` (F5.1) still calls `lower_scan_pipeline` directly. The new `@lowering` registration is a 1-line delegate to the same helper, so byte-equivalence holds by construction and the registry has a discoverable canonical entry.

Registry-based dispatch from `KernelCtx` is documented as a follow-up in the new module's docstring — requires plumbing `Compiler` through `KernelCtx` (today only `LowerCtx` carries it).

## Test plan
- [x] 10 new tests (direct invocation parity, registry lookup parity, full kernel pipeline still works, `compile_pipeline` byte-stable, pragma coexistence with DedupHash, USE_DECLARATIVE exclusion, no-assert on direct call)
- [x] Full byte-equivalence harness: 636 passed + 2 skipped
- [x] Kernel pipeline tests (default_pipelines_shims + f5_acceptance + verify_renderability): 41 passed
- [x] D19 / discipline tests: 131 passed
- [x] Full suite: 1599 passed, 5 skipped
- [x] ruff check + format (CI v0.9.10): clean
- [x] mypy: 1 pre-existing error eliminated (the inline closure used to lack annotations)

## Cross-PR conflict expectations
- **B-CJ-multi + B-Cart** (parallel): mechanical conflicts on `_register_passes` block (you're modifying the existing `lower_execute_pipeline` registration; they're adding new ones near it). Trivial unions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)