### PR TITLE
B-Cart: CartesianJoin per-MIR-op @lowering migration (Wave 2A order 7, hard)

### DIFF
--- a/src/srdatalog/ir/dialects/relation/sorted_array/__init__.py
+++ b/src/srdatalog/ir/dialects/relation/sorted_array/__init__.py
@@ -73,6 +73,18 @@ USE_DECLARATIVE: frozenset[type] = frozenset(
     _mir_for_use_declarative.ColumnJoin,
     _mir_for_use_declarative.Negation,
     _mir_for_use_declarative.Aggregate,
+    # B-Cart (per docs/phase_b_lowering_dispatcher.md §4 row B-Cart,
+    # difficulty `hard`, order 7): adds `mir.CartesianJoin` to the
+    # ratchet. The new `@lowering`-dispatch path owns BOTH the root
+    # position (dispatched from `lower_scan_pipeline`) and the mid-
+    # chain position (dispatched from `_lower_inner_chain`); the
+    # `_should_use_declarative` helper has no source-count / shape
+    # guard for Cart (unlike B-CJ-single, which gates on source
+    # count). The C5 `TiledCartesian` typed-pragma wrap op is a
+    # DIFFERENT MIR op type (`mir.TiledCartesian`) and continues to
+    # route through `lower_tiled_cartesian_in_chain` independently —
+    # see `lowerings/lower_mir_cart.py` for the coexistence rationale.
+    _mir_for_use_declarative.CartesianJoin,
   }
 )
 
@@ -373,6 +385,39 @@ def _register_passes() -> None:
   )
   def _lower_mir_aggregate_registered(op: Any, ctx: Any) -> Any:
     return lower_mir_aggregate(op, ctx)
+
+  # Wave 2A / B-Cart (per docs/phase_b_lowering_dispatcher.md §4 row
+  # B-Cart, difficulty `hard`, order 7): `mir.CartesianJoin` migrates
+  # to a standalone `@lowering` registration in its own file under
+  # `lowerings/lower_mir_cart.py`. The registered stub asserts on
+  # direct invocation because the position-aware variants
+  # (`lower_mir_cart_root` from `lower_scan_pipeline`,
+  # `lower_mir_cart_in_chain` from `_lower_inner_chain`) need the
+  # trailing pipeline / chain — same split-with-stub rationale as
+  # B-Scan / B-Negation. The `USE_DECLARATIVE` ratchet above routes
+  # BOTH the root and mid-chain dispatch through the new path while
+  # keeping this registration as the dialect-ownership contract.
+  #
+  # Coexistence with C5 (`mir.TiledCartesian` wrap op): the wrap op
+  # is a DIFFERENT MIR op type and has its own `@lowering`
+  # registration (above, `lower_mir_tiled_cartesian`). The C5
+  # dispatch in `_lower_inner_chain` matches `mir.TiledCartesian`
+  # by isinstance and never falls through to the bare
+  # `mir.CartesianJoin` branch — both branches coexist independently.
+  # See `lowerings/lower_mir_cart.py` module docstring for the full
+  # coexistence rationale + the C5 dual-write transition handling.
+  from srdatalog.ir.dialects.relation.sorted_array.lowerings.lower_mir_cart import (
+    lower_mir_cart,
+  )
+
+  @lowering(
+    DIALECT,
+    mir.CartesianJoin,
+    consumes=('mir',),
+    produces=('iir.cf',),
+  )
+  def _lower_mir_cart_registered(op: Any, ctx: Any) -> Any:
+    return lower_mir_cart(op, ctx)
 
   # Verifier scaffolding — per-op invariants (D9: SaHint inside
   # IterURV scope, etc.) land incrementally as we encode them.

--- a/src/srdatalog/ir/dialects/relation/sorted_array/lowerings/__init__.py
+++ b/src/srdatalog/ir/dialects/relation/sorted_array/lowerings/__init__.py
@@ -358,6 +358,19 @@ def lower_scan_pipeline(
       )
 
       return lower_mir_scan_in_chain(head, rest, ctx)
