### PR TITLE
chore: fix I001 import sort in complete_runner.py (unblocks PR-1a/1b CI)

### DIFF
--- a/src/srdatalog/ir/codegen/cuda/complete_runner.py
+++ b/src/srdatalog/ir/codegen/cuda/complete_runner.py
@@ -43,7 +43,6 @@ from srdatalog.ir.codegen.cuda.pipeline_utils import (
   has_tiled_cartesian_eligible,
 )
 from srdatalog.ir.codegen.cuda.plugin import plugin_gen_host_view_setup, plugin_view_count
-from srdatalog.ir.mir.passes import ep_has_work_stealing
 
 # Pure-template phase emitters now live in the dialect's runner module.
 # Local aliases preserve the legacy call sites until the rest of this
@@ -75,6 +74,7 @@ from srdatalog.ir.codegen.cuda.view_slots import (
   compute_total_view_count,
   source_spec_key,
 )
+from srdatalog.ir.mir.passes import ep_has_work_stealing
 
 # -----------------------------------------------------------------------------
 # Source spec extraction helpers (mirror Nim's inline lambdas)


### PR DESCRIPTION
## Summary
- Pre-existing ruff `I001` failure on `design/redesign-package` blocks PR-1a (#78) and PR-1b (#77) from going CLEAN
- One-line mechanical re-sort: `ep_has_work_stealing` import moves into the alphabetical block
- No behavior change

## Test plan
- [x] `ruff check src/srdatalog/ir/codegen/cuda/complete_runner.py` clean
- [x] CI ruff job passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)