+    if isinstance(head, mir.CartesianJoin):
+      # B-Cart root entry: `_should_use_declarative` returns True for
+      # all `mir.CartesianJoin` instances (no source-count guard,
+      # unlike B-CJ-single). The C5 `mir.TiledCartesian` wrap op
+      # only wraps NESTED Cartesians (`_wrap_eligible_carts` slices
+      # `pipeline[1:]`), so root position never sees a wrap — only
+      # bare `mir.CartesianJoin`. See `lowerings/lower_mir_cart.py`
+      # module docstring for the full coexistence rationale.
+      from srdatalog.ir.dialects.relation.sorted_array.lowerings.lower_mir_cart import (
+        lower_mir_cart_root,
+      )
+
+      return lower_mir_cart_root(head, rest, ctx)
     raise AssertionError(
       f'lower_scan_pipeline: USE_DECLARATIVE contains {type(head).__name__!r} '
       f'(and `_should_use_declarative` returned True) but no root-'
@@ -1177,6 +1190,26 @@ def _lower_inner_chain(
       )
 
       return lower_mir_aggregate_in_chain(head, tail, ctx)
+    if isinstance(head, mir.CartesianJoin):
+      # B-Cart mid-chain entry: `_should_use_declarative` returns
+      # True for all `mir.CartesianJoin` instances. The C5
+      # `mir.TiledCartesian` wrap op is a DIFFERENT MIR op type and
+      # never reaches this branch (handled by the
+      # `isinstance(head, mir.TiledCartesian)` branch below the
+      # USE_DECLARATIVE block — `TiledCartesian` is NOT in the set
+      # so it falls through to the legacy dispatch).
+      #
+      # The delegated `_lower_nested_cart` still performs its own
+      # `_tiled_cart_eligible(...)` check and forwards to
+      # `_lower_nested_cart_tiled` when the legacy `ctx.tiled_cartesian`
+      # bool path is active — preserving the C5 dual-write transition.
+      # See `lowerings/lower_mir_cart.py` module docstring for the
+      # coexistence rationale.
+      from srdatalog.ir.dialects.relation.sorted_array.lowerings.lower_mir_cart import (
+        lower_mir_cart_in_chain,
+      )
+
+      return lower_mir_cart_in_chain(head, tail, ctx)
     raise AssertionError(
       f'_lower_inner_chain: USE_DECLARATIVE contains {type(head).__name__!r} '
       f'but no chain-dispatch wiring exists for it. Add the '

--- a/src/srdatalog/ir/dialects/relation/sorted_array/lowerings/lower_mir_cart.py
+++ b/src/srdatalog/ir/dialects/relation/sorted_array/lowerings/lower_mir_cart.py
@@ -1,0 +1,247 @@
+'''Lowering: `mir.CartesianJoin` -> iir.cf — Wave 2A B-Cart migration
+(per `docs/phase_b_lowering_dispatcher.md` §4, row B-Cart, order 7,
+difficulty `hard`).
+
+Per `docs/phase_b_lowering_dispatcher.md` §4 (per-MIR-op work-unit
+table) and §4.1 (per-PR template): each MIR op type gets one
+`@lowering(target=iir.cf, source=mir.X)` rule in its own file under
+`dialects/relation/sorted_array/lowerings/`. The registry registration
+lives alongside the dialect's other lowerings in
+`__init__.py:_register_passes`.
+
+Structural-position split (root vs nested), mirroring `mir.Scan`'s
+root-only situation and the B-CJ-multi root + chain dual-entry pattern:
+
+`mir.CartesianJoin` is structurally allowed in TWO positions per
+`_supported_pipeline`:
+
+  - ROOT position (`lower_scan_pipeline` head): a Cartesian as the
+    pipeline's first op, followed by a trailing run of InsertIntos.
+    Legacy dispatch: `_lower_root_cart(head, rest, ctx)`. No middle
+    ops between Cart and the InsertInto run today (see
+    `_supported_pipeline`'s `len(middle) == 0` guard on the
+    Cart-root branch).
+
+  - NESTED / MID-CHAIN position (`_lower_inner_chain` head): a
+    Cartesian following a Scan or multi-source ColumnJoin root, with
+    arbitrary intervening Filter / ConstantBind / Negation /
+    CartesianJoin / `mir.TiledCartesian` between it and the trailing
+    InsertIntos. Legacy dispatch: `_lower_nested_cart(head, tail,
+    ctx)`. This is the path that interacts with the typed
+    `TiledCartesian` pragma + the `ctx.neg_pre_narrow` registration
+    consumed by mid-chain `mir.Negation`.
+
+Both positions share the same MIR op type (`mir.CartesianJoin`), so a
+single `@lowering` registration covers both — the dispatching site
+decides which legacy helper to forward to. We therefore expose THREE
+entry points:
+
+  - `lower_mir_cart_root(op, rest, ctx)`: called from
+    `lower_scan_pipeline` when `_should_use_declarative(head)` and
+    `isinstance(head, mir.CartesianJoin)`. Delegates to
+    `_lower_root_cart`.
+  - `lower_mir_cart_in_chain(op, tail, ctx)`: called from
+    `_lower_inner_chain` when `_should_use_declarative(head)` and
+    `isinstance(head, mir.CartesianJoin)`. Delegates to
+    `_lower_nested_cart`.
+  - `lower_mir_cart(op, ctx)`: the `@lowering`-registered stub.
+    Asserts on direct invocation — the framework dispatch path is
+    reserved for a future MIR-IIR walker that no longer routes
+    through `lower_scan_pipeline` / `_lower_inner_chain` and can
+    plumb the positional trailing argument through.
+
+Coexistence with the C5 `TiledCartesian` typed pragma + wrap op
+(per `docs/phase_c_pragma_materialization.md` §4.3):
+
+  `mir.TiledCartesian(inner=mir.CartesianJoin)` is a DIFFERENT MIR
+  op type — the C5 pragma's materialization handler wraps shape-
+  eligible nested Cartesians in `TiledCartesian` BEFORE lowering
+  reaches `_lower_inner_chain`. The wrap op has its own `@lowering`
+  registration (registered by `_register_passes` from
+  `pragmas/tiled_cartesian.py:lower_tiled_cartesian`) and its own
+  chain-aware variant (`lower_tiled_cartesian_in_chain`) that calls
+  `_lower_nested_cart_tiled` directly. Because the wrap op is a
+  distinct type, the `_lower_inner_chain` dispatch sees
+  `TiledCartesian` (not `CartesianJoin`) for the wrapped case — the
+  B-Cart `mir.CartesianJoin` entry only fires for non-wrapped /
+  non-eligible Cartesians.
+
+  In the C5 dual-write transition (where the legacy runner-driven
+  `ep.tiled_cartesian=True` short-circuits the wrap step in
+  `materialize_tiled_cartesian`), the eligible Cartesian remains a
+  bare `mir.CartesianJoin` and reaches `lower_mir_cart_in_chain`.
+  The delegated `_lower_nested_cart` then checks
+  `_tiled_cart_eligible(cart_op, ctx)` and forwards to
+  `_lower_nested_cart_tiled` itself — so the tiled path still fires
+  via the legacy `ctx.tiled_cartesian` bool. Either way the wrap-op
+  dispatch (when present) and the bare-Cart dispatch (when not)
+  reach the same `_lower_nested_cart_tiled` body, and the C5
+  end-to-end test pins the cross-path byte-equivalence.
+
+Negation interaction (per `_register_neg_pre_narrow`):
+
+  `_lower_nested_cart` sets up `ctx.neg_pre_narrow` BEFORE rendering
+  the body, so any `mir.Negation` in `tail` (already routed through
+  `lower_mir_negation_in_chain` under USE_DECLARATIVE) finds the
+  pre-allocated handle. This delegation preserves that contract
+  byte-for-byte — the Cart's chain-aware variant just hands the
+  whole `(cart_op, tail, ctx)` triple to `_lower_nested_cart`, which
+  performs the pre-narrow registration + body render + scaffold
+  emission atomically.
+
+Byte-equivalence contract (§4.2): the migrated op produces the same
+IIR tree as the legacy `if isinstance(head, mir.CartesianJoin):`
+branches in both `lower_scan_pipeline` (root) and `_lower_inner_chain`
+(mid-chain) on every fixture that exercises them. We delegate
+straight back into the legacy `_lower_root_cart` / `_lower_nested_cart`
+helpers to make byte-equivalence hold by construction; the migration
+moves dispatch ownership without duplicating the body. This is the
+same delegation pattern used by B-Filter / B-ConstantBind /
+B-InsertInto / B-Scan / B-CJ-single / B-Negation / B-Aggregate and
+the C2 / C4 / C5 / C6 wrap-op lowerings.
+'''
+
+from __future__ import annotations
+
+from typing import Any
+
+import srdatalog.ir.mir.types as mir
+from srdatalog.ir.core import Op
+
+
+def lower_mir_cart_root(
+  op: mir.CartesianJoin,
+  rest: list[Any],
+  ctx: Any,
+) -> Op:
+  '''Emit the IIR for a ROOT `mir.CartesianJoin` with trailing pipeline `rest`.
+
+  Mirrors the legacy `if isinstance(head, mir.CartesianJoin): return
+  _lower_root_cart(head, rest, ctx)` dispatch in
+  `lower_scan_pipeline` byte-for-byte by delegating to the legacy
+  helper. The goal of this Wave 2A PR is byte-equivalence with the
+  legacy emitter, not a from-scratch rewrite of the (M7.x) root
+  Cartesian scaffolding — the helper stays LIVE until Layer 3
+  cleanup deletes both the legacy branches AND the
+  `USE_DECLARATIVE` ratchet.
+
+  `rest` is the trailing pipeline AFTER the Cart at root position:
+  per `_supported_pipeline` this is a pure run of InsertIntos today
+  (no middle ops between root Cart and the InsertInto tail). The
+  legacy `_lower_root_cart` walks it via `_lower_inner_chain` for
+  the body and emits the root-Cart scaffold (per-source handle bind
+  off SaRoot, combined validity `return`, per-source degree, total,
+  total-zero `return`, ParallelFor grid-stride loop with per-source
+  decompose + SaGetValAt var binds).
+
+  Per the module docstring's coexistence note: the C5
+  `TiledCartesian` wrap op only fires for NESTED Cartesians (per
+  `_wrap_eligible_carts`'s `pipeline[1:]` slice), so the root
+  position never sees a `TiledCartesian` head — only bare
+  `mir.CartesianJoin`. This entry is therefore unaffected by C5.
+  '''
+  # Deferred import: the pipeline dispatcher + `_lower_root_cart`
+  # live in the package `__init__.py` (the legacy monolith), which
+  # imports this module via `_register_passes`. Import-at-call-time
+  # keeps the package import graph linear (avoids a circular import
+  # between `__init__.py` and this sibling module).
+  from srdatalog.ir.dialects.relation.sorted_array.lowerings import (
+    _lower_root_cart,
+  )
+
+  return _lower_root_cart(op, rest, ctx)
+
+
+def lower_mir_cart_in_chain(
+  op: mir.CartesianJoin,
+  tail: list[Any],
+  ctx: Any,
+) -> Op:
+  '''Emit the IIR for a NESTED `mir.CartesianJoin` chain head with
+  trailing `tail`.
+
+  Mirrors the legacy `if isinstance(head, mir.CartesianJoin):
+  return _lower_nested_cart(head, tail, ctx)` branch in
+  `_lower_inner_chain` byte-for-byte by delegating to the legacy
+  helper. The helper handles:
+
+    - 1, 2, or N>=3 source counts (3+ uses the CartesianNDecompose
+      countdown remainder).
+    - State-key handle reuse for prefix-bearing sources; fresh root
+      construction for prefix-empty sources; chained `.prefix(...)`
+      walks for Scan-bound prefix vars.
+    - `neg_pre_narrow` registration for any `mir.Negation` in
+      `tail` (pre-allocates the negation handle BEFORE body rendering
+      so the counter trajectory matches legacy).
+    - The R1 count-as-product short-circuit (closed-form
+      `add_count(lane_share)` in count phase, no per-thread idx).
+    - Tiled-Cartesian dispatch (N7): when `_tiled_cart_eligible(...)`
+      returns True (legacy `ctx.tiled_cartesian` bool path), the
+      helper forwards to `_lower_nested_cart_tiled` itself —
+      preserving the C5 dual-write transition without this entry
+      needing to know about it.
+
+  Per the module docstring's coexistence note: the C5
+  `TiledCartesian` wrap op is a DIFFERENT MIR op type
+  (`mir.TiledCartesian`) — its dispatch lives below this branch in
+  `_lower_inner_chain` and forwards to
+  `lower_tiled_cartesian_in_chain`. The bare `mir.CartesianJoin`
+  entry here only fires for non-wrapped Cartesians (which includes
+  the legacy `ctx.tiled_cartesian` bool path for shape-eligible
+  Cartesians that haven't been wrapped — `_lower_nested_cart`'s own
+  `_tiled_cart_eligible` check forwards to the tiled helper in
+  that case). The dispatch order in `_lower_inner_chain` is
+  load-bearing: the `TiledCartesian` branch sits AFTER this Cart
+  branch because the wrap op type doesn't match `mir.CartesianJoin`
+  isinstance — both branches coexist independently.
+  '''
+  # Deferred import: the chain dispatcher + `_lower_nested_cart`
+  # live in the package `__init__.py` (the legacy monolith), which
+  # imports this module via `_register_passes`. Import-at-call-time
+  # keeps the package import graph linear (avoids a circular import
+  # between `__init__.py` and this sibling module).
+  from srdatalog.ir.dialects.relation.sorted_array.lowerings import (
+    _lower_nested_cart,
+  )
+
+  return _lower_nested_cart(op, tail, ctx)
+
+
+def lower_mir_cart(op: mir.CartesianJoin, ctx: Any) -> Op:
+  '''Framework-registry stub for `@lowering(target=iir.cf,
+  source=mir.CartesianJoin)`. The actual dispatch lives in
+  `lowerings.lower_scan_pipeline` (root position) and
+  `lowerings._lower_inner_chain` (mid-chain position), both gated
+  by the `USE_DECLARATIVE` ratchet. They call `lower_mir_cart_root`
+  / `lower_mir_cart_in_chain` with the trailing pipeline / chain
+  in scope.
+
+  This stub exists so the dialect's `lowerings` list pins the
+  (consumes, produces) contract for `mir.CartesianJoin` — the
+  discipline test consults the dialect to verify ownership. Note
+  that a single registration covers BOTH structural positions; the
+  position-aware dispatch lives in the two callers above.
+
+  Calling this stub directly raises a structural assertion — the
+  framework path is reserved for future readers who can plumb in
+  the missing trailing argument (`rest` at root, `tail` mid-chain)
+  through (e.g. a refactored MIR-IIR walker that no longer routes
+  through `lower_scan_pipeline` / `_lower_inner_chain`).
+  '''
+  raise AssertionError(
+    'lower_mir_cart: dispatch goes through '
+    '`lowerings.lower_scan_pipeline` -> `lower_mir_cart_root` (root '
+    'position) or `lowerings._lower_inner_chain` -> '
+    '`lower_mir_cart_in_chain` (mid-chain position) so the trailing '
+    'pipeline / chain is in scope. Direct invocation indicates a '
+    'refactor that bypassed the positional dispatch — plumb the '
+    'trailing argument through and call `lower_mir_cart_root` or '
+    '`lower_mir_cart_in_chain` instead.'
+  )
+
+
+__all__ = [
+  'lower_mir_cart',
+  'lower_mir_cart_in_chain',
+  'lower_mir_cart_root',
+]

--- a/tests/test_lower_mir_cart_byte_equivalent.py
+++ b/tests/test_lower_mir_cart_byte_equivalent.py
@@ -1,0 +1,789 @@
+'''Byte-equivalence test for Wave 2A B-Cart migration.
+
+Per `docs/phase_b_lowering_dispatcher.md` §4.2 (per-PR acceptance
+gate): each per-MIR-op migration ships a
+`test_lower_mir_<op>_byte_equivalent` test that runs the migrated
+path on every relevant fixture and asserts byte equality with the
+legacy `if isinstance(head, mir.X):` branch.
+
+For CartesianJoin the relevant fixtures (per
+`docs/phase_b_lowering_dispatcher.md` §4 row B-Cart, "hard" —
+`_lower_root_cart` / `_lower_nested_cart` interact with multi-source
+shapes, prefix narrowing, the C5 `TiledCartesian` typed pragma, and
+the `_register_neg_pre_narrow` -> `ctx.neg_pre_narrow` contract
+consumed by mid-chain `mir.Negation`):
+
+  - root 2-source Cart with trailing InsertInto (`_lower_root_cart`),
+  - root 3-source Cart (CartesianNDecompose path),
+  - mid-chain 2-source Cart under a Scan root,
+  - mid-chain 3-source Cart under a Scan root,
+  - mid-chain Cart with inner Negation (verifies the
+    `ctx.neg_pre_narrow` registration in `_lower_nested_cart` still
+    flows through `lower_mir_negation_in_chain`),
+  - mid-chain Cart under a multi-source ColumnJoin root,
+  - tiled-eligible shape (2 sources, 1 var per source, materialize
+    phase) — verifies the C5 `TiledCartesian` wrap-op path remains
+    intact (the wrap fires BEFORE this Cart entry sees the op,
+    because `_should_use_declarative` returns True for
+    `mir.CartesianJoin` but the wrap op is a different type;
+    `_lower_inner_chain`'s `mir.TiledCartesian` branch still
+    catches the wrap form).
+  - legacy `ctx.tiled_cartesian=True` short-circuit path: the bare
+    `mir.CartesianJoin` reaches `lower_mir_cart_in_chain` ->
+    `_lower_nested_cart`, which forwards to `_lower_nested_cart_tiled`
+    via its own `_tiled_cart_eligible` check — verifies the dual-write
+    transition still emits byte-identical IIR.
+  - full pipeline through `compile_pipeline` for both root and nested
+    shapes.
+
+The test compares two compilation paths:
+
+  - LEGACY: `USE_DECLARATIVE` patched to NOT contain
+    `mir.CartesianJoin`, so `lower_scan_pipeline` /
+    `_lower_inner_chain` fall into the legacy imperative branches
+    (`_lower_root_cart` / `_lower_nested_cart`).
+  - NEW: `USE_DECLARATIVE` left alone (CartesianJoin IS in the set),
+    so dispatch routes through `lower_mir_cart_root` /
+    `lower_mir_cart_in_chain`.
+
+Byte-equivalence is asserted on the rendered IIR text. The C5
+end-to-end test (`tests/test_pragma_tiled_cartesian_end_to_end.py`)
+re-running green under this PR is the strongest signal that the C5
+path remains intact; this file adds direct-call coverage of the
+non-tiled corner cases plus the tiled coexistence anchor.
+'''
+
+from __future__ import annotations
+
+from contextlib import contextmanager
+from typing import Any
+
+import pytest
+
+import srdatalog.ir.mir.types as mir
+from srdatalog.ir.codegen.cuda.emit import EmitCtx, emit
+from srdatalog.ir.dialects.iir.cf import Block as IirBlock
+from srdatalog.ir.dialects.relation.sorted_array.lowerings import (
+  LoweringCtx,
+  _should_use_declarative,
+  lower_scan_pipeline,
+)
+from srdatalog.ir.dialects.relation.sorted_array.lowerings.lower_mir_cart import (
+  lower_mir_cart,
+  lower_mir_cart_in_chain,
+  lower_mir_cart_root,
+)
+from srdatalog.ir.hir.types import Version
+
+# -----------------------------------------------------------------------------
+# Helpers
+# -----------------------------------------------------------------------------
+
+
+def _render(op: Any) -> str:
+  '''Render an IIR op tree through the CUDA emitter — the same
+  surface the byte-equivalence harnesses exercise.'''
+  return emit(op, EmitCtx(indent_level=2))
+
+
+@contextmanager
+def _force_legacy_branch():
+  '''Temporarily strip `mir.CartesianJoin` from `USE_DECLARATIVE` so
+  `lower_scan_pipeline` / `_lower_inner_chain` fall into the legacy
+  imperative branches (`_lower_root_cart` / `_lower_nested_cart`).
+
+  Save / restore as a context manager — the dialect module's
+  `USE_DECLARATIVE` is a frozenset re-bound name; the dispatch
+  helper `_should_use_declarative` re-reads it on each call, so
+  swapping the frozenset for the duration of one block is enough to
+  force the legacy path.
+  '''
+  import srdatalog.ir.dialects.relation.sorted_array as sa_dialect
+
+  saved = sa_dialect.USE_DECLARATIVE
+  sa_dialect.USE_DECLARATIVE = frozenset(saved - {mir.CartesianJoin})
+  try:
+    yield
+  finally:
+    sa_dialect.USE_DECLARATIVE = saved
+
+
+def _new_ctx(**kwargs: Any) -> LoweringCtx:
+  '''Fresh LoweringCtx — counters reset so both paths bump identically.'''
+  view_var_names = kwargs.pop('view_var_names', None) or {
+    '0': 'v_Src_full',
+    '1': 'v_R_full',
+    '2': 'v_S_full',
+    '3': 'v_T_full',
+  }
+  return LoweringCtx(output_var='ctx0', view_var_names=view_var_names, **kwargs)
+
+
+def _column_source(
+  rel: str,
+  handle_start: int,
+  prefix_vars: tuple[str, ...] = (),
+  index: tuple[int, ...] = (0,),
+) -> mir.ColumnSource:
+  return mir.ColumnSource(
+    rel_name=rel,
+    version=Version.FULL,
+    index=list(index),
+    prefix_vars=list(prefix_vars),
+    handle_start=handle_start,
+  )
+
+
+def _cart(
+  *sources: mir.ColumnSource,
+  vars_: tuple[str, ...],
+  var_from_source: tuple[tuple[str, ...], ...],
+  handle_start: int = -1,
+) -> mir.CartesianJoin:
+  return mir.CartesianJoin(
+    vars=list(vars_),
+    sources=list(sources),
+    var_from_source=[list(vfs) for vfs in var_from_source],
+    handle_start=handle_start,
+  )
+
+
+def _insert_into(vars_: tuple[str, ...]) -> mir.InsertInto:
+  return mir.InsertInto(
+    rel_name='Dst',
+    version=Version.NEW,
+    vars=list(vars_),
+    index=list(range(len(vars_))),
+  )
+
+
+def _scan(vars_: tuple[str, ...] = ('x',), handle_start: int = 0) -> mir.Scan:
+  return mir.Scan(
+    vars=list(vars_),
+    rel_name='Src',
+    version=Version.FULL,
+    index=list(range(len(vars_))),
+    handle_start=handle_start,
+  )
+
+
+# -----------------------------------------------------------------------------
+# 1. Root Cart — `lower_scan_pipeline` -> `lower_mir_cart_root`
+# -----------------------------------------------------------------------------
+
+
+def test_root_cart_two_sources_byte_equivalent():
+  '''Root 2-source Cart with trailing InsertInto. Emits per-source
+  handle binds (SaRoot), combined validity `return`, per-source
+  degree, total, total-zero `return`, ParallelFor grid-stride loop
+  with per-source decompose + SaGetValAt var binds.'''
+  cart = _cart(
+    _column_source('R', handle_start=1),
+    _column_source('S', handle_start=2),
+    vars_=('y', 'z'),
+    var_from_source=(('y',), ('z',)),
+    handle_start=1,
+  )
+  ins = _insert_into(('y', 'z'))
+
+  with _force_legacy_branch():
+    legacy_text = _render(lower_scan_pipeline([cart, ins], _new_ctx()))
+  new_text = _render(lower_scan_pipeline([cart, ins], _new_ctx()))
+
+  assert legacy_text == new_text
+  # Root-Cart scaffold markers: `return` (not `continue`) on validity.
+  assert 'return' in legacy_text
+  assert 'h_R_1' in legacy_text and 'h_S_2' in legacy_text
+
+
+def test_root_cart_three_sources_byte_equivalent():
+  '''Root 3-source Cart: emits CartesianNDecompose for per-thread idx.'''
+  cart = _cart(
+    _column_source('R', handle_start=1),
+    _column_source('S', handle_start=2),
+    _column_source('T', handle_start=3),
+    vars_=('y', 'z', 'w'),
+    var_from_source=(('y',), ('z',), ('w',)),
+    handle_start=1,
+  )
+  ins = _insert_into(('y', 'z', 'w'))
+
+  with _force_legacy_branch():
+    legacy_text = _render(lower_scan_pipeline([cart, ins], _new_ctx()))
+  new_text = _render(lower_scan_pipeline([cart, ins], _new_ctx()))
+
+  assert legacy_text == new_text
+  assert 'h_R_1' in legacy_text
+  assert 'h_S_2' in legacy_text
+  assert 'h_T_3' in legacy_text
+
+
+def test_root_cart_one_source_byte_equivalent():
+  '''Root 1-source Cart (legal per `_lower_root_cart` assertion
+  `num_sources >= 1`). Emits the same scaffold without the
+  per-source decompose.'''
+  cart = _cart(
+    _column_source('R', handle_start=1),
+    vars_=('y',),
+    var_from_source=(('y',),),
+    handle_start=1,
+  )
+  ins = _insert_into(('y',))
+
+  with _force_legacy_branch():
+    legacy_text = _render(lower_scan_pipeline([cart, ins], _new_ctx()))
+  new_text = _render(lower_scan_pipeline([cart, ins], _new_ctx()))
+
+  assert legacy_text == new_text
+
+
+# -----------------------------------------------------------------------------
+# 2. Mid-chain Cart under a Scan root — `_lower_inner_chain` ->
+# `lower_mir_cart_in_chain`
+# -----------------------------------------------------------------------------
+
+
+def test_nested_cart_two_sources_under_scan_byte_equivalent():
+  '''2-source Cart nested under a Scan root. Emits the
+  nested-Cart scaffold (lane/group_size, per-source handle, total,
+  flat_idx, idx vars).'''
+  scan = _scan(('x',))
+  cart = _cart(
+    _column_source('R', handle_start=1),
+    _column_source('S', handle_start=2),
+    vars_=('y', 'z'),
+    var_from_source=(('y',), ('z',)),
+    handle_start=1,
+  )
+  ins = _insert_into(('x', 'y', 'z'))
+
+  with _force_legacy_branch():
+    legacy_text = _render(lower_scan_pipeline([scan, cart, ins], _new_ctx()))
+  new_text = _render(lower_scan_pipeline([scan, cart, ins], _new_ctx()))
+
+  assert legacy_text == new_text
+  # Nested-Cart marker: lane / group_size scaffold.
+  assert 'lane' in legacy_text
+  assert 'group_size' in legacy_text
+
+
+def test_nested_cart_three_sources_under_scan_byte_equivalent():
+  '''3-source nested Cart: uses CartesianNDecompose for idx vars.'''
+  scan = _scan(('x',))
+  cart = _cart(
+    _column_source('R', handle_start=1),
+    _column_source('S', handle_start=2),
+    _column_source('T', handle_start=3),
+    vars_=('y', 'z', 'w'),
+    var_from_source=(('y',), ('z',), ('w',)),
+    handle_start=1,
+  )
+  ins = _insert_into(('x', 'y', 'z', 'w'))
+
+  with _force_legacy_branch():
+    legacy_text = _render(lower_scan_pipeline([scan, cart, ins], _new_ctx()))
+  new_text = _render(lower_scan_pipeline([scan, cart, ins], _new_ctx()))
+
+  assert legacy_text == new_text
+
+
+def test_nested_cart_one_source_byte_equivalent():
+  '''1-source nested Cart: minimal scaffold, single idx var.'''
+  scan = _scan(('x',))
+  cart = _cart(
+    _column_source('R', handle_start=1),
+    vars_=('y',),
+    var_from_source=(('y',),),
+    handle_start=1,
+  )
+  ins = _insert_into(('x', 'y'))
+
+  with _force_legacy_branch():
+    legacy_text = _render(lower_scan_pipeline([scan, cart, ins], _new_ctx()))
+  new_text = _render(lower_scan_pipeline([scan, cart, ins], _new_ctx()))
+
+  assert legacy_text == new_text
+
+
+# -----------------------------------------------------------------------------
+# 3. Nested Cart with mid-chain Negation — `ctx.neg_pre_narrow` contract
+# -----------------------------------------------------------------------------
+
+
+def test_nested_cart_with_inner_negation_byte_equivalent():
+  '''Nested Cart followed by a Negation whose prefix var is bound
+  OUTSIDE the Cart (by the Scan). `_lower_nested_cart` registers a
+  `neg_pre_narrow` entry for the negation's handle_idx BEFORE
+  rendering the body; the body's chain dispatcher then routes the
+  Negation through `lower_mir_negation_in_chain` which sees the
+  registration.
+
+  Both paths must produce identical text — the `neg_pre_narrow`
+  flow is preserved by construction (the B-Cart migration delegates
+  to `_lower_nested_cart`, which is the registrar).
+  '''
+  scan = _scan(('x',))
+  cart = _cart(
+    _column_source('R', handle_start=1),
+    _column_source('S', handle_start=2),
+    vars_=('y', 'z'),
+    var_from_source=(('y',), ('z',)),
+    handle_start=1,
+  )
+  neg = mir.Negation(
+    rel_name='Bad',
+    version=Version.FULL,
+    prefix_vars=['x'],
+    index=[0],
+    handle_start=3,
+  )
+  ins = _insert_into(('x', 'y', 'z'))
+
+  views = {
+    '0': 'v_Src_full',
+    '1': 'v_R_full',
+    '2': 'v_S_full',
+    '3': 'v_Bad_full',
+  }
+
+  with _force_legacy_branch():
+    legacy_text = _render(
+      lower_scan_pipeline([scan, cart, neg, ins], _new_ctx(view_var_names=views))
+    )
+  new_text = _render(lower_scan_pipeline([scan, cart, neg, ins], _new_ctx(view_var_names=views)))
+
+  assert legacy_text == new_text
+  # Pre-narrow handle var (registered by _register_neg_pre_narrow)
+  # appears in the rendered output.
+  assert 'h_Bad_neg_pre' in legacy_text
+
+
+def test_nested_cart_with_negation_inside_cart_vars_byte_equivalent():
+  '''Negation whose prefix vars come from INSIDE the Cart: no
+  pre-narrow registration (the helper's `pre_vars` ends up empty
+  because the var is in `cartesian_bound_set`). Both paths should
+  still match byte-for-byte.'''
+  scan = _scan(('x',))
+  cart = _cart(
+    _column_source('R', handle_start=1),
+    _column_source('S', handle_start=2),
+    vars_=('y', 'z'),
+    var_from_source=(('y',), ('z',)),
+    handle_start=1,
+  )
+  # Prefix var `y` is bound INSIDE the Cart (var_from_source[0]).
+  neg = mir.Negation(
+    rel_name='Bad',
+    version=Version.FULL,
+    prefix_vars=['y'],
+    index=[0],
+    handle_start=3,
+  )
+  ins = _insert_into(('x', 'y', 'z'))
+
+  views = {
+    '0': 'v_Src_full',
+    '1': 'v_R_full',
+    '2': 'v_S_full',
+    '3': 'v_Bad_full',
+  }
+
+  with _force_legacy_branch():
+    legacy_text = _render(
+      lower_scan_pipeline([scan, cart, neg, ins], _new_ctx(view_var_names=views))
+    )
+  new_text = _render(lower_scan_pipeline([scan, cart, neg, ins], _new_ctx(view_var_names=views)))
+
+  assert legacy_text == new_text
+
+
+# -----------------------------------------------------------------------------
+# 4. Nested Cart under a multi-source ColumnJoin root
+# -----------------------------------------------------------------------------
+
+
+def test_nested_cart_under_cj_root_byte_equivalent():
+  '''A multi-source ColumnJoin root with a nested Cart in the middle:
+  exercises the Scan-rooted vs CJ-rooted dispatch in
+  `_supported_pipeline` — both must accept the shape and both
+  byte-equivalence paths must agree.'''
+  cj_root = mir.ColumnJoin(
+    var_name='x',
+    sources=[
+      mir.ColumnSource(
+        rel_name='A',
+        version=Version.FULL,
+        index=[0],
+        prefix_vars=[],
+        handle_start=0,
+      ),
+      mir.ColumnSource(
+        rel_name='B',
+        version=Version.FULL,
+        index=[0],
+        prefix_vars=[],
+        handle_start=1,
+      ),
+    ],
+    handle_start=0,
+  )
+  cart = _cart(
+    _column_source('R', handle_start=2),
+    _column_source('S', handle_start=3),
+    vars_=('y', 'z'),
+    var_from_source=(('y',), ('z',)),
+    handle_start=2,
+  )
+  ins = _insert_into(('x', 'y', 'z'))
+
+  views = {
+    '0': 'v_A_full',
+    '1': 'v_B_full',
+    '2': 'v_R_full',
+    '3': 'v_S_full',
+  }
+
+  with _force_legacy_branch():
+    legacy_text = _render(lower_scan_pipeline([cj_root, cart, ins], _new_ctx(view_var_names=views)))
+  new_text = _render(lower_scan_pipeline([cj_root, cart, ins], _new_ctx(view_var_names=views)))
+
+  assert legacy_text == new_text
+
+
+# -----------------------------------------------------------------------------
+# 5. Tiled-eligible shape — C5 dual-write coexistence
+# -----------------------------------------------------------------------------
+
+
+def test_tiled_eligible_cart_legacy_bool_path_byte_equivalent():
+  '''Tiled-eligible 2-source / 1-var-per-source Cart with
+  `ctx.tiled_cartesian=True` (the legacy runner-driven bool path,
+  pre-A3). The bare `mir.CartesianJoin` reaches
+  `lower_mir_cart_in_chain` -> `_lower_nested_cart`, which forwards
+  to `_lower_nested_cart_tiled` via its own `_tiled_cart_eligible`
+  check.
+
+  Both paths produce the tiled IIR (TiledBallotBlock +
+  SaTiledCartesian2D scaffold) — the C5 dual-write transition is
+  preserved.
+  '''
+  scan = _scan(('x',))
+  cart = _cart(
+    _column_source('R', handle_start=1),
+    _column_source('S', handle_start=2),
+    vars_=('y', 'z'),
+    var_from_source=(('y',), ('z',)),
+    handle_start=1,
+  )
+  ins = _insert_into(('x', 'y', 'z'))
+
+  with _force_legacy_branch():
+    legacy_text = _render(lower_scan_pipeline([scan, cart, ins], _new_ctx(tiled_cartesian=True)))
+  new_text = _render(lower_scan_pipeline([scan, cart, ins], _new_ctx(tiled_cartesian=True)))
+
+  assert legacy_text == new_text
+  # Tiled-mode marker: the tc_valid_<n> name appears in the body.
+  assert 'tc_valid' in legacy_text
+
+
+def test_tiled_eligible_cart_wrap_op_path_byte_equivalent():
+  '''Tiled-eligible Cart wrapped in `mir.TiledCartesian` (the C5
+  post-A3 / pure-typed-pragma form). The wrap op is a DIFFERENT
+  MIR op type — `_lower_inner_chain` dispatches it through
+  `lower_tiled_cartesian_in_chain` (C5), NOT through the B-Cart
+  entry. This test verifies that B-Cart's `USE_DECLARATIVE`
+  membership does NOT perturb the C5 wrap-op dispatch.
+
+  Both paths produce byte-identical IIR via the same
+  `_lower_nested_cart_tiled` helper.
+  '''
+  scan = _scan(('x',))
+  bare_cart = _cart(
+    _column_source('R', handle_start=1),
+    _column_source('S', handle_start=2),
+    vars_=('y', 'z'),
+    var_from_source=(('y',), ('z',)),
+    handle_start=1,
+  )
+  wrap = mir.TiledCartesian(inner=bare_cart)
+  ins = _insert_into(('x', 'y', 'z'))
+
+  with _force_legacy_branch():
+    legacy_text = _render(lower_scan_pipeline([scan, wrap, ins], _new_ctx()))
+  new_text = _render(lower_scan_pipeline([scan, wrap, ins], _new_ctx()))
+
+  assert legacy_text == new_text
+  # Tiled-mode marker present.
+  assert 'tc_valid' in legacy_text
+
+
+def test_tiled_eligible_cart_wrap_op_unaffected_by_use_declarative():
+  '''Pin the C5 invariant: the `mir.TiledCartesian` wrap op never
+  routes through `_should_use_declarative` (because
+  `mir.TiledCartesian` is not in `USE_DECLARATIVE`). The B-Cart
+  migration adds `mir.CartesianJoin` to the set, but the wrap op
+  type is distinct.'''
+  from srdatalog.ir.dialects.relation.sorted_array import USE_DECLARATIVE
+
+  # Pin: the wrap op type is NOT in USE_DECLARATIVE.
+  assert mir.TiledCartesian not in USE_DECLARATIVE
+  # And `_should_use_declarative` returns False for an instance of it.
+  wrap = mir.TiledCartesian(
+    inner=mir.CartesianJoin(vars=[], sources=[], var_from_source=[], handle_start=-1)
+  )
+  assert _should_use_declarative(wrap) is False
+  # Bare CartesianJoin IS in the set and gates True.
+  bare = mir.CartesianJoin(vars=[], sources=[], var_from_source=[], handle_start=-1)
+  assert _should_use_declarative(bare) is True
+
+
+# -----------------------------------------------------------------------------
+# 6. Direct call into the chain-aware variant
+# -----------------------------------------------------------------------------
+
+
+def test_lower_mir_cart_in_chain_returns_block():
+  '''Pin the IIR tree shape directly: nested Cart produces a `Block`
+  with at least the scaffold (lane bind, group_size bind, per-source
+  handle binds, total bind, loop). Same shape as legacy
+  `_lower_nested_cart`.'''
+  cart = _cart(
+    _column_source('R', handle_start=1),
+    _column_source('S', handle_start=2),
+    vars_=('y', 'z'),
+    var_from_source=(('y',), ('z',)),
+    handle_start=1,
+  )
+  ins = _insert_into(('y', 'z'))
+  ctx = _new_ctx(debug=False)
+
+  out = lower_mir_cart_in_chain(cart, [ins], ctx)
+  assert isinstance(out, IirBlock)
+  # The block must contain a lane bind and group_size bind among its
+  # opening stmts — the unique signature of `_lower_nested_cart`.
+  rendered = _render(out)
+  assert 'lane' in rendered
+  assert 'group_size' in rendered
+
+
+def test_lower_mir_cart_root_returns_block():
+  '''Pin the IIR tree shape directly: root Cart produces a `Block`
+  with the root-Cart scaffold (per-source SaRoot binds, combined
+  validity `return`, per-source degree, ParallelFor).'''
+  cart = _cart(
+    _column_source('R', handle_start=1),
+    _column_source('S', handle_start=2),
+    vars_=('y', 'z'),
+    var_from_source=(('y',), ('z',)),
+    handle_start=1,
+  )
+  ins = _insert_into(('y', 'z'))
+  ctx = _new_ctx(debug=False)
+
+  out = lower_mir_cart_root(cart, [ins], ctx)
+  assert isinstance(out, IirBlock)
+  rendered = _render(out)
+  # Root-Cart uses `return` (not `continue`).
+  assert 'return' in rendered
+
+
+# -----------------------------------------------------------------------------
+# 7. Registry contract — stub asserts on direct call + ownership
+# -----------------------------------------------------------------------------
+
+
+def test_lower_mir_cart_registry_stub_asserts():
+  '''The `@lowering(target=iir.cf, source=mir.CartesianJoin)`
+  registry entry is a stub that asserts on direct invocation —
+  dispatch flows through `lower_scan_pipeline` (root) or
+  `_lower_inner_chain` (mid-chain) to the position-aware variants.
+  Mirrors the C5 `lower_tiled_cartesian` split + B-Scan / B-Negation
+  splits.'''
+  cart = _cart(
+    _column_source('R', handle_start=1),
+    vars_=('y',),
+    var_from_source=(('y',),),
+    handle_start=1,
+  )
+  ctx = _new_ctx()
+  with pytest.raises(AssertionError, match=r'lower_mir_cart_(root|in_chain)'):
+    lower_mir_cart(cart, ctx)
+
+
+def test_lower_mir_cart_is_registered_on_sorted_array_dialect():
+  '''The `CartesianJoin` `@lowering` is registered on the
+  `relation.sorted_array` dialect. Pins dialect ownership per
+  `docs/phase_b_lowering_dispatcher.md` §4 (one `@lowering` per
+  MIR op, on the dialect that lowers it).'''
+  from srdatalog.ir.dialects.relation.sorted_array import DIALECT as SA_DIALECT
+
+  matched = [low for low in SA_DIALECT.lowerings if low.matches is mir.CartesianJoin]
+  assert len(matched) == 1
+  assert matched[0].consumes == ('mir',)
+  assert 'iir.cf' in matched[0].produces
+
+
+# -----------------------------------------------------------------------------
+# 8. USE_DECLARATIVE invariants
+# -----------------------------------------------------------------------------
+
+
+def test_use_declarative_contains_cart():
+  '''Pin the ratchet: after this Wave 2A PR, `mir.CartesianJoin`
+  must appear in `USE_DECLARATIVE`. The monotonic discipline test
+  (when it lands) catches accidental removals.'''
+  from srdatalog.ir.dialects.relation.sorted_array import USE_DECLARATIVE
+
+  assert mir.CartesianJoin in USE_DECLARATIVE
+  # Sanity: previously-migrated ops still in the set.
+  assert mir.Filter in USE_DECLARATIVE
+  assert mir.ConstantBind in USE_DECLARATIVE
+  assert mir.InsertInto in USE_DECLARATIVE
+  assert mir.Scan in USE_DECLARATIVE
+  assert mir.Negation in USE_DECLARATIVE
+  assert mir.Aggregate in USE_DECLARATIVE
+  assert mir.ColumnJoin in USE_DECLARATIVE
+
+
+# -----------------------------------------------------------------------------
+# 9. Smoke test through the full compile_pipeline surface
+# -----------------------------------------------------------------------------
+
+
+def test_root_cart_in_full_pipeline_byte_equivalent():
+  '''Smoke test: a root 2-source Cart + InsertInto pipeline rendered
+  through `compile_pipeline` (the production surface that the
+  byte-equivalence harnesses guard) must produce identical CUDA
+  under both `USE_DECLARATIVE` states.'''
+  from srdatalog.compile import compile_pipeline
+
+  cart = _cart(
+    _column_source('R', handle_start=0),
+    _column_source('S', handle_start=1),
+    vars_=('y', 'z'),
+    var_from_source=(('y',), ('z',)),
+    handle_start=0,
+  )
+  ins = mir.InsertInto(
+    rel_name='Dst',
+    version=Version.NEW,
+    vars=['y', 'z'],
+    index=[0, 1],
+  )
+  ep = mir.ExecutePipeline(
+    pipeline=[cart, ins],
+    source_specs=[*cart.sources],
+    dest_specs=[ins],
+    rule_name='RootCart',
+  )
+
+  with _force_legacy_branch():
+    legacy_out = compile_pipeline(ep)
+  new_out = compile_pipeline(ep)
+
+  assert legacy_out == new_out
+
+
+def test_nested_cart_in_full_pipeline_byte_equivalent():
+  '''Smoke test: a Scan + 2-source Cart + InsertInto pipeline.'''
+  from srdatalog.compile import compile_pipeline
+
+  scan = _scan(('x',))
+  cart = _cart(
+    _column_source('R', handle_start=1),
+    _column_source('S', handle_start=2),
+    vars_=('y', 'z'),
+    var_from_source=(('y',), ('z',)),
+    handle_start=1,
+  )
+  ins = mir.InsertInto(
+    rel_name='Dst',
+    version=Version.NEW,
+    vars=['x', 'y', 'z'],
+    index=[0, 1, 2],
+  )
+  ep = mir.ExecutePipeline(
+    pipeline=[scan, cart, ins],
+    source_specs=[scan, *cart.sources],
+    dest_specs=[ins],
+    rule_name='NestedCart',
+  )
+
+  with _force_legacy_branch():
+    legacy_out = compile_pipeline(ep)
+  new_out = compile_pipeline(ep)
+
+  assert legacy_out == new_out
+
+
+def test_nested_cart_with_filter_in_full_pipeline_byte_equivalent():
+  '''Scan + 2-source Cart + Filter + InsertInto: middle-of-chain
+  Filter follows the Cart, exercising the Cart's body-render path
+  that re-enters `_lower_inner_chain` (which routes Filter through
+  the new path under USE_DECLARATIVE).'''
+  from srdatalog.compile import compile_pipeline
+
+  scan = _scan(('x',))
+  cart = _cart(
+    _column_source('R', handle_start=1),
+    _column_source('S', handle_start=2),
+    vars_=('y', 'z'),
+    var_from_source=(('y',), ('z',)),
+    handle_start=1,
+  )
+  flt = mir.Filter(vars=['y', 'z'], code='y < z')
+  ins = mir.InsertInto(
+    rel_name='Dst',
+    version=Version.NEW,
+    vars=['x', 'y', 'z'],
+    index=[0, 1, 2],
+  )
+  ep = mir.ExecutePipeline(
+    pipeline=[scan, cart, flt, ins],
+    source_specs=[scan, *cart.sources],
+    dest_specs=[ins],
+    rule_name='CartFilter',
+  )
+
+  with _force_legacy_branch():
+    legacy_out = compile_pipeline(ep)
+  new_out = compile_pipeline(ep)
+
+  assert legacy_out == new_out
+
+
+# -----------------------------------------------------------------------------
+# 10. Multi-source Cart still routes correctly (sanity: no shape gate)
+# -----------------------------------------------------------------------------
+
+
+def test_should_use_declarative_no_source_count_gate_for_cart():
+  '''Unlike B-CJ-single (which gates on `len(sources) == 1`),
+  B-Cart has NO source-count gate in `_should_use_declarative` —
+  all source counts route through the new path. Pin the invariant
+  so a future B-Cart-multi PR doesn't accidentally re-add the gate.
+  '''
+  one_src = _cart(
+    _column_source('R', handle_start=1),
+    vars_=('y',),
+    var_from_source=(('y',),),
+    handle_start=1,
+  )
+  two_src = _cart(
+    _column_source('R', handle_start=1),
+    _column_source('S', handle_start=2),
+    vars_=('y', 'z'),
+    var_from_source=(('y',), ('z',)),
+    handle_start=1,
+  )
+  three_src = _cart(
+    _column_source('R', handle_start=1),
+    _column_source('S', handle_start=2),
+    _column_source('T', handle_start=3),
+    vars_=('y', 'z', 'w'),
+    var_from_source=(('y',), ('z',), ('w',)),
+    handle_start=1,
+  )
+  assert _should_use_declarative(one_src) is True
+  assert _should_use_declarative(two_src) is True
+  assert _should_use_declarative(three_src) is True


### PR DESCRIPTION
## Summary
- Adds `mir.CartesianJoin` to `USE_DECLARATIVE` + `lowerings/lower_mir_cart.py`
- 9th Phase B op migrated (after #69 B-ExecutePipeline; before #58 B-CJ-multi)

## Design
- Single `@lowering(DIALECT, mir.CartesianJoin)` registration; dispatch site picks root vs chain helper
- **Root**: `lower_scan_pipeline` → `lower_mir_cart_root` → delegates to legacy `_lower_root_cart`
- **Mid-chain**: `_lower_inner_chain` → `lower_mir_cart_in_chain` → delegates to legacy `_lower_nested_cart` (preserves `_register_neg_pre_narrow` + `_tiled_cart_eligible` short-circuit byte-for-byte)
- Stub asserts on direct call (split-with-stub convention)

## Coexistence with C5 TiledCartesian
`mir.TiledCartesian` is a different MIR op type — falls through to the legacy `isinstance(head, mir.TiledCartesian)` branch that dispatches to `lower_tiled_cartesian_in_chain` (C5). The two never collide because the isinstance types are disjoint.

In the C5 dual-write transition (when legacy `ctx.tiled_cartesian=True`), bare `mir.CartesianJoin` reaches `lower_mir_cart_in_chain` → `_lower_nested_cart`, which forwards to `_lower_nested_cart_tiled` via its own `_tiled_cart_eligible` check — preserving the dual-write contract. C5's `lower_tiled_cartesian_in_chain` was NOT modified.

## Test plan
- [x] 21 new tests (root 2/3/1-source, mid-chain 1/2/3-source, mid-chain Cart with inner Negation in both pre-narrow + in-Cart-vars shapes, tiled-eligible via both legacy bool path AND C5 wrap-op path, mid-chain Cart under multi-source CJ root, full-pipeline smoke)
- [x] C5 e2e: `test_pragma_tiled_cartesian_end_to_end.py` — 15 passed (no regressions)
- [x] Full byte-equivalence: 660 passed
- [x] Full suite: 1610 passed, 5 skipped (+21 from new tests)
- [x] D19 / discipline tests: all green
- [x] ruff check + format (CI v0.9.10): clean
- [x] mypy on new file: clean

## Cross-PR conflict expectations
- **B-CJ-multi** (parallel): mechanical conflicts on `USE_DECLARATIVE` + `_register_passes` + `_lower_inner_chain` dispatch ladder. Trivial unions.
- **B-ExecutePipeline** (PR #69): already opened; modifies `_register_passes`'s existing EP registration — different block from this PR's new Cart registration. No direct conflict.

🤖 Generated with [Claude Code](https://claude.com/claude-code)